### PR TITLE
feat(pi-permission-system): add UI prompt broadcast contract

### DIFF
--- a/packages/pi-permission-system/CHANGELOG.md
+++ b/packages/pi-permission-system/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Features
+
+* broadcast `permissions:ui_prompt` before active user-facing permission UI prompts
+
+### Documentation
+
+* document UI prompt broadcasts in the README and cross-extension API reference
+
 ## [9.2.0](https://github.com/gotgenes/pi-packages/compare/pi-permission-system-v9.1.0...pi-permission-system-v9.2.0) (2026-06-02)
 
 

--- a/packages/pi-permission-system/README.md
+++ b/packages/pi-permission-system/README.md
@@ -20,6 +20,7 @@ Permission enforcement extension for the [Pi](https://pi.mariozechner.at/) codin
 - **Protects sensitive file patterns** — cross-cutting `path` rules deny `.env`, `~/.ssh/*`, etc. across all tools and bash at once
 - **Guards external paths** — prompts before file tools or bash commands reach outside `cwd`
 - **Forwards prompts from subagents** — `ask` policies work even in non-UI execution contexts
+- **Broadcasts UI prompt events** — `permissions:ui_prompt` fires only when the permission system is about to invoke the active user-facing permission UI
 - **Native [`@gotgenes/pi-subagents`](https://github.com/gotgenes/pi-subagents) integration** — in-process child sessions register with the permission system automatically, enabling per-agent policy enforcement and `ask`-state forwarding to the parent UI without configuration
 
 ## Install
@@ -93,7 +94,7 @@ For the full reference — all surfaces, runtime knobs, per-agent overrides, mer
 | ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
 | [docs/configuration.md](docs/configuration.md)                                                                                 | Full policy reference, runtime knobs, per-agent overrides, recipes           |
 | [docs/session-approvals.md](docs/session-approvals.md)                                                                         | Session-scoped rules, pattern suggestions, bash arity table                  |
-| [docs/cross-extension-api.md](docs/cross-extension-api.md)                                                                     | Cross-extension service accessor, event bus integration, decision broadcasts |
+| [docs/cross-extension-api.md](docs/cross-extension-api.md)                                                                     | Cross-extension service accessor, event bus integration, prompt and decision broadcasts |
 | [docs/subagent-integration.md](docs/subagent-integration.md)                                                                   | Permission forwarding, coexistence with subagent extensions                  |
 | [docs/guides/permission-frontmatter-for-subagent-extensions.md](docs/guides/permission-frontmatter-for-subagent-extensions.md) | Convention guide for subagent extension authors                              |
 | [docs/opencode-compatibility.md](docs/opencode-compatibility.md)                                                               | OpenCode compatibility — shared concepts, divergences, porting guide         |

--- a/packages/pi-permission-system/docs/cross-extension-api.md
+++ b/packages/pi-permission-system/docs/cross-extension-api.md
@@ -249,11 +249,50 @@ The protocol version constant is exported from `src/permission-events.ts` and em
 | Channel                                    | Direction | When                              | Payload type                                      |
 | ------------------------------------------ | --------- | --------------------------------- | ------------------------------------------------- |
 | `permissions:ready`                        | Broadcast | At `session_start`, after publish | `PermissionsReadyEvent`                           |
+| `permissions:ui_prompt`                    | Broadcast | Before active UI prompt           | `PermissionUiPromptEvent`                         |
 | `permissions:decision`                     | Broadcast | After every gate resolution       | `PermissionDecisionEvent`                         |
 | `permissions:rpc:check`                    | Request   | On-demand                         | `PermissionsCheckRequest`                         |
 | `permissions:rpc:check:reply:<requestId>`  | Reply     | After each check request          | `PermissionsRpcReply<PermissionsCheckReplyData>`  |
 | `permissions:rpc:prompt`                   | Request   | On-demand                         | `PermissionsPromptRequest`                        |
 | `permissions:rpc:prompt:reply:<requestId>` | Reply     | After prompt is resolved          | `PermissionsRpcReply<PermissionsPromptReplyData>` |
+
+---
+
+## UI Prompt Broadcasts
+
+The permission system emits `permissions:ui_prompt` immediately before it invokes the active user-facing permission UI.
+This event is for integrations such as notification extensions that should alert only when the user needs to respond to a permission prompt.
+It is not a generic "permission request entered waiting state" event, and it does not imply the prompt will be approved.
+Policy decisions that resolve without an active UI prompt, such as `policy_allow`, `policy_deny`, `session_approved`, `infrastructure_auto_allowed`, or `auto_approved`, do not emit this event.
+Non-UI child sessions also do not emit this event when they create a forwarded permission request; the parent UI session emits it immediately before showing the forwarded permission dialog.
+
+```typescript
+pi.events.on("permissions:ui_prompt", (raw) => {
+  const event = raw as import("@gotgenes/pi-permission-system").PermissionUiPromptEvent;
+  console.log(event.surface, event.value, event.message);
+  // e.g. "bash" "git push" "Allow git push?"
+});
+```
+
+### Payload Fields
+
+| Field              | Type             | Description                                                                                                      |
+| ------------------ | ---------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `protocolVersion`  | `number`         | Cross-extension event protocol version                                                                           |
+| `requestId`        | `string`         | Unique ID for the permission request being prompted                                                              |
+| `source`           | `PermissionUiPromptSource` | Prompt source: `"tool_call"`, `"skill_input"`, `"skill_read"`, `"rpc_prompt"`, or `"forwarded_permission"` |
+| `surface`          | `string \| null` | Permission surface being evaluated, when known                                                                   |
+| `value`            | `string \| null` | Value being evaluated: command, path, skill name, tool target, etc.                                              |
+| `agentName`        | `string \| null` | Active/requesting agent name when known                                                                          |
+| `message`          | `string`         | Message displayed in the permission prompt                                                                       |
+| `toolCallId`       | `string \| null` | Tool call ID when the prompt is for a tool call                                                                  |
+| `toolName`         | `string \| null` | Tool name when the prompt is for a tool call                                                                     |
+| `skillName`        | `string \| null` | Skill name when the prompt is for a skill request                                                                |
+| `path`             | `string \| null` | Path being evaluated, when available                                                                             |
+| `command`          | `string \| null` | Command being evaluated, when available                                                                          |
+| `target`           | `string \| null` | Generic target being evaluated, when available                                                                   |
+| `toolInputPreview` | `string \| null` | Tool input preview shown in logs/prompts, when available                                                         |
+| `sessionLabel`     | `string \| null` | Override label for the "for this session" dialog option                                                          |
 
 ---
 

--- a/packages/pi-permission-system/src/forwarded-permissions/polling.ts
+++ b/packages/pi-permission-system/src/forwarded-permissions/polling.ts
@@ -12,6 +12,12 @@ import type {
   RequestPermissionOptions,
 } from "#src/permission-dialog";
 import {
+  emitUiPromptEvent,
+  PERMISSIONS_PROTOCOL_VERSION,
+  type PermissionEventBus,
+  type PermissionUiPromptEvent,
+} from "#src/permission-events";
+import {
   type ForwardedPermissionRequest,
   type ForwardedPermissionResponse,
   isForwardedPermissionRequestForSession,
@@ -43,6 +49,8 @@ export interface PermissionForwardingDeps {
   subagentSessionsDir: string;
   /** In-process subagent session registry for detection and forwarding target resolution. */
   registry?: SubagentSessionRegistry;
+  /** Event bus used for UI prompt broadcasts. */
+  events?: PermissionEventBus;
   logger: ForwardedPermissionLogger;
   writeReviewLog: (event: string, details: Record<string, unknown>) => void;
   requestPermissionDecisionFromUi: (
@@ -296,6 +304,26 @@ export async function processForwardedPermissionRequests(
         forwardedPermissionLogDetails,
       );
       try {
+        if (deps.events) {
+          const message = formatForwardedPermissionPrompt(request);
+          emitUiPromptEvent(deps.events, {
+            protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
+            requestId: request.id,
+            source: "forwarded_permission",
+            surface: null,
+            value: request.message,
+            agentName: request.requesterAgentName || null,
+            message,
+            toolCallId: null,
+            toolName: null,
+            skillName: null,
+            path: null,
+            command: null,
+            target: request.message,
+            toolInputPreview: null,
+            sessionLabel: null,
+          });
+        }
         decision = await deps.requestPermissionDecisionFromUi(
           ctx.ui,
           "Permission Required (Subagent)",
@@ -359,8 +387,12 @@ export async function confirmPermission(
   message: string,
   deps: PermissionForwardingDeps,
   options?: RequestPermissionOptions,
+  uiPromptEvent?: PermissionUiPromptEvent,
 ): Promise<PermissionPromptDecision> {
   if (ctx.hasUI) {
+    if (deps.events && uiPromptEvent) {
+      emitUiPromptEvent(deps.events, uiPromptEvent);
+    }
     return deps.requestPermissionDecisionFromUi(
       ctx.ui,
       "Permission Required",

--- a/packages/pi-permission-system/src/index.ts
+++ b/packages/pi-permission-system/src/index.ts
@@ -62,6 +62,7 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
     forwardingDir: runtime.forwardingDir,
     subagentSessionsDir: runtime.subagentSessionsDir,
     registry: subagentRegistry,
+    events: pi.events,
     logger: {
       writeReviewLog: runtime.writeReviewLog.bind(runtime),
       writeDebugLog: runtime.writeDebugLog.bind(runtime),

--- a/packages/pi-permission-system/src/index.ts
+++ b/packages/pi-permission-system/src/index.ts
@@ -54,6 +54,7 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
     subagentSessionsDir: runtime.subagentSessionsDir,
     forwardingDir: runtime.forwardingDir,
     registry: subagentRegistry,
+    events: pi.events,
     requestPermissionDecisionFromUi,
   });
 

--- a/packages/pi-permission-system/src/permission-event-rpc.ts
+++ b/packages/pi-permission-system/src/permission-event-rpc.ts
@@ -21,7 +21,7 @@ import type {
   PermissionsRpcReply,
 } from "./permission-events";
 import {
-  emitPromptEvent,
+  emitUiPromptEvent,
   PERMISSIONS_PROTOCOL_VERSION,
   PERMISSIONS_RPC_CHECK_CHANNEL,
   PERMISSIONS_RPC_PROMPT_CHANNEL,
@@ -156,9 +156,12 @@ async function handlePromptRpc(
       ? `Permission request${agentName ? ` from ${agentName}` : ""}`
       : "Permission request";
 
-    emitPromptEvent(events, {
+    emitUiPromptEvent(events, {
+      protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
       requestId,
       source: "rpc_prompt",
+      surface: surface ?? null,
+      value: value ?? null,
       agentName: agentName ?? null,
       message,
       toolCallId: null,

--- a/packages/pi-permission-system/src/permission-event-rpc.ts
+++ b/packages/pi-permission-system/src/permission-event-rpc.ts
@@ -21,6 +21,7 @@ import type {
   PermissionsRpcReply,
 } from "./permission-events";
 import {
+  emitPromptEvent,
   PERMISSIONS_PROTOCOL_VERSION,
   PERMISSIONS_RPC_CHECK_CHANNEL,
   PERMISSIONS_RPC_PROMPT_CHANNEL,
@@ -154,6 +155,21 @@ async function handlePromptRpc(
     const title = surface
       ? `Permission request${agentName ? ` from ${agentName}` : ""}`
       : "Permission request";
+
+    emitPromptEvent(events, {
+      requestId,
+      source: "rpc_prompt",
+      agentName: agentName ?? null,
+      message,
+      toolCallId: null,
+      toolName: null,
+      skillName: null,
+      path: null,
+      command: null,
+      target: value ?? null,
+      toolInputPreview: null,
+      sessionLabel: sessionLabel ?? null,
+    });
 
     const decision = await deps.requestPermissionDecisionFromUi(
       ctx.ui,

--- a/packages/pi-permission-system/src/permission-events.ts
+++ b/packages/pi-permission-system/src/permission-events.ts
@@ -27,8 +27,8 @@ export const PERMISSIONS_PROTOCOL_VERSION = 1;
 /** Emitted at `session_start`, after the service is published. */
 export const PERMISSIONS_READY_CHANNEL = "permissions:ready";
 
-/** Emitted when the user is being prompted for a permission decision. */
-export const PERMISSIONS_PROMPT_CHANNEL = "permissions:prompt";
+/** Emitted when a permission request is committed to the active UI prompt path. */
+export const PERMISSIONS_UI_PROMPT_CHANNEL = "permissions:ui_prompt";
 
 /** Emitted after every permission gate resolution. */
 export const PERMISSIONS_DECISION_CHANNEL = "permissions:decision";
@@ -69,14 +69,27 @@ export interface PermissionsReadyEvent {
   protocolVersion: number;
 }
 
-// ── permissions:prompt ─────────────────────────────────────────────────────
+// ── permissions:ui_prompt ──────────────────────────────────────────────────
 
-/** Payload emitted on `permissions:prompt`. */
-export interface PermissionPromptEvent {
+/** Payload emitted on `permissions:ui_prompt`. */
+export type PermissionUiPromptSource =
+  | "tool_call"
+  | "skill_input"
+  | "skill_read"
+  | "rpc_prompt"
+  | "forwarded_permission";
+
+export interface PermissionUiPromptEvent {
+  /** Protocol version for the cross-extension event contract. */
+  protocolVersion: number;
   /** Unique ID for the permission request being prompted. */
   requestId: string;
   /** Prompt source: tool call, skill input/read, RPC, forwarded subagent request, etc. */
-  source: string;
+  source: PermissionUiPromptSource;
+  /** Permission surface being evaluated, when known. */
+  surface: string | null;
+  /** Value being evaluated: command, path, skill name, tool target, etc. */
+  value: string | null;
   /** Agent name (when known). */
   agentName: string | null;
   /** Message displayed to the user. */
@@ -204,14 +217,19 @@ export function emitReadyEvent(events: PermissionEventBus): void {
 }
 
 /**
- * Emit a `permissions:prompt` broadcast.
- * Call immediately before showing or forwarding a permission prompt.
+ * Emit a `permissions:ui_prompt` broadcast.
+ * Call immediately before invoking the active user-facing permission UI.
  */
-export function emitPromptEvent(
+export function emitUiPromptEvent(
   events: PermissionEventBus,
-  event: PermissionPromptEvent,
+  event: PermissionUiPromptEvent,
 ): void {
-  events.emit(PERMISSIONS_PROMPT_CHANNEL, event);
+  try {
+    events.emit(PERMISSIONS_UI_PROMPT_CHANNEL, event);
+  } catch {
+    // UI-prompt broadcasts are observational. A consumer failure must not block
+    // the permission dialog itself.
+  }
 }
 
 /**

--- a/packages/pi-permission-system/src/permission-events.ts
+++ b/packages/pi-permission-system/src/permission-events.ts
@@ -27,6 +27,9 @@ export const PERMISSIONS_PROTOCOL_VERSION = 1;
 /** Emitted at `session_start`, after the service is published. */
 export const PERMISSIONS_READY_CHANNEL = "permissions:ready";
 
+/** Emitted when the user is being prompted for a permission decision. */
+export const PERMISSIONS_PROMPT_CHANNEL = "permissions:prompt";
+
 /** Emitted after every permission gate resolution. */
 export const PERMISSIONS_DECISION_CHANNEL = "permissions:decision";
 
@@ -64,6 +67,36 @@ export type PermissionsRpcReply<T = void> =
 /** Payload emitted on `permissions:ready`. */
 export interface PermissionsReadyEvent {
   protocolVersion: number;
+}
+
+// ── permissions:prompt ─────────────────────────────────────────────────────
+
+/** Payload emitted on `permissions:prompt`. */
+export interface PermissionPromptEvent {
+  /** Unique ID for the permission request being prompted. */
+  requestId: string;
+  /** Prompt source: tool call, skill input/read, RPC, forwarded subagent request, etc. */
+  source: string;
+  /** Agent name (when known). */
+  agentName: string | null;
+  /** Message displayed to the user. */
+  message: string;
+  /** Tool call ID (when the prompt is for a tool call). */
+  toolCallId: string | null;
+  /** Tool name (when the prompt is for a tool call). */
+  toolName: string | null;
+  /** Skill name (when the prompt is for a skill request). */
+  skillName: string | null;
+  /** Path being evaluated (when available). */
+  path: string | null;
+  /** Command being evaluated (when available). */
+  command: string | null;
+  /** Target being evaluated (when available). */
+  target: string | null;
+  /** Tool input preview shown in logs/prompts (when available). */
+  toolInputPreview: string | null;
+  /** Override label for the "for this session" dialog option. */
+  sessionLabel: string | null;
 }
 
 // ── permissions:decision ───────────────────────────────────────────────────
@@ -168,6 +201,17 @@ export function emitReadyEvent(events: PermissionEventBus): void {
     protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
   };
   events.emit(PERMISSIONS_READY_CHANNEL, payload);
+}
+
+/**
+ * Emit a `permissions:prompt` broadcast.
+ * Call immediately before showing or forwarding a permission prompt.
+ */
+export function emitPromptEvent(
+  events: PermissionEventBus,
+  event: PermissionPromptEvent,
+): void {
+  events.emit(PERMISSIONS_PROMPT_CHANNEL, event);
 }
 
 /**

--- a/packages/pi-permission-system/src/permission-prompter.ts
+++ b/packages/pi-permission-system/src/permission-prompter.ts
@@ -9,8 +9,11 @@ import type {
   PermissionPromptDecision,
   RequestPermissionOptions,
 } from "./permission-dialog";
-import type { PermissionEventBus } from "./permission-events";
-import { emitPromptEvent } from "./permission-events";
+import {
+  PERMISSIONS_PROTOCOL_VERSION,
+  type PermissionEventBus,
+  type PermissionUiPromptEvent,
+} from "./permission-events";
 import type { SubagentSessionRegistry } from "./subagent-registry";
 import { shouldAutoApprovePermissionState } from "./yolo-mode";
 
@@ -31,6 +34,46 @@ export interface PromptPermissionDetails {
   toolInputPreview?: string;
   /** Override label for the "for this session" dialog option. */
   sessionLabel?: string;
+}
+
+function promptSurface(details: PromptPermissionDetails): string | null {
+  if (details.source === "skill_input" || details.source === "skill_read") {
+    return "skill";
+  }
+  return details.toolName ?? null;
+}
+
+function promptValue(details: PromptPermissionDetails): string | null {
+  return (
+    details.command ??
+    details.path ??
+    details.target ??
+    details.skillName ??
+    details.toolName ??
+    null
+  );
+}
+
+function buildUiPromptEvent(
+  details: PromptPermissionDetails,
+): PermissionUiPromptEvent {
+  return {
+    protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
+    requestId: details.requestId,
+    source: details.source,
+    surface: promptSurface(details),
+    value: promptValue(details),
+    agentName: details.agentName,
+    message: details.message,
+    toolCallId: details.toolCallId ?? null,
+    toolName: details.toolName ?? null,
+    skillName: details.skillName ?? null,
+    path: details.path ?? null,
+    command: details.command ?? null,
+    target: details.target ?? null,
+    toolInputPreview: details.toolInputPreview ?? null,
+    sessionLabel: details.sessionLabel ?? null,
+  };
 }
 
 /** Mockable contract for permission prompting. */
@@ -59,7 +102,7 @@ export interface PermissionPrompterDeps {
   forwardingDir: string;
   /** In-process subagent session registry for detection and forwarding target resolution. */
   registry?: SubagentSessionRegistry;
-  /** Event bus used for permission prompt broadcasts. */
+  /** Event bus used for UI prompt broadcasts. */
   events: PermissionEventBus;
   /** Show the interactive permission dialog in the UI. */
   requestPermissionDecisionFromUi(
@@ -94,26 +137,13 @@ export class PermissionPrompter implements PermissionPrompterApi {
     }
 
     this.writeReviewEntry("permission_request.waiting", details);
-    emitPromptEvent(this.deps.events, {
-      requestId: details.requestId,
-      source: details.source,
-      agentName: details.agentName,
-      message: details.message,
-      toolCallId: details.toolCallId ?? null,
-      toolName: details.toolName ?? null,
-      skillName: details.skillName ?? null,
-      path: details.path ?? null,
-      command: details.command ?? null,
-      target: details.target ?? null,
-      toolInputPreview: details.toolInputPreview ?? null,
-      sessionLabel: details.sessionLabel ?? null,
-    });
 
     const decision = await confirmPermission(
       ctx,
       details.message,
       this.buildForwardingDeps(),
       details.sessionLabel ? { sessionLabel: details.sessionLabel } : undefined,
+      buildUiPromptEvent(details),
     );
 
     this.writeReviewEntry(
@@ -177,6 +207,7 @@ export class PermissionPrompter implements PermissionPrompterApi {
       forwardingDir: deps.forwardingDir,
       subagentSessionsDir: deps.subagentSessionsDir,
       registry: deps.registry,
+      events: deps.events,
       logger,
       // eslint-disable-next-line @typescript-eslint/unbound-method -- logger methods are plain function closures; no this-binding issue
       writeReviewLog: deps.writeReviewLog,

--- a/packages/pi-permission-system/src/permission-prompter.ts
+++ b/packages/pi-permission-system/src/permission-prompter.ts
@@ -9,6 +9,8 @@ import type {
   PermissionPromptDecision,
   RequestPermissionOptions,
 } from "./permission-dialog";
+import type { PermissionEventBus } from "./permission-events";
+import { emitPromptEvent } from "./permission-events";
 import type { SubagentSessionRegistry } from "./subagent-registry";
 import { shouldAutoApprovePermissionState } from "./yolo-mode";
 
@@ -57,6 +59,8 @@ export interface PermissionPrompterDeps {
   forwardingDir: string;
   /** In-process subagent session registry for detection and forwarding target resolution. */
   registry?: SubagentSessionRegistry;
+  /** Event bus used for permission prompt broadcasts. */
+  events: PermissionEventBus;
   /** Show the interactive permission dialog in the UI. */
   requestPermissionDecisionFromUi(
     ui: ExtensionContext["ui"],
@@ -90,6 +94,20 @@ export class PermissionPrompter implements PermissionPrompterApi {
     }
 
     this.writeReviewEntry("permission_request.waiting", details);
+    emitPromptEvent(this.deps.events, {
+      requestId: details.requestId,
+      source: details.source,
+      agentName: details.agentName,
+      message: details.message,
+      toolCallId: details.toolCallId ?? null,
+      toolName: details.toolName ?? null,
+      skillName: details.skillName ?? null,
+      path: details.path ?? null,
+      command: details.command ?? null,
+      target: details.target ?? null,
+      toolInputPreview: details.toolInputPreview ?? null,
+      sessionLabel: details.sessionLabel ?? null,
+    });
 
     const decision = await confirmPermission(
       ctx,

--- a/packages/pi-permission-system/src/service.ts
+++ b/packages/pi-permission-system/src/service.ts
@@ -15,6 +15,25 @@ import type { ToolInputFormatter } from "./tool-input-formatter-registry";
 import type { PermissionCheckResult, PermissionState } from "./types";
 
 export type { PermissionCheckResult, PermissionState, ToolInputFormatter };
+export {
+  PERMISSIONS_DECISION_CHANNEL,
+  PERMISSIONS_PROTOCOL_VERSION,
+  PERMISSIONS_READY_CHANNEL,
+  PERMISSIONS_RPC_CHECK_CHANNEL,
+  PERMISSIONS_RPC_PROMPT_CHANNEL,
+  PERMISSIONS_UI_PROMPT_CHANNEL,
+} from "./permission-events";
+export type {
+  PermissionDecisionEvent,
+  PermissionsCheckReplyData,
+  PermissionsCheckRequest,
+  PermissionsPromptReplyData,
+  PermissionsPromptRequest,
+  PermissionsReadyEvent,
+  PermissionsRpcReply,
+  PermissionUiPromptEvent,
+  PermissionUiPromptSource,
+} from "./permission-events";
 
 /** Process-global key for the service slot. */
 const SERVICE_KEY = Symbol.for("@gotgenes/pi-permission-system:service");

--- a/packages/pi-permission-system/test/permission-event-rpc.test.ts
+++ b/packages/pi-permission-system/test/permission-event-rpc.test.ts
@@ -11,9 +11,9 @@ import type {
 } from "#src/permission-events";
 import {
   PERMISSIONS_PROTOCOL_VERSION,
-  PERMISSIONS_PROMPT_CHANNEL,
   PERMISSIONS_RPC_CHECK_CHANNEL,
   PERMISSIONS_RPC_PROMPT_CHANNEL,
+  PERMISSIONS_UI_PROMPT_CHANNEL,
 } from "#src/permission-events";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -318,7 +318,7 @@ describe("registerPermissionRpcHandlers — permissions:rpc:prompt", () => {
     }
   });
 
-  it("emits a prompt broadcast before awaiting the UI decision", async () => {
+  it("emits a UI prompt broadcast before awaiting the UI decision", async () => {
     const bus = createEventBus();
     const ctx = makeCtxWithUi();
     const requestUi = vi
@@ -330,7 +330,7 @@ describe("registerPermissionRpcHandlers — permissions:rpc:prompt", () => {
     });
     registerPermissionRpcHandlers(bus, deps);
 
-    const promptPromise = waitForReply(bus, PERMISSIONS_PROMPT_CHANNEL);
+    const promptPromise = waitForReply(bus, PERMISSIONS_UI_PROMPT_CHANNEL);
     const replyPromise = waitForReply(
       bus,
       `${PERMISSIONS_RPC_PROMPT_CHANNEL}:reply:req-prompt-broadcast`,
@@ -345,8 +345,11 @@ describe("registerPermissionRpcHandlers — permissions:rpc:prompt", () => {
     });
 
     await expect(promptPromise).resolves.toEqual({
+      protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
       requestId: "req-prompt-broadcast",
       source: "rpc_prompt",
+      surface: "bash",
+      value: "git push",
       agentName: "Worker",
       message: "Allow git push?",
       toolCallId: null,

--- a/packages/pi-permission-system/test/permission-event-rpc.test.ts
+++ b/packages/pi-permission-system/test/permission-event-rpc.test.ts
@@ -11,6 +11,7 @@ import type {
 } from "#src/permission-events";
 import {
   PERMISSIONS_PROTOCOL_VERSION,
+  PERMISSIONS_PROMPT_CHANNEL,
   PERMISSIONS_RPC_CHECK_CHANNEL,
   PERMISSIONS_RPC_PROMPT_CHANNEL,
 } from "#src/permission-events";
@@ -315,6 +316,49 @@ describe("registerPermissionRpcHandlers — permissions:rpc:prompt", () => {
       expect(reply.data?.approved).toBe(true);
       expect(reply.data?.state).toBe("approved");
     }
+  });
+
+  it("emits a prompt broadcast before awaiting the UI decision", async () => {
+    const bus = createEventBus();
+    const ctx = makeCtxWithUi();
+    const requestUi = vi
+      .fn()
+      .mockResolvedValue({ approved: true, state: "approved" as const });
+    const deps = makeDeps({
+      getRuntimeContext: vi.fn().mockReturnValue(ctx),
+      requestPermissionDecisionFromUi: requestUi,
+    });
+    registerPermissionRpcHandlers(bus, deps);
+
+    const promptPromise = waitForReply(bus, PERMISSIONS_PROMPT_CHANNEL);
+    const replyPromise = waitForReply(
+      bus,
+      `${PERMISSIONS_RPC_PROMPT_CHANNEL}:reply:req-prompt-broadcast`,
+    );
+    bus.emit(PERMISSIONS_RPC_PROMPT_CHANNEL, {
+      requestId: "req-prompt-broadcast",
+      surface: "bash",
+      value: "git push",
+      message: "Allow git push?",
+      agentName: "Worker",
+      sessionLabel: "Allow git *",
+    });
+
+    await expect(promptPromise).resolves.toEqual({
+      requestId: "req-prompt-broadcast",
+      source: "rpc_prompt",
+      agentName: "Worker",
+      message: "Allow git push?",
+      toolCallId: null,
+      toolName: null,
+      skillName: null,
+      path: null,
+      command: null,
+      target: "git push",
+      toolInputPreview: null,
+      sessionLabel: "Allow git *",
+    });
+    await replyPromise;
   });
 
   it("passes the message to requestPermissionDecisionFromUi", async () => {

--- a/packages/pi-permission-system/test/permission-events.test.ts
+++ b/packages/pi-permission-system/test/permission-events.test.ts
@@ -8,7 +8,7 @@ import { getGlobalConfigPath } from "#src/config-paths";
 import piPermissionSystemExtension from "#src/index";
 import type {
   PermissionDecisionEvent,
-  PermissionPromptEvent,
+  PermissionUiPromptEvent,
   PermissionsCheckReplyData,
   PermissionsCheckRequest,
   PermissionsPromptReplyData,
@@ -18,14 +18,14 @@ import type {
 } from "#src/permission-events";
 import {
   emitDecisionEvent,
-  emitPromptEvent,
   emitReadyEvent,
+  emitUiPromptEvent,
   PERMISSIONS_DECISION_CHANNEL,
-  PERMISSIONS_PROMPT_CHANNEL,
   PERMISSIONS_PROTOCOL_VERSION,
   PERMISSIONS_READY_CHANNEL,
   PERMISSIONS_RPC_CHECK_CHANNEL,
   PERMISSIONS_RPC_PROMPT_CHANNEL,
+  PERMISSIONS_UI_PROMPT_CHANNEL,
 } from "#src/permission-events";
 
 // ── Minimal EventBus stub ──────────────────────────────────────────────────
@@ -46,7 +46,7 @@ describe("constants", () => {
 
   it("channel names have the correct values", () => {
     expect(PERMISSIONS_READY_CHANNEL).toBe("permissions:ready");
-    expect(PERMISSIONS_PROMPT_CHANNEL).toBe("permissions:prompt");
+    expect(PERMISSIONS_UI_PROMPT_CHANNEL).toBe("permissions:ui_prompt");
     expect(PERMISSIONS_DECISION_CHANNEL).toBe("permissions:decision");
     expect(PERMISSIONS_RPC_CHECK_CHANNEL).toBe("permissions:rpc:check");
     expect(PERMISSIONS_RPC_PROMPT_CHANNEL).toBe("permissions:rpc:prompt");
@@ -73,15 +73,18 @@ describe("emitReadyEvent", () => {
   });
 });
 
-// ── emitPromptEvent ────────────────────────────────────────────────────────
+// ── emitUiPromptEvent ──────────────────────────────────────────────────────
 
-describe("emitPromptEvent", () => {
-  function makePromptEvent(
-    overrides: Partial<PermissionPromptEvent> = {},
-  ): PermissionPromptEvent {
+describe("emitUiPromptEvent", () => {
+  function makeUiPromptEvent(
+    overrides: Partial<PermissionUiPromptEvent> = {},
+  ): PermissionUiPromptEvent {
     return {
+      protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
       requestId: "req-123",
       source: "tool_call",
+      surface: "bash",
+      value: "git status",
       agentName: "Explore",
       message: "Allow git status?",
       toolCallId: "call-123",
@@ -96,18 +99,36 @@ describe("emitPromptEvent", () => {
     };
   }
 
-  it("emits on the permissions:prompt channel", () => {
+  it("emits on the permissions:ui_prompt channel", () => {
     const bus = makeEventBus();
-    emitPromptEvent(bus, makePromptEvent());
+    emitUiPromptEvent(bus, makeUiPromptEvent());
     expect(bus.emit).toHaveBeenCalledOnce();
-    expect(bus.emit.mock.calls[0][0]).toBe("permissions:prompt");
+    expect(bus.emit.mock.calls[0][0]).toBe("permissions:ui_prompt");
   });
 
   it("forwards the full payload unchanged", () => {
     const bus = makeEventBus();
-    const event = makePromptEvent({ sessionLabel: "Allow for session" });
-    emitPromptEvent(bus, event);
+    const event = makeUiPromptEvent({ sessionLabel: "Allow for session" });
+    emitUiPromptEvent(bus, event);
     expect(bus.emit.mock.calls[0][1]).toEqual(event);
+  });
+
+  it("includes the protocol version in UI prompt events", () => {
+    const bus = makeEventBus();
+    emitUiPromptEvent(bus, makeUiPromptEvent());
+    const payload = bus.emit.mock.calls[0][1] as PermissionUiPromptEvent;
+    expect(payload.protocolVersion).toBe(PERMISSIONS_PROTOCOL_VERSION);
+  });
+
+  it("swallows event bus errors because UI prompt broadcasts are observational", () => {
+    const bus = {
+      emit: vi.fn(() => {
+        throw new Error("listener failed");
+      }),
+      on: vi.fn().mockReturnValue(() => undefined),
+    };
+
+    expect(() => emitUiPromptEvent(bus, makeUiPromptEvent())).not.toThrow();
   });
 });
 

--- a/packages/pi-permission-system/test/permission-events.test.ts
+++ b/packages/pi-permission-system/test/permission-events.test.ts
@@ -8,6 +8,7 @@ import { getGlobalConfigPath } from "#src/config-paths";
 import piPermissionSystemExtension from "#src/index";
 import type {
   PermissionDecisionEvent,
+  PermissionPromptEvent,
   PermissionsCheckReplyData,
   PermissionsCheckRequest,
   PermissionsPromptReplyData,
@@ -17,8 +18,10 @@ import type {
 } from "#src/permission-events";
 import {
   emitDecisionEvent,
+  emitPromptEvent,
   emitReadyEvent,
   PERMISSIONS_DECISION_CHANNEL,
+  PERMISSIONS_PROMPT_CHANNEL,
   PERMISSIONS_PROTOCOL_VERSION,
   PERMISSIONS_READY_CHANNEL,
   PERMISSIONS_RPC_CHECK_CHANNEL,
@@ -43,6 +46,7 @@ describe("constants", () => {
 
   it("channel names have the correct values", () => {
     expect(PERMISSIONS_READY_CHANNEL).toBe("permissions:ready");
+    expect(PERMISSIONS_PROMPT_CHANNEL).toBe("permissions:prompt");
     expect(PERMISSIONS_DECISION_CHANNEL).toBe("permissions:decision");
     expect(PERMISSIONS_RPC_CHECK_CHANNEL).toBe("permissions:rpc:check");
     expect(PERMISSIONS_RPC_PROMPT_CHANNEL).toBe("permissions:rpc:prompt");
@@ -66,6 +70,44 @@ describe("emitReadyEvent", () => {
     emitReadyEvent(bus);
     const payload = bus.emit.mock.calls[0][1] as PermissionsReadyEvent;
     expect(typeof payload.protocolVersion).toBe("number");
+  });
+});
+
+// ── emitPromptEvent ────────────────────────────────────────────────────────
+
+describe("emitPromptEvent", () => {
+  function makePromptEvent(
+    overrides: Partial<PermissionPromptEvent> = {},
+  ): PermissionPromptEvent {
+    return {
+      requestId: "req-123",
+      source: "tool_call",
+      agentName: "Explore",
+      message: "Allow git status?",
+      toolCallId: "call-123",
+      toolName: "bash",
+      skillName: null,
+      path: null,
+      command: "git status",
+      target: null,
+      toolInputPreview: null,
+      sessionLabel: null,
+      ...overrides,
+    };
+  }
+
+  it("emits on the permissions:prompt channel", () => {
+    const bus = makeEventBus();
+    emitPromptEvent(bus, makePromptEvent());
+    expect(bus.emit).toHaveBeenCalledOnce();
+    expect(bus.emit.mock.calls[0][0]).toBe("permissions:prompt");
+  });
+
+  it("forwards the full payload unchanged", () => {
+    const bus = makeEventBus();
+    const event = makePromptEvent({ sessionLabel: "Allow for session" });
+    emitPromptEvent(bus, event);
+    expect(bus.emit.mock.calls[0][1]).toEqual(event);
   });
 });
 

--- a/packages/pi-permission-system/test/permission-forwarding.test.ts
+++ b/packages/pi-permission-system/test/permission-forwarding.test.ts
@@ -1,9 +1,19 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
+  confirmPermission,
+  processForwardedPermissionRequests,
+} from "#src/forwarded-permissions/polling";
+import {
+  createPermissionForwardingLocation,
   resolvePermissionForwardingTargetSessionId,
   SUBAGENT_PARENT_SESSION_ENV_CANDIDATES,
   SUBAGENT_PARENT_SESSION_ENV_KEY,
 } from "#src/permission-forwarding";
+import type { PermissionUiPromptEvent } from "#src/permission-events";
 import { SubagentSessionRegistry } from "#src/subagent-registry";
 
 afterEach(() => {
@@ -238,5 +248,223 @@ describe("resolvePermissionForwardingTargetSessionId — registry resolution", (
         env: { PI_AGENT_ROUTER_PARENT_SESSION_ID: "parent-from-env" },
       }),
     ).toBe("parent-from-env");
+  });
+});
+
+describe("processForwardedPermissionRequests", () => {
+  test("emits a UI prompt event before showing a forwarded permission dialog", async () => {
+    const root = mkdtempSync(join(tmpdir(), "permission-forwarding-"));
+    try {
+      const forwardingDir = join(root, "forwarding");
+      const location = createPermissionForwardingLocation(
+        forwardingDir,
+        "parent-session",
+      );
+      mkdirSync(location.requestsDir, { recursive: true });
+      mkdirSync(location.responsesDir, { recursive: true });
+      writeFileSync(
+        join(location.requestsDir, "req-forwarded.json"),
+        JSON.stringify({
+          id: "req-forwarded",
+          createdAt: Date.now(),
+          requesterSessionId: "child-session",
+          targetSessionId: "parent-session",
+          requesterAgentName: "Explore",
+          message: "Allow git push?",
+        }),
+        "utf-8",
+      );
+
+      const events = {
+        emit: vi.fn(),
+        on: vi.fn().mockReturnValue(() => undefined),
+      };
+      const requestPermissionDecisionFromUi = vi
+        .fn()
+        .mockResolvedValue({ approved: true, state: "approved" as const });
+
+      await processForwardedPermissionRequests(
+        {
+          hasUI: true,
+          ui: { select: vi.fn(), input: vi.fn() },
+          sessionManager: {
+            getSessionId: vi.fn().mockReturnValue("parent-session"),
+          },
+        } as unknown as ExtensionContext,
+        {
+          forwardingDir,
+          subagentSessionsDir: join(root, "subagents"),
+          events,
+          logger: { writeReviewLog: vi.fn(), writeDebugLog: vi.fn() },
+          writeReviewLog: vi.fn(),
+          requestPermissionDecisionFromUi,
+          shouldAutoApprove: () => false,
+        },
+      );
+
+      expect(events.emit).toHaveBeenCalledWith(
+        "permissions:ui_prompt",
+        expect.objectContaining({
+          protocolVersion: 1,
+          requestId: "req-forwarded",
+          source: "forwarded_permission",
+          surface: null,
+          value: "Allow git push?",
+          agentName: "Explore",
+          target: "Allow git push?",
+        }),
+      );
+      expect(requestPermissionDecisionFromUi).toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("does not emit a UI prompt event when forwarded permission auto-approves", async () => {
+    const root = mkdtempSync(join(tmpdir(), "permission-forwarding-"));
+    try {
+      const forwardingDir = join(root, "forwarding");
+      const location = createPermissionForwardingLocation(
+        forwardingDir,
+        "parent-session",
+      );
+      mkdirSync(location.requestsDir, { recursive: true });
+      mkdirSync(location.responsesDir, { recursive: true });
+      writeFileSync(
+        join(location.requestsDir, "req-forwarded-auto.json"),
+        JSON.stringify({
+          id: "req-forwarded-auto",
+          createdAt: Date.now(),
+          requesterSessionId: "child-session",
+          targetSessionId: "parent-session",
+          requesterAgentName: "Explore",
+          message: "Allow git push?",
+        }),
+        "utf-8",
+      );
+
+      const events = {
+        emit: vi.fn(),
+        on: vi.fn().mockReturnValue(() => undefined),
+      };
+      const requestPermissionDecisionFromUi = vi.fn();
+
+      await processForwardedPermissionRequests(
+        {
+          hasUI: true,
+          ui: { select: vi.fn(), input: vi.fn() },
+          sessionManager: {
+            getSessionId: vi.fn().mockReturnValue("parent-session"),
+          },
+        } as unknown as ExtensionContext,
+        {
+          forwardingDir,
+          subagentSessionsDir: join(root, "subagents"),
+          events,
+          logger: { writeReviewLog: vi.fn(), writeDebugLog: vi.fn() },
+          writeReviewLog: vi.fn(),
+          requestPermissionDecisionFromUi,
+          shouldAutoApprove: () => true,
+        },
+      );
+
+      expect(events.emit).not.toHaveBeenCalledWith(
+        "permissions:ui_prompt",
+        expect.anything(),
+      );
+      expect(requestPermissionDecisionFromUi).not.toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("confirmPermission", () => {
+  const uiPromptEvent: PermissionUiPromptEvent = {
+    protocolVersion: 1,
+    requestId: "req-ui",
+    source: "tool_call",
+    surface: "bash",
+    value: "git push",
+    agentName: null,
+    message: "Allow git push?",
+    toolCallId: "call-ui",
+    toolName: "bash",
+    skillName: null,
+    path: null,
+    command: "git push",
+    target: null,
+    toolInputPreview: null,
+    sessionLabel: null,
+  };
+
+  test("emits a UI prompt event only when the active UI prompt path is used", async () => {
+    const events = {
+      emit: vi.fn(),
+      on: vi.fn().mockReturnValue(() => undefined),
+    };
+    const requestPermissionDecisionFromUi = vi
+      .fn()
+      .mockResolvedValue({ approved: true, state: "approved" as const });
+
+    await confirmPermission(
+      {
+        hasUI: true,
+        ui: { select: vi.fn(), input: vi.fn() },
+      } as unknown as ExtensionContext,
+      "Allow git push?",
+      {
+        forwardingDir: "/tmp/forwarding",
+        subagentSessionsDir: "/tmp/subagents",
+        events,
+        logger: { writeReviewLog: vi.fn(), writeDebugLog: vi.fn() },
+        writeReviewLog: vi.fn(),
+        requestPermissionDecisionFromUi,
+        shouldAutoApprove: () => false,
+      },
+      undefined,
+      uiPromptEvent,
+    );
+
+    expect(events.emit).toHaveBeenCalledWith(
+      "permissions:ui_prompt",
+      uiPromptEvent,
+    );
+    expect(requestPermissionDecisionFromUi).toHaveBeenCalled();
+  });
+
+  test("does not emit a UI prompt event when no active UI prompt exists", async () => {
+    const events = {
+      emit: vi.fn(),
+      on: vi.fn().mockReturnValue(() => undefined),
+    };
+    const requestPermissionDecisionFromUi = vi.fn();
+
+    await confirmPermission(
+      {
+        hasUI: false,
+        sessionManager: {
+          getSessionDir: vi.fn().mockReturnValue(null),
+        },
+      } as unknown as ExtensionContext,
+      "Allow git push?",
+      {
+        forwardingDir: "/tmp/forwarding",
+        subagentSessionsDir: "/tmp/subagents",
+        events,
+        logger: { writeReviewLog: vi.fn(), writeDebugLog: vi.fn() },
+        writeReviewLog: vi.fn(),
+        requestPermissionDecisionFromUi,
+        shouldAutoApprove: () => false,
+      },
+      undefined,
+      uiPromptEvent,
+    );
+
+    expect(events.emit).not.toHaveBeenCalledWith(
+      "permissions:ui_prompt",
+      expect.anything(),
+    );
+    expect(requestPermissionDecisionFromUi).not.toHaveBeenCalled();
   });
 });

--- a/packages/pi-permission-system/test/permission-prompter.test.ts
+++ b/packages/pi-permission-system/test/permission-prompter.test.ts
@@ -72,8 +72,13 @@ describe("PermissionPrompter", () => {
 
   describe("yolo-mode auto-approve", () => {
     it("returns approved without calling confirmPermission when yoloMode is true", async () => {
+      const events = {
+        emit: vi.fn(),
+        on: vi.fn().mockReturnValue(() => undefined),
+      };
       const deps = makeDeps({
         getConfig: () => ({ ...DEFAULT_EXTENSION_CONFIG, yoloMode: true }),
+        events,
       });
       const prompter = new PermissionPrompter(deps);
 
@@ -85,6 +90,10 @@ describe("PermissionPrompter", () => {
         autoApproved: true,
       });
       expect(mockConfirmPermission).not.toHaveBeenCalled();
+      expect(events.emit).not.toHaveBeenCalledWith(
+        "permissions:ui_prompt",
+        expect.anything(),
+      );
     });
 
     it("logs permission_request.auto_approved in yolo mode", async () => {
@@ -152,6 +161,75 @@ describe("PermissionPrompter", () => {
       ).toBeGreaterThanOrEqual(0);
       expect(calls.indexOf("permission_request.waiting")).toBeLessThan(
         calls.indexOf("permission_request.approved"),
+      );
+    });
+
+    it("passes a UI prompt event with normalized surface and value to confirmPermission", async () => {
+      const events = {
+        emit: vi.fn(),
+        on: vi.fn().mockReturnValue(() => undefined),
+      };
+      mockConfirmPermission.mockResolvedValue({
+        approved: true,
+        state: "approved",
+      });
+      const deps = makeDeps({ events });
+      const prompter = new PermissionPrompter(deps);
+
+      await prompter.prompt(
+        makeCtx(true),
+        makeDetails({
+          toolName: "bash",
+          command: "git push",
+          toolInputPreview: "git push",
+        }),
+      );
+
+      expect(events.emit).not.toHaveBeenCalled();
+      expect(mockConfirmPermission.mock.calls[0][4]).toEqual(
+        expect.objectContaining({
+          protocolVersion: 1,
+          requestId: "req-123",
+          source: "tool_call",
+          surface: "bash",
+          value: "git push",
+          toolName: "bash",
+          command: "git push",
+          toolInputPreview: "git push",
+        }),
+      );
+    });
+
+    it("normalizes skill UI prompt events to the skill surface", async () => {
+      const events = {
+        emit: vi.fn(),
+        on: vi.fn().mockReturnValue(() => undefined),
+      };
+      mockConfirmPermission.mockResolvedValue({
+        approved: true,
+        state: "approved",
+      });
+      const deps = makeDeps({ events });
+      const prompter = new PermissionPrompter(deps);
+
+      await prompter.prompt(
+        makeCtx(true),
+        makeDetails({
+          source: "skill_input",
+          toolName: undefined,
+          skillName: "deploy-helper",
+        }),
+      );
+
+      expect(events.emit).not.toHaveBeenCalled();
+      expect(mockConfirmPermission.mock.calls[0][4]).toEqual(
+        expect.objectContaining({
+          protocolVersion: 1,
+          source: "skill_input",
+          surface: "skill",
+          value: "deploy-helper",
+          skillName: "deploy-helper",
+        }),
       );
     });
 
@@ -246,6 +324,7 @@ describe("PermissionPrompter", () => {
         expect.any(String),
         expect.anything(),
         { sessionLabel: "Yes, for 'read' tool" },
+        expect.objectContaining({ sessionLabel: "Yes, for 'read' tool" }),
       );
     });
 
@@ -264,6 +343,7 @@ describe("PermissionPrompter", () => {
         expect.any(String),
         expect.anything(),
         undefined,
+        expect.objectContaining({ sessionLabel: null }),
       );
     });
 
@@ -283,6 +363,7 @@ describe("PermissionPrompter", () => {
         "Allow bash: git status?",
         expect.anything(),
         undefined,
+        expect.objectContaining({ message: "Allow bash: git status?" }),
       );
     });
   });

--- a/packages/pi-permission-system/test/permission-prompter.test.ts
+++ b/packages/pi-permission-system/test/permission-prompter.test.ts
@@ -53,6 +53,7 @@ function makeDeps(
     writeReviewLog: vi.fn(),
     subagentSessionsDir: "/sessions/subagents",
     forwardingDir: "/sessions/permission-forwarding",
+    events: { emit: vi.fn(), on: vi.fn().mockReturnValue(() => undefined) },
     requestPermissionDecisionFromUi: vi
       .fn()
       .mockResolvedValue({ approved: true, state: "approved" }),


### PR DESCRIPTION
## Summary

This builds on the direction from #253 by formalizing a stricter permission UI prompt broadcast contract: `permissions:ui_prompt`.

## Motivation

I am building a notification extension that listens for permission lifecycle events. For permission prompts, `pi-permission-system` should remain the source of truth: notification extensions should not need to patch internals or predict when a prompt will appear from `tool_call` events or permission config.

The important boundary for notification extensions is not "a permission request entered a waiting state". It is "the permission system is about to invoke the active user-facing permission UI, so the user needs to return and respond".

This PR adds a stable event for that narrower boundary so external extensions can notify on the same active permission prompts that `pi-permission-system` actually shows, without duplicating permission logic.

## Relationship to #253

This PR builds directly on #253. The first commit carries the same core idea from that PR: broadcasting before a permission prompt.

The additional commit tightens that contract for notification use cases:

- the public event is now `permissions:ui_prompt`, not a generic request/waiting event
- direct prompts emit only from the active UI prompt path, immediately before `requestPermissionDecisionFromUi`
- non-UI child sessions do not emit when they create forwarded permission requests
- the parent UI session emits before showing the forwarded permission dialog
- the payload is versioned and includes `source`, `surface`, `value`, and related prompt context

If #253 lands first, I am happy to rebase this branch on top of it and keep only the stricter UI-prompt contract and hardening changes. If this lands first, it should cover the same use case as #253 plus the extra contract, forwarded-prompt coverage, and tests.

## Changes

- broadcast `permissions:ui_prompt` before active user-facing permission UI prompts
- keep the event out of auto-resolved paths such as `policy_allow`, `policy_deny`, `session_approved`, `infrastructure_auto_allowed`, and `auto_approved`
- pass direct prompter prompt metadata down into `confirmPermission`, then emit only from the `ctx.hasUI` path
- cover RPC prompts and file-based forwarded permission prompts
- make UI prompt broadcasts best-effort so listener failures cannot block permission handling
- export the UI prompt event contract from the package root
- document the event boundary in the README and cross-extension API reference
- add regression coverage for UI prompt broadcasts, auto-approved paths, and non-UI paths that must not emit

## Third-party listener guidance

Notification extensions should listen to `permissions:ui_prompt` when they need to alert the user:

```ts
eventBus?.on?.("permissions:ui_prompt", handler);
```

`permissions:decision` remains useful for debug logs, status tracking, and audit trails, but it should not be treated as a "notify the user now" event.

## Testing

- `env CI=true pnpm --filter @gotgenes/pi-permission-system test -- test/permission-prompter.test.ts test/permission-forwarding.test.ts test/permission-event-rpc.test.ts test/permission-events.test.ts`
  - 73 files / 1667 tests passed
- `env CI=true pnpm --filter @gotgenes/pi-permission-system check`
  - `tsc --noEmit` passed
- `git diff --check origin/main..HEAD`
  - passed
