### PR TITLE
Broadcast permission prompts on permissions:prompt channel

### DIFF
--- a/packages/pi-permission-system/src/index.ts
+++ b/packages/pi-permission-system/src/index.ts
@@ -43,6 +43,7 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
     subagentSessionsDir: runtime.subagentSessionsDir,
     forwardingDir: runtime.forwardingDir,
     registry: subagentRegistry,
+    events: pi.events,
     requestPermissionDecisionFromUi,
   });
 

--- a/packages/pi-permission-system/src/permission-event-rpc.ts
+++ b/packages/pi-permission-system/src/permission-event-rpc.ts
@@ -21,6 +21,7 @@ import type {
   PermissionsRpcReply,
 } from "./permission-events";
 import {
+  emitPromptEvent,
   PERMISSIONS_PROTOCOL_VERSION,
   PERMISSIONS_RPC_CHECK_CHANNEL,
   PERMISSIONS_RPC_PROMPT_CHANNEL,
@@ -154,6 +155,21 @@ async function handlePromptRpc(
     const title = surface
       ? `Permission request${agentName ? ` from ${agentName}` : ""}`
       : "Permission request";
+
+    emitPromptEvent(events, {
+      requestId,
+      source: "rpc_prompt",
+      agentName: agentName ?? null,
+      message,
+      toolCallId: null,
+      toolName: null,
+      skillName: null,
+      path: null,
+      command: null,
+      target: value ?? null,
+      toolInputPreview: null,
+      sessionLabel: sessionLabel ?? null,
+    });
 
     const decision = await deps.requestPermissionDecisionFromUi(
       ctx.ui,

--- a/packages/pi-permission-system/src/permission-events.ts
+++ b/packages/pi-permission-system/src/permission-events.ts
@@ -27,6 +27,9 @@ export const PERMISSIONS_PROTOCOL_VERSION = 1;
 /** Emitted once on extension load. */
 export const PERMISSIONS_READY_CHANNEL = "permissions:ready";
 
+/** Emitted when the user is being prompted for a permission decision. */
+export const PERMISSIONS_PROMPT_CHANNEL = "permissions:prompt";
+
 /** Emitted after every permission gate resolution. */
 export const PERMISSIONS_DECISION_CHANNEL = "permissions:decision";
 
@@ -64,6 +67,36 @@ export type PermissionsRpcReply<T = void> =
 /** Payload emitted on `permissions:ready`. */
 export interface PermissionsReadyEvent {
   protocolVersion: number;
+}
+
+// ── permissions:prompt ─────────────────────────────────────────────────────
+
+/** Payload emitted on `permissions:prompt`. */
+export interface PermissionPromptEvent {
+  /** Unique ID for the permission request being prompted. */
+  requestId: string;
+  /** Prompt source: tool call, skill input/read, RPC, forwarded subagent request, etc. */
+  source: string;
+  /** Agent name (when known). */
+  agentName: string | null;
+  /** Message displayed to the user. */
+  message: string;
+  /** Tool call ID (when the prompt is for a tool call). */
+  toolCallId: string | null;
+  /** Tool name (when the prompt is for a tool call). */
+  toolName: string | null;
+  /** Skill name (when the prompt is for a skill request). */
+  skillName: string | null;
+  /** Path being evaluated (when available). */
+  path: string | null;
+  /** Command being evaluated (when available). */
+  command: string | null;
+  /** Target being evaluated (when available). */
+  target: string | null;
+  /** Tool input preview shown in logs/prompts (when available). */
+  toolInputPreview: string | null;
+  /** Override label for the "for this session" dialog option. */
+  sessionLabel: string | null;
 }
 
 // ── permissions:decision ───────────────────────────────────────────────────
@@ -167,6 +200,17 @@ export function emitReadyEvent(events: PermissionEventBus): void {
     protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
   };
   events.emit(PERMISSIONS_READY_CHANNEL, payload);
+}
+
+/**
+ * Emit a `permissions:prompt` broadcast.
+ * Call immediately before showing or forwarding a permission prompt.
+ */
+export function emitPromptEvent(
+  events: PermissionEventBus,
+  event: PermissionPromptEvent,
+): void {
+  events.emit(PERMISSIONS_PROMPT_CHANNEL, event);
 }
 
 /**

--- a/packages/pi-permission-system/src/permission-prompter.ts
+++ b/packages/pi-permission-system/src/permission-prompter.ts
@@ -9,6 +9,8 @@ import type {
   PermissionPromptDecision,
   RequestPermissionOptions,
 } from "./permission-dialog";
+import type { PermissionEventBus } from "./permission-events";
+import { emitPromptEvent } from "./permission-events";
 import type { SubagentSessionRegistry } from "./subagent-registry";
 import { shouldAutoApprovePermissionState } from "./yolo-mode";
 
@@ -57,6 +59,8 @@ export interface PermissionPrompterDeps {
   forwardingDir: string;
   /** In-process subagent session registry for detection and forwarding target resolution. */
   registry?: SubagentSessionRegistry;
+  /** Event bus used for permission prompt broadcasts. */
+  events: PermissionEventBus;
   /** Show the interactive permission dialog in the UI. */
   requestPermissionDecisionFromUi(
     ui: ExtensionContext["ui"],
@@ -90,6 +94,20 @@ export class PermissionPrompter implements PermissionPrompterApi {
     }
 
     this.writeReviewEntry("permission_request.waiting", details);
+    emitPromptEvent(this.deps.events, {
+      requestId: details.requestId,
+      source: details.source,
+      agentName: details.agentName,
+      message: details.message,
+      toolCallId: details.toolCallId ?? null,
+      toolName: details.toolName ?? null,
+      skillName: details.skillName ?? null,
+      path: details.path ?? null,
+      command: details.command ?? null,
+      target: details.target ?? null,
+      toolInputPreview: details.toolInputPreview ?? null,
+      sessionLabel: details.sessionLabel ?? null,
+    });
 
     const decision = await confirmPermission(
       ctx,

--- a/packages/pi-permission-system/test/permission-event-rpc.test.ts
+++ b/packages/pi-permission-system/test/permission-event-rpc.test.ts
@@ -11,6 +11,7 @@ import type {
 } from "#src/permission-events";
 import {
   PERMISSIONS_PROTOCOL_VERSION,
+  PERMISSIONS_PROMPT_CHANNEL,
   PERMISSIONS_RPC_CHECK_CHANNEL,
   PERMISSIONS_RPC_PROMPT_CHANNEL,
 } from "#src/permission-events";
@@ -315,6 +316,49 @@ describe("registerPermissionRpcHandlers — permissions:rpc:prompt", () => {
       expect(reply.data?.approved).toBe(true);
       expect(reply.data?.state).toBe("approved");
     }
+  });
+
+  it("emits a prompt broadcast before awaiting the UI decision", async () => {
+    const bus = createEventBus();
+    const ctx = makeCtxWithUi();
+    const requestUi = vi
+      .fn()
+      .mockResolvedValue({ approved: true, state: "approved" as const });
+    const deps = makeDeps({
+      getRuntimeContext: vi.fn().mockReturnValue(ctx),
+      requestPermissionDecisionFromUi: requestUi,
+    });
+    registerPermissionRpcHandlers(bus, deps);
+
+    const promptPromise = waitForReply(bus, PERMISSIONS_PROMPT_CHANNEL);
+    const replyPromise = waitForReply(
+      bus,
+      `${PERMISSIONS_RPC_PROMPT_CHANNEL}:reply:req-prompt-broadcast`,
+    );
+    bus.emit(PERMISSIONS_RPC_PROMPT_CHANNEL, {
+      requestId: "req-prompt-broadcast",
+      surface: "bash",
+      value: "git push",
+      message: "Allow git push?",
+      agentName: "Worker",
+      sessionLabel: "Allow git *",
+    });
+
+    await expect(promptPromise).resolves.toEqual({
+      requestId: "req-prompt-broadcast",
+      source: "rpc_prompt",
+      agentName: "Worker",
+      message: "Allow git push?",
+      toolCallId: null,
+      toolName: null,
+      skillName: null,
+      path: null,
+      command: null,
+      target: "git push",
+      toolInputPreview: null,
+      sessionLabel: "Allow git *",
+    });
+    await replyPromise;
   });
 
   it("passes the message to requestPermissionDecisionFromUi", async () => {

--- a/packages/pi-permission-system/test/permission-events.test.ts
+++ b/packages/pi-permission-system/test/permission-events.test.ts
@@ -8,6 +8,7 @@ import { getGlobalConfigPath } from "#src/config-paths";
 import piPermissionSystemExtension from "#src/index";
 import type {
   PermissionDecisionEvent,
+  PermissionPromptEvent,
   PermissionsCheckReplyData,
   PermissionsCheckRequest,
   PermissionsPromptReplyData,
@@ -17,8 +18,10 @@ import type {
 } from "#src/permission-events";
 import {
   emitDecisionEvent,
+  emitPromptEvent,
   emitReadyEvent,
   PERMISSIONS_DECISION_CHANNEL,
+  PERMISSIONS_PROMPT_CHANNEL,
   PERMISSIONS_PROTOCOL_VERSION,
   PERMISSIONS_READY_CHANNEL,
   PERMISSIONS_RPC_CHECK_CHANNEL,
@@ -43,6 +46,7 @@ describe("constants", () => {
 
   it("channel names have the correct values", () => {
     expect(PERMISSIONS_READY_CHANNEL).toBe("permissions:ready");
+    expect(PERMISSIONS_PROMPT_CHANNEL).toBe("permissions:prompt");
     expect(PERMISSIONS_DECISION_CHANNEL).toBe("permissions:decision");
     expect(PERMISSIONS_RPC_CHECK_CHANNEL).toBe("permissions:rpc:check");
     expect(PERMISSIONS_RPC_PROMPT_CHANNEL).toBe("permissions:rpc:prompt");
@@ -66,6 +70,44 @@ describe("emitReadyEvent", () => {
     emitReadyEvent(bus);
     const payload = bus.emit.mock.calls[0][1] as PermissionsReadyEvent;
     expect(typeof payload.protocolVersion).toBe("number");
+  });
+});
+
+// ── emitPromptEvent ────────────────────────────────────────────────────────
+
+describe("emitPromptEvent", () => {
+  function makePromptEvent(
+    overrides: Partial<PermissionPromptEvent> = {},
+  ): PermissionPromptEvent {
+    return {
+      requestId: "req-123",
+      source: "tool_call",
+      agentName: "Explore",
+      message: "Allow git status?",
+      toolCallId: "call-123",
+      toolName: "bash",
+      skillName: null,
+      path: null,
+      command: "git status",
+      target: null,
+      toolInputPreview: null,
+      sessionLabel: null,
+      ...overrides,
+    };
+  }
+
+  it("emits on the permissions:prompt channel", () => {
+    const bus = makeEventBus();
+    emitPromptEvent(bus, makePromptEvent());
+    expect(bus.emit).toHaveBeenCalledOnce();
+    expect(bus.emit.mock.calls[0][0]).toBe("permissions:prompt");
+  });
+
+  it("forwards the full payload unchanged", () => {
+    const bus = makeEventBus();
+    const event = makePromptEvent({ sessionLabel: "Allow for session" });
+    emitPromptEvent(bus, event);
+    expect(bus.emit.mock.calls[0][1]).toEqual(event);
   });
 });
 

--- a/packages/pi-permission-system/test/permission-prompter.test.ts
+++ b/packages/pi-permission-system/test/permission-prompter.test.ts
@@ -53,6 +53,7 @@ function makeDeps(
     writeReviewLog: vi.fn(),
     subagentSessionsDir: "/sessions/subagents",
     forwardingDir: "/sessions/permission-forwarding",
+    events: { emit: vi.fn(), on: vi.fn().mockReturnValue(() => undefined) },
     requestPermissionDecisionFromUi: vi
       .fn()
       .mockResolvedValue({ approved: true, state: "approved" }),


### PR DESCRIPTION
Adds a simple event bus broadcast on "permissions:prompt" channel  for when user is being prompted for permissions.
Very useful for notifications and things of similar nature.