### PR TITLE
feat: add custom permission pattern selection and persistence

### DIFF
--- a/packages/pi-permission-system/docs/configuration.md
+++ b/packages/pi-permission-system/docs/configuration.md
@@ -10,6 +10,7 @@ One unified config file per scope:
 | Project | `<cwd>/.pi/extensions/pi-permission-system/config.json`                                    |
 
 Project config overrides global config; per-agent frontmatter overrides both.
+The permission prompt can also write custom `allow` rules to either the project or global config when the user selects **Yes, save a custom pattern to config**.
 
 > **Coming from OpenCode?**
 > This extension's permission model was inspired by OpenCode's.
@@ -376,6 +377,28 @@ They are expanded to the OS home directory at match time, so configs are portabl
 ```
 
 The pattern is stored and displayed as written (e.g. `~/development/*`) in logs and approval dialogs.
+
+### Saving Custom Patterns from the Permission Prompt
+
+When a permission prompt appears, **Yes, save a custom pattern to config** shows several candidate patterns derived from the current request.
+After choosing a candidate, an input box is shown with that pattern prefilled so it can be accepted as-is or edited before saving.
+The user then chooses either the project config or the global config.
+The nested choosers include `← Back`, so the user can return to the top-level permission choices before any config file is written.
+The extension writes the final pattern under the current permission surface with action `allow`.
+For example, entering `git checkout *` for a bash prompt and choosing project config writes a project-level rule equivalent to:
+
+```jsonc
+{
+  "permission": {
+    "bash": {
+      "git checkout *": "allow"
+    }
+  }
+}
+```
+
+If the surface already has a string shorthand such as `"bash": "ask"`, saving a non-`*` custom pattern expands it to a pattern map and preserves the old catch-all as `"*": "ask"`.
+Project config rules override global config rules, and per-agent frontmatter still overrides both.
 
 ---
 

--- a/packages/pi-permission-system/docs/session-approvals.md
+++ b/packages/pi-permission-system/docs/session-approvals.md
@@ -1,15 +1,27 @@
 # Session-Scoped Approvals
 
-When any permission resolves to `ask`, the permission dialog offers four options:
+When any permission resolves to `ask`, the permission dialog offers six options:
 
 ```text
-Yes | Yes, allow "<pattern>" for this session | No | No, provide reason
+Yes | Yes, allow "<pattern>" for this session | Yes, enter a custom pattern for this session | Yes, save a custom pattern to config | No | No, provide reason
 ```
 
 Selecting **Yes, allow "\<pattern\>" for this session** approves the current request and records the suggested wildcard pattern as a session rule.
 Subsequent requests that match the pattern skip the prompt for the remainder of the session.
 
+Selecting **Yes, enter a custom pattern for this session** opens a second chooser with several candidate patterns derived from the current request.
+After choosing a candidate, an input box is shown with that pattern prefilled so it can be accepted as-is or edited before saving.
+Selecting `← Back` or dismissing a nested chooser returns to the previous permission choice instead of denying the request.
+The final pattern approves the current request and is recorded as a session rule.
+Use this when the suggested pattern is too broad or too narrow but the approval should remain temporary.
+
+Selecting **Yes, save a custom pattern to config** uses the same candidate-pattern chooser and editable input flow, then asks whether to save the final pattern to the project config or the global config.
+The config-target chooser also includes `← Back`, allowing the user to return to the top-level permission choices before anything is written.
+The saved rule uses `allow` as the permission action, so future matching requests are approved without prompting according to normal config precedence.
+Use this when the pattern should persist across sessions.
+
 Session approvals are ephemeral — they are never persisted to disk and are cleared on `session_shutdown`.
+Persisted custom patterns are written to config and remain until removed or overridden.
 
 ## Suggested Patterns
 

--- a/packages/pi-permission-system/src/forwarded-permissions/io.ts
+++ b/packages/pi-permission-system/src/forwarded-permissions/io.ts
@@ -254,6 +254,28 @@ export function writeJsonFileAtomic(
   }
 }
 
+function parseRequestPermissionOptions(
+  value: unknown,
+): ForwardedPermissionRequest["options"] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const options: ForwardedPermissionRequest["options"] = {};
+  if (typeof record.sessionLabel === "string") {
+    options.sessionLabel = record.sessionLabel;
+  }
+  if (
+    Array.isArray(record.customPatternOptions) &&
+    record.customPatternOptions.every(
+      (item): item is string => typeof item === "string",
+    )
+  ) {
+    options.customPatternOptions = record.customPatternOptions;
+  }
+  return Object.keys(options).length > 0 ? options : undefined;
+}
+
 export function readForwardedPermissionRequest(
   logger: ForwardedPermissionLogger | null,
   filePath: string,
@@ -284,6 +306,7 @@ export function readForwardedPermissionRequest(
       targetSessionId: parsed.targetSessionId,
       requesterAgentName: parsed.requesterAgentName,
       message: parsed.message,
+      options: parseRequestPermissionOptions(parsed.options),
     };
   } catch (error) {
     logPermissionForwardingWarning(
@@ -321,6 +344,18 @@ export function readForwardedPermissionResponse(
       denialReason:
         typeof parsed.denialReason === "string"
           ? parsed.denialReason
+          : undefined,
+      customPatternApproval:
+        parsed.customPatternApproval &&
+        typeof parsed.customPatternApproval === "object" &&
+        typeof parsed.customPatternApproval.pattern === "string" &&
+        (parsed.customPatternApproval.target === "session" ||
+          parsed.customPatternApproval.target === "project" ||
+          parsed.customPatternApproval.target === "global")
+          ? {
+              pattern: parsed.customPatternApproval.pattern,
+              target: parsed.customPatternApproval.target,
+            }
           : undefined,
       responderSessionId: parsed.responderSessionId,
       respondedAt:

--- a/packages/pi-permission-system/src/forwarded-permissions/polling.ts
+++ b/packages/pi-permission-system/src/forwarded-permissions/polling.ts
@@ -99,6 +99,7 @@ export async function waitForForwardedPermissionApproval(
   ctx: ExtensionContext,
   message: string,
   deps: PermissionForwardingDeps,
+  options?: RequestPermissionOptions,
 ): Promise<PermissionPromptDecision> {
   const requesterSessionId = getSessionId(ctx);
   const targetSessionId = resolvePermissionForwardingTargetSessionId({
@@ -145,6 +146,7 @@ export async function waitForForwardedPermissionApproval(
     targetSessionId,
     requesterAgentName,
     message,
+    options,
   };
 
   const requestPath = join(location.requestsDir, `${requestId}.json`);
@@ -182,6 +184,8 @@ export async function waitForForwardedPermissionApproval(
         approved: response?.approved ?? null,
         state: response?.state ?? null,
         denialReason: response?.denialReason ?? null,
+        customPattern: response?.customPatternApproval?.pattern ?? null,
+        customPatternTarget: response?.customPatternApproval?.target ?? null,
         responderSessionId: response?.responderSessionId ?? null,
         targetSessionId,
         responsePath,
@@ -290,6 +294,7 @@ export async function processForwardedPermissionRequests(
           ctx.ui,
           "Permission Required (Subagent)",
           formatForwardedPermissionPrompt(request),
+          request.options,
         );
       } catch (error) {
         logPermissionForwardingError(
@@ -322,6 +327,7 @@ export async function processForwardedPermissionRequests(
         approved: decision.approved,
         state: decision.state,
         denialReason: decision.denialReason,
+        customPatternApproval: decision.customPatternApproval,
         responderSessionId: currentSessionId,
         respondedAt: Date.now(),
       } satisfies ForwardedPermissionResponse);
@@ -363,5 +369,5 @@ export async function confirmPermission(
     return { approved: false, state: "denied" };
   }
 
-  return waitForForwardedPermissionApproval(ctx, message, deps);
+  return waitForForwardedPermissionApproval(ctx, message, deps, options);
 }

--- a/packages/pi-permission-system/src/handlers/gates/bash-external-directory.ts
+++ b/packages/pi-permission-system/src/handlers/gates/bash-external-directory.ts
@@ -1,4 +1,5 @@
 import { getNonEmptyString, toRecord } from "../../common";
+import { suggestSessionPattern } from "../../pattern-suggest";
 import type { Rule } from "../../rule";
 import { deriveApprovalPattern } from "../../session-rules";
 import type { PermissionCheckResult } from "../../types";
@@ -88,6 +89,13 @@ export async function describeBashExternalDirectoryGate(
   );
 
   const patterns = uncoveredPaths.map((p) => deriveApprovalPattern(p));
+  const customPatternOptions = patterns.flatMap(
+    (pattern, index) =>
+      suggestSessionPattern(
+        "external_directory",
+        uncoveredPaths[index] ?? pattern,
+      ).patternOptions,
+  );
 
   return {
     surface: "external_directory",
@@ -115,9 +123,12 @@ export async function describeBashExternalDirectoryGate(
       source: "tool_call",
       agentName: tcc.agentName,
       message: bashExtMessage,
+      surface: "external_directory",
+      defaultPersistAction: "allow",
       toolCallId: tcc.toolCallId,
       toolName: tcc.toolName,
       command,
+      customPatternOptions,
     },
     logContext: {
       source: "tool_call",

--- a/packages/pi-permission-system/src/handlers/gates/descriptor.ts
+++ b/packages/pi-permission-system/src/handlers/gates/descriptor.ts
@@ -1,8 +1,8 @@
-import type { PermissionPromptDecision } from "../../permission-dialog";
 import type {
-  PermissionDecisionEvent,
-  PermissionDecisionResolution,
-} from "../../permission-events";
+  CustomPatternApprovalTarget,
+  PermissionPromptDecision,
+} from "../../permission-dialog";
+import type { PermissionDecisionEvent } from "../../permission-events";
 import type { PromptPermissionDetails } from "../../permission-prompter";
 import type { Rule } from "../../rule";
 import type { PermissionCheckResult, PermissionState } from "../../types";
@@ -94,6 +94,13 @@ export interface GateRunnerDeps {
   ): PermissionCheckResult;
   getSessionRuleset(): Rule[];
   approveSessionRule(surface: string, pattern: string): void;
+  persistCustomPattern(
+    target: CustomPatternApprovalTarget,
+    surface: string,
+    pattern: string,
+    action: "allow" | "ask",
+  ): string;
+  refreshConfig(): void;
   writeReviewLog(event: string, details: Record<string, unknown>): void;
   emitDecision(event: PermissionDecisionEvent): void;
   canConfirm(): boolean;

--- a/packages/pi-permission-system/src/handlers/gates/external-directory.ts
+++ b/packages/pi-permission-system/src/handlers/gates/external-directory.ts
@@ -4,6 +4,7 @@ import {
   isPiInfrastructureRead,
   normalizePathForComparison,
 } from "../../path-utils";
+import { suggestSessionPattern } from "../../pattern-suggest";
 import { deriveApprovalPattern } from "../../session-rules";
 import type { GateResult } from "./descriptor";
 import {
@@ -76,6 +77,10 @@ export function describeExternalDirectoryGate(
   );
 
   const pattern = deriveApprovalPattern(normalizedExtPath);
+  const suggestion = suggestSessionPattern(
+    "external_directory",
+    normalizedExtPath,
+  );
 
   return {
     surface: "external_directory",
@@ -103,9 +108,12 @@ export function describeExternalDirectoryGate(
       source: "tool_call",
       agentName: tcc.agentName,
       message: extDirMessage,
+      surface: "external_directory",
+      defaultPersistAction: "allow",
       toolCallId: tcc.toolCallId,
       toolName: tcc.toolName,
       path: externalDirectoryPath,
+      customPatternOptions: suggestion.patternOptions,
     },
     logContext: {
       source: "tool_call",

--- a/packages/pi-permission-system/src/handlers/gates/helpers.ts
+++ b/packages/pi-permission-system/src/handlers/gates/helpers.ts
@@ -22,9 +22,9 @@ export function deriveDecisionValue(
  *
  * @param state     - The permission state passed to the gate.
  * @param action    - The gate's resulting action ("allow" | "block").
- * @param hasSession - True when the gate result carries a sessionApproval
- *                    (indicates the user chose "for this session").
+ * @param hasSession - True when the gate result carries a sessionApproval.
  * @param canConfirm - Whether an interactive prompt was available.
+ * @param hasCustomPattern - True when the user entered a custom pattern.
  */
 export function deriveResolution(
   state: "allow" | "deny" | "ask",
@@ -32,12 +32,14 @@ export function deriveResolution(
   hasSession: boolean,
   canConfirm: boolean,
   autoApproved = false,
+  hasCustomPattern = false,
 ): PermissionDecisionResolution {
   if (state === "allow") return "policy_allow";
   if (state === "deny") return "policy_deny";
   // state === "ask"
   if (action === "allow") {
     if (autoApproved) return "auto_approved";
+    if (hasCustomPattern) return "approved_with_custom_pattern";
     return hasSession ? "user_approved_for_session" : "user_approved";
   }
   return canConfirm ? "user_denied" : "confirmation_unavailable";

--- a/packages/pi-permission-system/src/handlers/gates/runner.ts
+++ b/packages/pi-permission-system/src/handlers/gates/runner.ts
@@ -1,4 +1,3 @@
-import type { PermissionPromptDecision } from "../../permission-dialog";
 import { applyPermissionGate } from "../../permission-gate";
 import type { PermissionCheckResult } from "../../types";
 import type { GateDescriptor, GateRunnerDeps } from "./descriptor";
@@ -102,6 +101,9 @@ export async function runGateCheck(
   // 4. Determine whether session approval was granted
   const hasSessionApproval =
     gateResult.action === "allow" && gateResult.sessionApproval !== undefined;
+  const hasCustomPatternApproval =
+    gateResult.action === "allow" &&
+    gateResult.customPatternApproval !== undefined;
 
   // 5. Emit decision event
   deps.emitDecision({
@@ -114,6 +116,7 @@ export async function runGateCheck(
       hasSessionApproval,
       canConfirm,
       autoApproved,
+      hasCustomPatternApproval,
     ),
     origin: check.origin ?? null,
     agentName: agentName ?? null,
@@ -133,6 +136,41 @@ export async function runGateCheck(
           descriptor.sessionApproval.pattern,
         );
       }
+    }
+  }
+
+  if (gateResult.action === "allow" && gateResult.customPatternApproval) {
+    const customPattern = gateResult.customPatternApproval;
+    const surface = descriptor.promptDetails.surface ?? descriptor.surface;
+
+    if (customPattern.target === "session") {
+      deps.approveSessionRule(surface, customPattern.pattern);
+      deps.writeReviewLog("permission_request.custom_pattern_recorded", {
+        ...descriptor.logContext,
+        agentName,
+        surface,
+        resolution: "approved_with_custom_pattern",
+        customPattern: customPattern.pattern,
+        customPatternTarget: "session",
+      });
+    } else {
+      const configPath = deps.persistCustomPattern(
+        customPattern.target,
+        surface,
+        customPattern.pattern,
+        descriptor.promptDetails.defaultPersistAction ?? "allow",
+      );
+      deps.approveSessionRule(surface, customPattern.pattern);
+      deps.refreshConfig();
+      deps.writeReviewLog("permission_request.custom_pattern_recorded", {
+        ...descriptor.logContext,
+        agentName,
+        surface,
+        resolution: "approved_with_custom_pattern",
+        customPattern: customPattern.pattern,
+        customPatternTarget: customPattern.target,
+        configPath,
+      });
     }
   }
 

--- a/packages/pi-permission-system/src/handlers/gates/skill-read.ts
+++ b/packages/pi-permission-system/src/handlers/gates/skill-read.ts
@@ -1,5 +1,6 @@
 import { toRecord } from "../../common";
 import { normalizePathForComparison } from "../../path-utils";
+import { suggestSessionPattern } from "../../pattern-suggest";
 import {
   formatSkillPathAskPrompt,
   formatSkillPathDenyReason,
@@ -51,6 +52,7 @@ export function describeSkillReadGate(
     path,
     tcc.agentName ?? undefined,
   );
+  const suggestion = suggestSessionPattern("skill", matchedSkill.name);
 
   return {
     surface: "skill",
@@ -73,10 +75,13 @@ export function describeSkillReadGate(
       source: "skill_read",
       agentName: tcc.agentName,
       message: skillReadMessage,
+      surface: "skill",
+      defaultPersistAction: "allow",
       toolCallId: tcc.toolCallId,
       toolName: tcc.toolName,
       skillName: matchedSkill.name,
       path,
+      customPatternOptions: suggestion.patternOptions,
     },
     logContext: {
       source: "skill_read",

--- a/packages/pi-permission-system/src/handlers/gates/tool.ts
+++ b/packages/pi-permission-system/src/handlers/gates/tool.ts
@@ -83,9 +83,12 @@ export function describeToolGate(
       source: "tool_call",
       agentName: tcc.agentName,
       message: askMessage,
+      surface: tcc.toolName,
+      defaultPersistAction: "allow",
       toolCallId: tcc.toolCallId,
       toolName: tcc.toolName,
       sessionLabel: suggestion.label,
+      customPatternOptions: suggestion.patternOptions,
       ...permissionLogContext,
     },
     logContext: {

--- a/packages/pi-permission-system/src/handlers/permission-gate-handler.ts
+++ b/packages/pi-permission-system/src/handlers/permission-gate-handler.ts
@@ -4,6 +4,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 
 import { toRecord } from "../common";
+import { suggestSessionPattern } from "../pattern-suggest";
 import {
   emitDecisionEvent,
   type PermissionEventBus,
@@ -16,6 +17,7 @@ import {
   formatUnknownToolReason,
 } from "../permission-prompts";
 import type { PermissionSession } from "../permission-session";
+import { persistPermissionRule } from "../persist-permission-rule";
 import {
   checkRequestedToolRegistration,
   getToolNameFromValue,
@@ -114,12 +116,32 @@ export class PermissionGateHandler {
     const getSessionRuleset = () => session.getSessionRuleset();
     const approveSessionRule = (surface: string, pattern: string) =>
       session.approveSessionRule(surface, pattern);
+    const persistCustomPattern: GateRunnerDeps["persistCustomPattern"] = (
+      target,
+      surface,
+      pattern,
+      action,
+    ) => {
+      if (target === "session") {
+        throw new Error("Session custom patterns are not persisted to config.");
+      }
+      return persistPermissionRule({
+        agentDir: session.getAgentDir(),
+        cwd: ctx.cwd,
+        scope: target,
+        surface,
+        pattern,
+        action,
+      }).path;
+    };
 
     // ── Shared runner deps (built once, reused for all gates) ────────────
     const runnerDeps: GateRunnerDeps = {
       checkPermission,
       getSessionRuleset,
       approveSessionRule,
+      persistCustomPattern,
+      refreshConfig: () => session.refreshConfig(ctx),
       writeReviewLog,
       emitDecision,
       canConfirm,
@@ -289,18 +311,27 @@ export class PermissionGateHandler {
       skillName,
       agentName ?? undefined,
     );
+    const skillSuggestion = suggestSessionPattern("skill", skillName);
     const skillInputCanConfirm = session.canPrompt(ctx);
     let skillInputAutoApproved = false;
     const skillInputGate = await applyPermissionGate({
       state: check.state,
       canConfirm: skillInputCanConfirm,
+      sessionApproval: {
+        surface: skillSuggestion.surface,
+        pattern: skillSuggestion.pattern,
+      },
       promptForApproval: async () => {
         const decision = await session.prompt(ctx, {
           requestId: session.createPermissionRequestId("skill-input"),
           source: "skill_input",
           agentName,
           message: skillInputMessage,
+          surface: "skill",
+          defaultPersistAction: "allow",
           skillName,
+          sessionLabel: skillSuggestion.label,
+          customPatternOptions: skillSuggestion.patternOptions,
         });
         skillInputAutoApproved = decision.autoApproved === true;
         return decision;
@@ -332,7 +363,11 @@ export class PermissionGateHandler {
             : skillInputGate.action === "allow"
               ? skillInputAutoApproved
                 ? "auto_approved"
-                : "user_approved"
+                : skillInputGate.customPatternApproval
+                  ? "approved_with_custom_pattern"
+                  : skillInputGate.sessionApproval
+                    ? "user_approved_for_session"
+                    : "user_approved"
               : skillInputCanConfirm
                 ? "user_denied"
                 : "confirmation_unavailable",
@@ -340,6 +375,38 @@ export class PermissionGateHandler {
       agentName: agentName ?? null,
       matchedPattern: check.matchedPattern ?? null,
     });
+
+    if (skillInputGate.action === "allow") {
+      if (skillInputGate.sessionApproval) {
+        session.approveSessionRule(
+          skillInputGate.sessionApproval.surface,
+          skillInputGate.sessionApproval.pattern,
+        );
+      }
+
+      if (skillInputGate.customPatternApproval) {
+        if (skillInputGate.customPatternApproval.target === "session") {
+          session.approveSessionRule(
+            "skill",
+            skillInputGate.customPatternApproval.pattern,
+          );
+        } else {
+          persistPermissionRule({
+            agentDir: session.getAgentDir(),
+            cwd: ctx.cwd,
+            scope: skillInputGate.customPatternApproval.target,
+            surface: "skill",
+            pattern: skillInputGate.customPatternApproval.pattern,
+            action: "allow",
+          });
+          session.approveSessionRule(
+            "skill",
+            skillInputGate.customPatternApproval.pattern,
+          );
+          session.refreshConfig(ctx);
+        }
+      }
+    }
 
     if (skillInputGate.action === "block") {
       return { action: "handled" };

--- a/packages/pi-permission-system/src/pattern-suggest.ts
+++ b/packages/pi-permission-system/src/pattern-suggest.ts
@@ -10,6 +10,8 @@ export interface SessionApprovalSuggestion {
   pattern: string;
   /** Human-readable label for the "for session" dialog option. */
   label: string;
+  /** Candidate patterns the user can choose or edit for custom approvals. */
+  patternOptions: string[];
 }
 
 /**
@@ -120,5 +122,51 @@ export function suggestSessionPattern(
       break;
   }
 
-  return { surface, pattern, label: buildLabel(pattern, surface) };
+  return {
+    surface,
+    pattern,
+    label: buildLabel(pattern, surface),
+    patternOptions: suggestPatternOptions(surface, value, pattern),
+  };
+}
+
+function suggestPatternOptions(
+  surface: string,
+  value: string,
+  primaryPattern: string,
+): string[] {
+  const trimmed = value.trim();
+  const candidates: string[] = [];
+
+  if (trimmed) {
+    candidates.push(trimmed);
+  }
+  candidates.push(primaryPattern);
+
+  if (surface === "bash") {
+    const firstToken = trimmed.split(/\s+/)[0];
+    if (firstToken) {
+      candidates.push(`${firstToken} *`);
+    }
+    candidates.push("*");
+  } else if (surface === "mcp") {
+    candidates.push("*");
+  } else if (surface === "skill") {
+    candidates.push("*");
+  } else if (surface === "external_directory") {
+    candidates.push("*");
+  } else {
+    candidates.push("*");
+  }
+
+  return dedupeNonEmpty(candidates);
+}
+
+function dedupeNonEmpty(values: readonly string[]): string[] {
+  return values
+    .map((value) => value.trim())
+    .filter(
+      (value, index, array) =>
+        value.length > 0 && array.indexOf(value) === index,
+    );
 }

--- a/packages/pi-permission-system/src/permission-dialog.ts
+++ b/packages/pi-permission-system/src/permission-dialog.ts
@@ -1,13 +1,22 @@
 export type PermissionDecisionState =
   | "approved"
   | "approved_for_session"
+  | "approved_with_custom_pattern"
   | "denied"
   | "denied_with_reason";
+
+export type CustomPatternApprovalTarget = "session" | "project" | "global";
+
+export interface CustomPatternApproval {
+  pattern: string;
+  target: CustomPatternApprovalTarget;
+}
 
 export type PermissionPromptDecision = {
   approved: boolean;
   state: PermissionDecisionState;
   denialReason?: string;
+  customPatternApproval?: CustomPatternApproval;
   /**
    * True when the decision was made automatically by yolo mode rather than
    * by an interactive user prompt. Used by handlers to emit "auto_approved"
@@ -23,14 +32,15 @@ export interface PermissionDecisionUi {
 
 const APPROVE_OPTION = "Yes";
 const APPROVE_FOR_SESSION_OPTION = "Yes, for this session";
+const CUSTOM_SESSION_PATTERN_OPTION =
+  "Yes, enter a custom pattern for this session";
+const CUSTOM_PERSISTED_PATTERN_OPTION = "Yes, save a custom pattern to config";
+const CUSTOM_PATTERN_MANUAL_OPTION = "Enter a custom pattern manually";
+const BACK_OPTION = "← Back";
+const PROJECT_CONFIG_OPTION = "Project config";
+const GLOBAL_CONFIG_OPTION = "Global config";
 const DENY_OPTION = "No";
 const DENY_WITH_REASON_OPTION = "No, provide reason";
-const PERMISSION_DECISION_OPTIONS = [
-  APPROVE_OPTION,
-  APPROVE_FOR_SESSION_OPTION,
-  DENY_OPTION,
-  DENY_WITH_REASON_OPTION,
-] as const;
 
 export function normalizePermissionDenialReason(
   value: unknown,
@@ -65,6 +75,7 @@ export function isPermissionDecisionState(
   return (
     value === "approved" ||
     value === "approved_for_session" ||
+    value === "approved_with_custom_pattern" ||
     value === "denied" ||
     value === "denied_with_reason"
   );
@@ -73,6 +84,8 @@ export function isPermissionDecisionState(
 export interface RequestPermissionOptions {
   /** Override the "for this session" option label (e.g. to show the suggested pattern). */
   sessionLabel?: string;
+  /** Candidate patterns shown when the user chooses a custom pattern flow. */
+  customPatternOptions?: string[];
 }
 
 export async function requestPermissionDecisionFromUi(
@@ -85,38 +98,171 @@ export async function requestPermissionDecisionFromUi(
   const decisionOptions = [
     APPROVE_OPTION,
     sessionOption,
+    CUSTOM_SESSION_PATTERN_OPTION,
+    CUSTOM_PERSISTED_PATTERN_OPTION,
     DENY_OPTION,
     DENY_WITH_REASON_OPTION,
   ] as const;
 
-  const selected = await ui.select(`${title}\n${message}`, [
-    ...decisionOptions,
-  ]);
+  while (true) {
+    const selected = await ui.select(`${title}\n${message}`, [
+      ...decisionOptions,
+    ]);
 
-  if (selected === APPROVE_OPTION) {
-    return {
-      approved: true,
-      state: "approved",
-    };
+    if (selected === APPROVE_OPTION) {
+      return {
+        approved: true,
+        state: "approved",
+      };
+    }
+
+    if (selected === sessionOption) {
+      return {
+        approved: true,
+        state: "approved_for_session",
+      };
+    }
+
+    if (selected === CUSTOM_SESSION_PATTERN_OPTION) {
+      const result = await requestCustomPattern(
+        ui,
+        title,
+        "Choose or edit a custom permission pattern for this session.",
+        options?.customPatternOptions ?? [],
+      );
+
+      if (result.action === "back") {
+        continue;
+      }
+
+      return {
+        approved: true,
+        state: "approved_with_custom_pattern",
+        customPatternApproval: {
+          pattern: result.pattern,
+          target: "session",
+        },
+      };
+    }
+
+    if (selected === CUSTOM_PERSISTED_PATTERN_OPTION) {
+      const result = await requestCustomPattern(
+        ui,
+        title,
+        "Choose or edit a custom permission pattern to save.",
+        options?.customPatternOptions ?? [],
+      );
+
+      if (result.action === "back") {
+        continue;
+      }
+
+      const target = await ui.select(`${title}\nSave this pattern to:`, [
+        PROJECT_CONFIG_OPTION,
+        GLOBAL_CONFIG_OPTION,
+        BACK_OPTION,
+      ]);
+
+      if (target === BACK_OPTION || target === undefined) {
+        continue;
+      }
+
+      if (target !== PROJECT_CONFIG_OPTION && target !== GLOBAL_CONFIG_OPTION) {
+        return createDeniedPermissionDecision();
+      }
+
+      return {
+        approved: true,
+        state: "approved_with_custom_pattern",
+        customPatternApproval: {
+          pattern: result.pattern,
+          target: target === PROJECT_CONFIG_OPTION ? "project" : "global",
+        },
+      };
+    }
+
+    if (selected === DENY_WITH_REASON_OPTION) {
+      const denialReason = normalizePermissionDenialReason(
+        await ui.input(
+          `${title}\nShare why this request was denied (optional).`,
+          "Reason shown back to the agent",
+        ),
+      );
+
+      return createDeniedPermissionDecision(denialReason);
+    }
+
+    return createDeniedPermissionDecision();
   }
+}
 
-  if (selected === sessionOption) {
-    return {
-      approved: true,
-      state: "approved_for_session",
-    };
-  }
+type CustomPatternResult =
+  | { action: "selected"; pattern: string }
+  | { action: "back" };
 
-  if (selected === DENY_WITH_REASON_OPTION) {
-    const denialReason = normalizePermissionDenialReason(
-      await ui.input(
-        `${title}\nShare why this request was denied (optional).`,
-        "Reason shown back to the agent",
-      ),
+async function requestCustomPattern(
+  ui: PermissionDecisionUi,
+  title: string,
+  prompt: string,
+  patternOptions: readonly string[],
+): Promise<CustomPatternResult> {
+  const candidates = dedupePatternOptions(patternOptions);
+
+  while (true) {
+    const selected =
+      candidates.length > 0
+        ? await ui.select(`${title}\n${prompt}`, [
+            ...candidates.map((pattern) => `Use pattern: ${pattern}`),
+            CUSTOM_PATTERN_MANUAL_OPTION,
+            BACK_OPTION,
+          ])
+        : CUSTOM_PATTERN_MANUAL_OPTION;
+
+    if (!selected || selected === BACK_OPTION) {
+      return { action: "back" };
+    }
+
+    const selectedPattern = selected.startsWith("Use pattern: ")
+      ? selected.slice("Use pattern: ".length)
+      : undefined;
+
+    if (
+      selectedPattern === undefined &&
+      selected !== CUSTOM_PATTERN_MANUAL_OPTION
+    ) {
+      return { action: "back" };
+    }
+
+    const entered = await ui.input(
+      selectedPattern
+        ? `${title}\nEdit pattern or press Enter to use:\n${selectedPattern}`
+        : `${title}\nEnter a custom permission pattern.`,
+      selectedPattern ?? "Pattern (supports * and ? wildcards)",
     );
 
-    return createDeniedPermissionDecision(denialReason);
-  }
+    if (entered === undefined) {
+      if (candidates.length === 0) {
+        return { action: "back" };
+      }
+      continue;
+    }
 
-  return createDeniedPermissionDecision();
+    const normalized = normalizePermissionDenialReason(entered);
+    if (normalized) {
+      return { action: "selected", pattern: normalized };
+    }
+
+    if (selectedPattern) {
+      return { action: "selected", pattern: selectedPattern };
+    }
+  }
+}
+
+function dedupePatternOptions(patternOptions: readonly string[]): string[] {
+  return patternOptions
+    .map((pattern) => pattern.trim())
+    .filter(
+      (pattern, index, array) =>
+        pattern.length > 0 && array.indexOf(pattern) === index,
+    );
 }

--- a/packages/pi-permission-system/src/permission-event-rpc.ts
+++ b/packages/pi-permission-system/src/permission-event-rpc.ts
@@ -169,6 +169,8 @@ async function handlePromptRpc(
       approved: decision.approved,
       resolution: decision.state,
       denialReason: decision.denialReason ?? null,
+      customPattern: decision.customPatternApproval?.pattern ?? null,
+      customPatternTarget: decision.customPatternApproval?.target ?? null,
     });
 
     const data: PermissionsPromptReplyData = {

--- a/packages/pi-permission-system/src/permission-events.ts
+++ b/packages/pi-permission-system/src/permission-events.ts
@@ -76,6 +76,7 @@ export type PermissionDecisionResolution =
   | "infrastructure_auto_allowed"
   | "user_approved"
   | "user_approved_for_session"
+  | "approved_with_custom_pattern"
   | "user_denied"
   | "auto_approved"
   | "confirmation_unavailable";

--- a/packages/pi-permission-system/src/permission-forwarding.ts
+++ b/packages/pi-permission-system/src/permission-forwarding.ts
@@ -1,6 +1,10 @@
 import { join } from "node:path";
 
-import type { PermissionDecisionState } from "./permission-dialog";
+import type {
+  CustomPatternApproval,
+  PermissionDecisionState,
+  RequestPermissionOptions,
+} from "./permission-dialog";
 
 export const PERMISSION_FORWARDING_POLL_INTERVAL_MS = 250;
 export const PERMISSION_FORWARDING_TIMEOUT_MS = 10 * 60 * 1000;
@@ -44,12 +48,14 @@ export type ForwardedPermissionRequest = {
   targetSessionId: string;
   requesterAgentName: string;
   message: string;
+  options?: RequestPermissionOptions;
 };
 
 export type ForwardedPermissionResponse = {
   approved: boolean;
   state: PermissionDecisionState;
   denialReason?: string;
+  customPatternApproval?: CustomPatternApproval;
   responderSessionId: string;
   respondedAt: number;
 };

--- a/packages/pi-permission-system/src/permission-gate.ts
+++ b/packages/pi-permission-system/src/permission-gate.ts
@@ -1,8 +1,15 @@
-import type { PermissionPromptDecision } from "./permission-dialog";
+import type {
+  CustomPatternApproval,
+  PermissionPromptDecision,
+} from "./permission-dialog";
 
 /** Result of applying the permission gate. */
 export type PermissionGateResult =
-  | { action: "allow"; sessionApproval?: { surface: string; pattern: string } }
+  | {
+      action: "allow";
+      sessionApproval?: { surface: string; pattern: string };
+      customPatternApproval?: CustomPatternApproval;
+    }
   | { action: "block"; reason: string };
 
 /** Everything the gate needs — no direct dependency on ExtensionContext. */
@@ -77,6 +84,12 @@ export async function applyPermissionGate(
     }
     if (decision.state === "approved_for_session" && params.sessionApproval) {
       return { action: "allow", sessionApproval: params.sessionApproval };
+    }
+    if (decision.state === "approved_with_custom_pattern") {
+      return {
+        action: "allow",
+        customPatternApproval: decision.customPatternApproval,
+      };
     }
   }
 

--- a/packages/pi-permission-system/src/permission-prompter.ts
+++ b/packages/pi-permission-system/src/permission-prompter.ts
@@ -6,6 +6,7 @@ import {
   type PermissionForwardingDeps,
 } from "./forwarded-permissions/polling";
 import type {
+  CustomPatternApprovalTarget,
   PermissionPromptDecision,
   RequestPermissionOptions,
 } from "./permission-dialog";
@@ -19,6 +20,8 @@ export interface PromptPermissionDetails {
   source: PermissionReviewSource;
   agentName: string | null;
   message: string;
+  surface?: string;
+  defaultPersistAction?: "allow" | "ask";
   toolCallId?: string;
   toolName?: string;
   skillName?: string;
@@ -28,6 +31,8 @@ export interface PromptPermissionDetails {
   toolInputPreview?: string;
   /** Override label for the "for this session" dialog option. */
   sessionLabel?: string;
+  /** Candidate patterns for custom session/config approval flows. */
+  customPatternOptions?: string[];
 }
 
 /** Mockable contract for permission prompting. */
@@ -74,6 +79,25 @@ export interface PermissionPrompterDeps {
  * parameter (e.g. a future sessionLabel variant) only requires changing
  * PromptPermissionDetails and this class — not the full threading chain.
  */
+function getCustomPatternApprovalTarget(details: {
+  customPatternApproval?: { target: CustomPatternApprovalTarget };
+}): CustomPatternApprovalTarget | null {
+  return details.customPatternApproval?.target ?? null;
+}
+
+function buildRequestPermissionOptions(
+  details: PromptPermissionDetails,
+): RequestPermissionOptions | undefined {
+  const options: RequestPermissionOptions = {};
+  if (details.sessionLabel) {
+    options.sessionLabel = details.sessionLabel;
+  }
+  if (details.customPatternOptions && details.customPatternOptions.length > 0) {
+    options.customPatternOptions = details.customPatternOptions;
+  }
+  return Object.keys(options).length > 0 ? options : undefined;
+}
+
 export class PermissionPrompter implements PermissionPrompterApi {
   constructor(private readonly deps: PermissionPrompterDeps) {}
 
@@ -92,7 +116,7 @@ export class PermissionPrompter implements PermissionPrompterApi {
       ctx,
       details.message,
       this.buildForwardingDeps(),
-      details.sessionLabel ? { sessionLabel: details.sessionLabel } : undefined,
+      buildRequestPermissionOptions(details),
     );
 
     this.writeReviewEntry(
@@ -103,6 +127,7 @@ export class PermissionPrompter implements PermissionPrompterApi {
         ...details,
         resolution: decision.state,
         denialReason: decision.denialReason,
+        customPatternApproval: decision.customPatternApproval,
       },
     );
 
@@ -116,6 +141,7 @@ export class PermissionPrompter implements PermissionPrompterApi {
     details: PromptPermissionDetails & {
       resolution?: string;
       denialReason?: string;
+      customPatternApproval?: { target: CustomPatternApprovalTarget };
     },
   ): void {
     this.deps.writeReviewLog(event, {
@@ -130,8 +156,11 @@ export class PermissionPrompter implements PermissionPrompterApi {
       command: details.command ?? null,
       target: details.target ?? null,
       toolInputPreview: details.toolInputPreview ?? null,
+      surface: details.surface ?? null,
+      defaultPersistAction: details.defaultPersistAction ?? null,
       resolution: details.resolution ?? null,
       denialReason: details.denialReason ?? null,
+      customPatternApprovalTarget: getCustomPatternApprovalTarget(details),
     });
   }
 

--- a/packages/pi-permission-system/src/permission-session.ts
+++ b/packages/pi-permission-system/src/permission-session.ts
@@ -250,6 +250,10 @@ export class PermissionSession {
 
   // ── Infrastructure paths ───────────────────────────────────────────────
 
+  getAgentDir(): string {
+    return this.paths.agentDir;
+  }
+
   getInfrastructureDirs(): readonly string[] {
     return this.paths.piInfrastructureDirs;
   }

--- a/packages/pi-permission-system/src/persist-permission-rule.ts
+++ b/packages/pi-permission-system/src/persist-permission-rule.ts
@@ -1,0 +1,115 @@
+import {
+  existsSync,
+  mkdirSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+
+import { loadUnifiedConfig } from "./config-loader";
+import { getGlobalConfigPath, getProjectConfigPath } from "./config-paths";
+import type { PermissionState } from "./types";
+
+export type PersistedPermissionScope = "global" | "project";
+
+export interface PersistPermissionRuleParams {
+  agentDir: string;
+  cwd?: string | null;
+  scope: PersistedPermissionScope;
+  surface: string;
+  pattern: string;
+  action: PermissionState;
+}
+
+export interface PersistPermissionRuleResult {
+  path: string;
+}
+
+export function persistPermissionRule(
+  params: PersistPermissionRuleParams,
+): PersistPermissionRuleResult {
+  const path = resolveConfigPath(params.agentDir, params.cwd, params.scope);
+  const loaded = loadUnifiedConfig(path);
+
+  if (loaded.issues.length > 0) {
+    throw new Error(loaded.issues.join("; "));
+  }
+
+  const next = {
+    ...loaded.config,
+    permission: {
+      ...(loaded.config.permission ?? {}),
+      [params.surface]: upsertSurfacePermission(
+        loaded.config.permission?.[params.surface],
+        params.pattern,
+        params.action,
+      ),
+    },
+  };
+
+  const tmpPath = `${path}.tmp`;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(tmpPath, `${JSON.stringify(next, null, 2)}\n`, "utf-8");
+    renameSync(tmpPath, path);
+  } catch (error) {
+    try {
+      if (existsSync(tmpPath)) {
+        unlinkSync(tmpPath);
+      }
+    } catch {
+      // Ignore cleanup failures.
+    }
+    throw error;
+  }
+
+  return { path };
+}
+
+function resolveConfigPath(
+  agentDir: string,
+  cwd: string | null | undefined,
+  scope: PersistedPermissionScope,
+): string {
+  if (scope === "global") {
+    return getGlobalConfigPath(agentDir);
+  }
+
+  if (!cwd) {
+    throw new Error(
+      "Project config cannot be updated without a working directory.",
+    );
+  }
+
+  return getProjectConfigPath(cwd);
+}
+
+function upsertSurfacePermission(
+  existing: PermissionState | Record<string, PermissionState> | undefined,
+  pattern: string,
+  action: PermissionState,
+): PermissionState | Record<string, PermissionState> {
+  if (typeof existing === "string") {
+    if (pattern === "*") {
+      return action;
+    }
+    return {
+      "*": existing,
+      [pattern]: action,
+    };
+  }
+
+  if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+    return {
+      ...existing,
+      [pattern]: action,
+    };
+  }
+
+  if (pattern === "*") {
+    return action;
+  }
+
+  return { [pattern]: action };
+}

--- a/packages/pi-permission-system/tests/handlers/gates/helpers.test.ts
+++ b/packages/pi-permission-system/tests/handlers/gates/helpers.test.ts
@@ -72,6 +72,12 @@ describe("deriveResolution", () => {
     );
   });
 
+  it("returns approved_with_custom_pattern for ask + allow with custom pattern", () => {
+    expect(deriveResolution("ask", "allow", false, true, false, true)).toBe(
+      "approved_with_custom_pattern",
+    );
+  });
+
   it("returns user_denied for ask + block with canConfirm", () => {
     expect(deriveResolution("ask", "block", false, true)).toBe("user_denied");
   });

--- a/packages/pi-permission-system/tests/handlers/gates/runner.test.ts
+++ b/packages/pi-permission-system/tests/handlers/gates/runner.test.ts
@@ -61,6 +61,8 @@ function makeRunnerDeps(
     checkPermission: vi.fn().mockReturnValue(makeCheckResult("allow")),
     getSessionRuleset: vi.fn().mockReturnValue([]),
     approveSessionRule: vi.fn(),
+    persistCustomPattern: vi.fn().mockReturnValue("/tmp/config.json"),
+    refreshConfig: vi.fn(),
     writeReviewLog: vi.fn(),
     emitDecision: vi.fn(),
     canConfirm: vi.fn().mockReturnValue(true),
@@ -201,6 +203,49 @@ describe("runGateCheck", () => {
     expect(deps.approveSessionRule).toHaveBeenCalledWith(
       "external_directory",
       "/outside/b/*",
+    );
+  });
+
+  it("persists a custom project pattern, records a session rule, refreshes config, and emits approved_with_custom_pattern", async () => {
+    const deps = makeRunnerDeps({
+      checkPermission: vi.fn().mockReturnValue(makeCheckResult("ask")),
+      promptPermission: vi.fn().mockResolvedValue({
+        approved: true,
+        state: "approved_with_custom_pattern",
+        customPatternApproval: {
+          pattern: "git checkout *",
+          target: "project",
+        },
+      }),
+    });
+    const descriptor = makeDescriptor({
+      surface: "bash",
+      promptDetails: {
+        source: "tool_call",
+        agentName: null,
+        message: "Allow?",
+        surface: "bash",
+        defaultPersistAction: "allow",
+        toolCallId: "tc-1",
+        toolName: "bash",
+      },
+      decision: { surface: "bash", value: "git checkout main" },
+    });
+    const result = await runGateCheck(descriptor, null, "tc-1", deps);
+    expect(result).toEqual({ action: "allow" });
+    expect(deps.persistCustomPattern).toHaveBeenCalledWith(
+      "project",
+      "bash",
+      "git checkout *",
+      "allow",
+    );
+    expect(deps.approveSessionRule).toHaveBeenCalledWith(
+      "bash",
+      "git checkout *",
+    );
+    expect(deps.refreshConfig).toHaveBeenCalledTimes(1);
+    expect(deps.emitDecision).toHaveBeenCalledWith(
+      expect.objectContaining({ resolution: "approved_with_custom_pattern" }),
     );
   });
 

--- a/packages/pi-permission-system/tests/handlers/input-events.test.ts
+++ b/packages/pi-permission-system/tests/handlers/input-events.test.ts
@@ -57,6 +57,8 @@ function makeSession(
     getToolPermission: vi.fn().mockReturnValue("allow" as PermissionState),
     getSessionRuleset: vi.fn().mockReturnValue([]),
     approveSessionRule: vi.fn(),
+    getAgentDir: vi.fn().mockReturnValue("/tmp/agent"),
+    refreshConfig: vi.fn(),
     canPrompt: vi.fn().mockReturnValue(true),
     prompt: vi.fn().mockResolvedValue({ approved: true, state: "approved" }),
     createPermissionRequestId: vi.fn().mockReturnValue("req-id"),
@@ -164,6 +166,52 @@ describe("handleInput decision events — skill gate", () => {
       result: "deny",
       resolution: "user_denied",
     });
+  });
+
+  it("emits allow with approved_with_custom_pattern when state=ask and user enters a custom pattern", async () => {
+    const { handler, events } = makeHandler("ask", {
+      prompt: vi.fn().mockResolvedValue({
+        approved: true,
+        state: "approved_with_custom_pattern",
+        customPatternApproval: {
+          pattern: "librarian",
+          target: "session",
+        },
+      }),
+    });
+    await handler.handleInput({ text: "/skill:librarian" }, makeCtx());
+
+    const decisions = getDecisionEvents(events);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toMatchObject({
+      surface: "skill",
+      value: "librarian",
+      result: "allow",
+      resolution: "approved_with_custom_pattern",
+    });
+  });
+
+  it("records a session rule and refreshes config when a custom skill pattern is persisted", async () => {
+    const refreshConfig = vi.fn();
+    const approveSessionRule = vi.fn();
+    const { handler } = makeHandler("ask", {
+      prompt: vi.fn().mockResolvedValue({
+        approved: true,
+        state: "approved_with_custom_pattern",
+        customPatternApproval: {
+          pattern: "librarian",
+          target: "global",
+        },
+      }),
+      approveSessionRule,
+      refreshConfig,
+    });
+    const ctx = makeCtx();
+
+    await handler.handleInput({ text: "/skill:librarian" }, ctx);
+
+    expect(approveSessionRule).toHaveBeenCalledWith("skill", "librarian");
+    expect(refreshConfig).toHaveBeenCalledWith(ctx);
   });
 
   it("emits deny with confirmation_unavailable when state=ask but no UI", async () => {

--- a/packages/pi-permission-system/tests/handlers/input.test.ts
+++ b/packages/pi-permission-system/tests/handlers/input.test.ts
@@ -45,6 +45,7 @@ function makeSession(
     getToolPermission: vi.fn().mockReturnValue("allow" as PermissionState),
     getSessionRuleset: vi.fn().mockReturnValue([]),
     approveSessionRule: vi.fn(),
+    refreshConfig: vi.fn(),
     canPrompt: vi.fn().mockReturnValue(true),
     prompt: vi.fn().mockResolvedValue({ approved: true, state: "approved" }),
     createPermissionRequestId: vi.fn().mockReturnValue("req-id"),

--- a/packages/pi-permission-system/tests/handlers/tool-call-events.test.ts
+++ b/packages/pi-permission-system/tests/handlers/tool-call-events.test.ts
@@ -83,6 +83,7 @@ function makeSession(
       .fn()
       .mockReturnValue(["/test/agent", "/test/agent/git"]),
     getInfrastructureReadPaths: vi.fn().mockReturnValue([]),
+    refreshConfig: vi.fn(),
     canPrompt: vi.fn().mockReturnValue(true),
     prompt: vi.fn().mockResolvedValue({ approved: true, state: "approved" }),
     ...overrides,

--- a/packages/pi-permission-system/tests/handlers/tool-call.test.ts
+++ b/packages/pi-permission-system/tests/handlers/tool-call.test.ts
@@ -74,6 +74,7 @@ function makeSession(
       .fn()
       .mockReturnValue(["/test/agent", "/test/agent/git"]),
     getInfrastructureReadPaths: vi.fn().mockReturnValue([]),
+    refreshConfig: vi.fn(),
     canPrompt: vi.fn().mockReturnValue(true),
     prompt: vi.fn().mockResolvedValue({ approved: true, state: "approved" }),
     ...overrides,

--- a/packages/pi-permission-system/tests/permission-dialog.test.ts
+++ b/packages/pi-permission-system/tests/permission-dialog.test.ts
@@ -24,6 +24,12 @@ describe("isPermissionDecisionState", () => {
     expect(isPermissionDecisionState("approved_for_session")).toBe(true);
   });
 
+  it("accepts approved_with_custom_pattern", () => {
+    expect(isPermissionDecisionState("approved_with_custom_pattern")).toBe(
+      true,
+    );
+  });
+
   it("rejects unknown strings", () => {
     expect(isPermissionDecisionState("unknown")).toBe(false);
   });
@@ -117,7 +123,7 @@ describe("requestPermissionDecisionFromUi", () => {
     expect(result).toEqual({ approved: false, state: "denied" });
   });
 
-  it("passes four options to ui.select", async () => {
+  it("passes six options to ui.select", async () => {
     const selectFn = vi.fn().mockResolvedValue("Yes");
     const ui: PermissionDecisionUi = {
       select: selectFn,
@@ -128,6 +134,8 @@ describe("requestPermissionDecisionFromUi", () => {
     expect(options).toEqual([
       "Yes",
       "Yes, for this session",
+      "Yes, enter a custom pattern for this session",
+      "Yes, save a custom pattern to config",
       "No",
       "No, provide reason",
     ]);
@@ -159,6 +167,163 @@ describe("requestPermissionDecisionFromUi", () => {
       { sessionLabel: customLabel },
     );
     expect(result).toEqual({ approved: true, state: "approved_for_session" });
+  });
+
+  it("returns approved_with_custom_pattern for custom session pattern", async () => {
+    const ui: PermissionDecisionUi = {
+      select: vi
+        .fn()
+        .mockResolvedValueOnce("Yes, enter a custom pattern for this session"),
+      input: vi.fn().mockResolvedValue("git checkout *"),
+    };
+    const result = await requestPermissionDecisionFromUi(
+      ui,
+      "Title",
+      "Message",
+    );
+    expect(result).toEqual({
+      approved: true,
+      state: "approved_with_custom_pattern",
+      customPatternApproval: {
+        pattern: "git checkout *",
+        target: "session",
+      },
+    });
+  });
+
+  it("returns approved_with_custom_pattern for persisted custom pattern", async () => {
+    const ui: PermissionDecisionUi = {
+      select: vi
+        .fn()
+        .mockResolvedValueOnce("Yes, save a custom pattern to config")
+        .mockResolvedValueOnce("Project config"),
+      input: vi.fn().mockResolvedValue("exa:search"),
+    };
+    const result = await requestPermissionDecisionFromUi(
+      ui,
+      "Title",
+      "Message",
+    );
+    expect(result).toEqual({
+      approved: true,
+      state: "approved_with_custom_pattern",
+      customPatternApproval: {
+        pattern: "exa:search",
+        target: "project",
+      },
+    });
+  });
+
+  it("shows custom pattern candidates before the edit input", async () => {
+    const selectFn = vi
+      .fn()
+      .mockResolvedValueOnce("Yes, enter a custom pattern for this session")
+      .mockResolvedValueOnce("Use pattern: git checkout *");
+    const inputFn = vi.fn().mockResolvedValue("git checkout main");
+    const ui: PermissionDecisionUi = {
+      select: selectFn,
+      input: inputFn,
+    };
+
+    const result = await requestPermissionDecisionFromUi(
+      ui,
+      "Title",
+      "Message",
+      {
+        customPatternOptions: ["git checkout main", "git checkout *", "git *"],
+      },
+    );
+
+    expect(selectFn.mock.calls[1][1]).toEqual([
+      "Use pattern: git checkout main",
+      "Use pattern: git checkout *",
+      "Use pattern: git *",
+      "Enter a custom pattern manually",
+      "← Back",
+    ]);
+    expect(inputFn).toHaveBeenCalledWith(
+      "Title\nEdit pattern or press Enter to use:\ngit checkout *",
+      "git checkout *",
+    );
+    expect(result).toEqual({
+      approved: true,
+      state: "approved_with_custom_pattern",
+      customPatternApproval: {
+        pattern: "git checkout main",
+        target: "session",
+      },
+    });
+  });
+
+  it("uses the selected candidate when the edit input is empty", async () => {
+    const ui: PermissionDecisionUi = {
+      select: vi
+        .fn()
+        .mockResolvedValueOnce("Yes, enter a custom pattern for this session")
+        .mockResolvedValueOnce("Use pattern: git *"),
+      input: vi.fn().mockResolvedValue(""),
+    };
+
+    const result = await requestPermissionDecisionFromUi(
+      ui,
+      "Title",
+      "Message",
+      { customPatternOptions: ["git *"] },
+    );
+
+    expect(result).toEqual({
+      approved: true,
+      state: "approved_with_custom_pattern",
+      customPatternApproval: {
+        pattern: "git *",
+        target: "session",
+      },
+    });
+  });
+
+  it("returns to the top-level choices from the custom pattern chooser", async () => {
+    const selectFn = vi
+      .fn()
+      .mockResolvedValueOnce("Yes, enter a custom pattern for this session")
+      .mockResolvedValueOnce("← Back")
+      .mockResolvedValueOnce("No");
+    const ui: PermissionDecisionUi = {
+      select: selectFn,
+      input: vi.fn(),
+    };
+
+    const result = await requestPermissionDecisionFromUi(
+      ui,
+      "Title",
+      "Message",
+      { customPatternOptions: ["git *"] },
+    );
+
+    expect(result).toEqual({ approved: false, state: "denied" });
+    expect(selectFn).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns to the top-level choices from config target selection", async () => {
+    const selectFn = vi
+      .fn()
+      .mockResolvedValueOnce("Yes, save a custom pattern to config")
+      .mockResolvedValueOnce("Use pattern: git *")
+      .mockResolvedValueOnce("← Back")
+      .mockResolvedValueOnce("Yes");
+    const ui: PermissionDecisionUi = {
+      select: selectFn,
+      input: vi.fn().mockResolvedValue(""),
+    };
+
+    const result = await requestPermissionDecisionFromUi(
+      ui,
+      "Title",
+      "Message",
+      { customPatternOptions: ["git *"] },
+    );
+
+    expect(result).toEqual({ approved: true, state: "approved" });
+    expect(selectFn).toHaveBeenCalledTimes(4);
   });
 
   it("falls back to default session label when no options provided", async () => {

--- a/packages/pi-permission-system/tests/permission-events.test.ts
+++ b/packages/pi-permission-system/tests/permission-events.test.ts
@@ -116,6 +116,7 @@ describe("emitDecisionEvent", () => {
       "infrastructure_auto_allowed",
       "user_approved",
       "user_approved_for_session",
+      "approved_with_custom_pattern",
       "user_denied",
       "auto_approved",
       "confirmation_unavailable",

--- a/packages/pi-permission-system/tests/permission-prompter.test.ts
+++ b/packages/pi-permission-system/tests/permission-prompter.test.ts
@@ -248,6 +248,31 @@ describe("PermissionPrompter", () => {
       );
     });
 
+    it("passes sessionLabel and customPatternOptions to confirmPermission when present", async () => {
+      mockConfirmPermission.mockResolvedValue({
+        approved: true,
+        state: "approved",
+      });
+      const deps = makeDeps();
+      const prompter = new PermissionPrompter(deps);
+      const details = makeDetails({
+        sessionLabel: "Yes, for 'read' tool",
+        customPatternOptions: ["path/file.ts", "path/*", "*"],
+      });
+
+      await prompter.prompt(makeCtx(true), details);
+
+      expect(mockConfirmPermission).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(String),
+        expect.anything(),
+        {
+          sessionLabel: "Yes, for 'read' tool",
+          customPatternOptions: ["path/file.ts", "path/*", "*"],
+        },
+      );
+    });
+
     it("passes undefined options to confirmPermission when sessionLabel is absent", async () => {
       mockConfirmPermission.mockResolvedValue({
         approved: true,
@@ -352,6 +377,30 @@ describe("PermissionPrompter", () => {
   });
 
   // ── Subagent forwarding path ─────────────────────────────────────────────
+
+  it("logs customPatternApprovalTarget when user enters a custom pattern", async () => {
+    const writeReviewLog = vi.fn();
+    mockConfirmPermission.mockResolvedValue({
+      approved: true,
+      state: "approved_with_custom_pattern",
+      customPatternApproval: {
+        pattern: "git *",
+        target: "project",
+      },
+    });
+    const deps = makeDeps({ writeReviewLog });
+    const prompter = new PermissionPrompter(deps);
+
+    await prompter.prompt(makeCtx(true), makeDetails({ surface: "bash" }));
+
+    expect(writeReviewLog).toHaveBeenCalledWith(
+      "permission_request.approved",
+      expect.objectContaining({
+        customPatternApprovalTarget: "project",
+        resolution: "approved_with_custom_pattern",
+      }),
+    );
+  });
 
   describe("subagent forwarding path", () => {
     it("calls confirmPermission even when ctx has no UI", async () => {


### PR DESCRIPTION
Allow users to choose, edit, and save suggested permission patterns from the permission prompt. Apply persisted custom patterns immediately in the current session.