### PR TITLE
feat(pi-permission-system)!: harden permissions:ui_prompt broadcast contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Fallow audit
         if: github.event_name == 'pull_request'
-        run: pnpm fallow audit
+        run: pnpm fallow audit --base origin/${{ github.base_ref }}
 
       - name: Fallow dead-code gate
         if: github.ref == 'refs/heads/main'

--- a/packages/pi-permission-system/CHANGELOG.md
+++ b/packages/pi-permission-system/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Features
+
+* broadcast `permissions:ui_prompt` before active user-facing permission UI prompts
+
+### Documentation
+
+* document UI prompt broadcasts in the README and cross-extension API reference
+
 ## [9.2.0](https://github.com/gotgenes/pi-packages/compare/pi-permission-system-v9.1.0...pi-permission-system-v9.2.0) (2026-06-02)
 
 

--- a/packages/pi-permission-system/CHANGELOG.md
+++ b/packages/pi-permission-system/CHANGELOG.md
@@ -5,16 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
-### Features
-
-* broadcast `permissions:ui_prompt` before active user-facing permission UI prompts
-
-### Documentation
-
-* document UI prompt broadcasts in the README and cross-extension API reference
-
 ## [9.2.0](https://github.com/gotgenes/pi-packages/compare/pi-permission-system-v9.1.0...pi-permission-system-v9.2.0) (2026-06-02)
 
 

--- a/packages/pi-permission-system/README.md
+++ b/packages/pi-permission-system/README.md
@@ -20,6 +20,7 @@ Permission enforcement extension for the [Pi](https://pi.mariozechner.at/) codin
 - **Protects sensitive file patterns** — cross-cutting `path` rules deny `.env`, `~/.ssh/*`, etc. across all tools and bash at once
 - **Guards external paths** — prompts before file tools or bash commands reach outside `cwd`
 - **Forwards prompts from subagents** — `ask` policies work even in non-UI execution contexts
+- **Broadcasts UI prompt events** — `permissions:ui_prompt` fires only when the permission system is about to invoke the active user-facing permission UI
 - **Native [`@gotgenes/pi-subagents`](https://github.com/gotgenes/pi-subagents) integration** — in-process child sessions register with the permission system automatically, enabling per-agent policy enforcement and `ask`-state forwarding to the parent UI without configuration
 
 ## Install
@@ -93,7 +94,7 @@ For the full reference — all surfaces, runtime knobs, per-agent overrides, mer
 | ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
 | [docs/configuration.md](docs/configuration.md)                                                                                 | Full policy reference, runtime knobs, per-agent overrides, recipes           |
 | [docs/session-approvals.md](docs/session-approvals.md)                                                                         | Session-scoped rules, pattern suggestions, bash arity table                  |
-| [docs/cross-extension-api.md](docs/cross-extension-api.md)                                                                     | Cross-extension service accessor, event bus integration, decision broadcasts |
+| [docs/cross-extension-api.md](docs/cross-extension-api.md)                                                                     | Cross-extension service accessor, event bus integration, prompt and decision broadcasts |
 | [docs/subagent-integration.md](docs/subagent-integration.md)                                                                   | Permission forwarding, coexistence with subagent extensions                  |
 | [docs/guides/permission-frontmatter-for-subagent-extensions.md](docs/guides/permission-frontmatter-for-subagent-extensions.md) | Convention guide for subagent extension authors                              |
 | [docs/opencode-compatibility.md](docs/opencode-compatibility.md)                                                               | OpenCode compatibility — shared concepts, divergences, porting guide         |

--- a/packages/pi-permission-system/README.md
+++ b/packages/pi-permission-system/README.md
@@ -90,16 +90,16 @@ For the full reference — all surfaces, runtime knobs, per-agent overrides, mer
 
 ## Documentation
 
-| Document                                                                                                                       | Contents                                                                     |
-| ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
-| [docs/configuration.md](docs/configuration.md)                                                                                 | Full policy reference, runtime knobs, per-agent overrides, recipes           |
-| [docs/session-approvals.md](docs/session-approvals.md)                                                                         | Session-scoped rules, pattern suggestions, bash arity table                  |
+| Document                                                                                                                       | Contents                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| [docs/configuration.md](docs/configuration.md)                                                                                 | Full policy reference, runtime knobs, per-agent overrides, recipes                      |
+| [docs/session-approvals.md](docs/session-approvals.md)                                                                         | Session-scoped rules, pattern suggestions, bash arity table                             |
 | [docs/cross-extension-api.md](docs/cross-extension-api.md)                                                                     | Cross-extension service accessor, event bus integration, prompt and decision broadcasts |
-| [docs/subagent-integration.md](docs/subagent-integration.md)                                                                   | Permission forwarding, coexistence with subagent extensions                  |
-| [docs/guides/permission-frontmatter-for-subagent-extensions.md](docs/guides/permission-frontmatter-for-subagent-extensions.md) | Convention guide for subagent extension authors                              |
-| [docs/opencode-compatibility.md](docs/opencode-compatibility.md)                                                               | OpenCode compatibility — shared concepts, divergences, porting guide         |
-| [docs/troubleshooting.md](docs/troubleshooting.md)                                                                             | Common issues, diagnostic logging, threat model                              |
-| [docs/migration/legacy-to-flat.md](docs/migration/legacy-to-flat.md)                                                           | Migration from pre-v2 config layout                                          |
+| [docs/subagent-integration.md](docs/subagent-integration.md)                                                                   | Permission forwarding, coexistence with subagent extensions                             |
+| [docs/guides/permission-frontmatter-for-subagent-extensions.md](docs/guides/permission-frontmatter-for-subagent-extensions.md) | Convention guide for subagent extension authors                                         |
+| [docs/opencode-compatibility.md](docs/opencode-compatibility.md)                                                               | OpenCode compatibility — shared concepts, divergences, porting guide                    |
+| [docs/troubleshooting.md](docs/troubleshooting.md)                                                                             | Common issues, diagnostic logging, threat model                                         |
+| [docs/migration/legacy-to-flat.md](docs/migration/legacy-to-flat.md)                                                           | Migration from pre-v2 config layout                                                     |
 
 ## Development
 

--- a/packages/pi-permission-system/docs/architecture/permission-prompter.md
+++ b/packages/pi-permission-system/docs/architecture/permission-prompter.md
@@ -8,11 +8,15 @@
 
 1. **Yolo-mode check** — if `yoloMode` is enabled in the active config, auto-approve and write a `permission_request.auto_approved` review-log entry without showing any UI.
 2. **Review log — waiting** — write `permission_request.waiting` before any dialog is shown.
-3. **UI/forwarding branch** — delegate to `confirmPermission()` in `forwarded-permissions/polling.ts`, which selects the correct path:
+3. **UI prompt broadcast** — build the `PermissionUiPromptEvent` once via `buildDirectUiPrompt(details)`.
+   When `ctx.hasUI`, emit it on `permissions:ui_prompt` so observers (e.g. notification extensions) know the user must respond.
+   A non-UI session does not emit here — the parent emits from the forwarded path instead.
+4. **UI/forwarding branch** — delegate to `confirmPermission()` in `forwarded-permissions/polling.ts`, which selects the correct path:
    - `ctx.hasUI` → show the interactive dialog via `requestPermissionDecisionFromUi`.
-   - subagent context → write a forwarded-permission request file and poll for the parent session's response.
+   - subagent context → write a forwarded-permission request file (carrying the relayed display fields) and poll for the parent session's response.
    - neither → deny immediately.
-4. **Review log — outcome** — write `permission_request.approved` or `permission_request.denied` with the final decision state and any denial reason.
+   The prompter relays the built event's `source`/`surface`/`value` to `confirmPermission` so a forwarded request persists them and the parent emits a non-degraded event.
+5. **Review log — outcome** — write `permission_request.approved` or `permission_request.denied` with the final decision state and any denial reason.
 
 ## Why a class instead of a free function
 
@@ -38,6 +42,8 @@ interface PermissionPrompterDeps {
   writeReviewLog(event: string, details: Record<string, unknown>): void;
   subagentSessionsDir: string;                   // forwarding path detection
   forwardingDir: string;                         // forwarded-request files
+  events: PermissionEventBus;                     // permissions:ui_prompt broadcast
+  registry?: SubagentSessionRegistry;             // subagent detection + target resolution
   requestPermissionDecisionFromUi(...): Promise<PermissionPromptDecision>;
 }
 ```

--- a/packages/pi-permission-system/docs/cross-extension-api.md
+++ b/packages/pi-permission-system/docs/cross-extension-api.md
@@ -249,11 +249,50 @@ The protocol version constant is exported from `src/permission-events.ts` and em
 | Channel                                    | Direction | When                              | Payload type                                      |
 | ------------------------------------------ | --------- | --------------------------------- | ------------------------------------------------- |
 | `permissions:ready`                        | Broadcast | At `session_start`, after publish | `PermissionsReadyEvent`                           |
+| `permissions:ui_prompt`                    | Broadcast | Before active UI prompt           | `PermissionUiPromptEvent`                         |
 | `permissions:decision`                     | Broadcast | After every gate resolution       | `PermissionDecisionEvent`                         |
 | `permissions:rpc:check`                    | Request   | On-demand                         | `PermissionsCheckRequest`                         |
 | `permissions:rpc:check:reply:<requestId>`  | Reply     | After each check request          | `PermissionsRpcReply<PermissionsCheckReplyData>`  |
 | `permissions:rpc:prompt`                   | Request   | On-demand                         | `PermissionsPromptRequest`                        |
 | `permissions:rpc:prompt:reply:<requestId>` | Reply     | After prompt is resolved          | `PermissionsRpcReply<PermissionsPromptReplyData>` |
+
+---
+
+## UI Prompt Broadcasts
+
+The permission system emits `permissions:ui_prompt` immediately before it invokes the active user-facing permission UI.
+This event is for integrations such as notification extensions that should alert only when the user needs to respond to a permission prompt.
+It is not a generic "permission request entered waiting state" event, and it does not imply the prompt will be approved.
+Policy decisions that resolve without an active UI prompt, such as `policy_allow`, `policy_deny`, `session_approved`, `infrastructure_auto_allowed`, or `auto_approved`, do not emit this event.
+Non-UI child sessions also do not emit this event when they create a forwarded permission request; the parent UI session emits it immediately before showing the forwarded permission dialog.
+
+```typescript
+pi.events.on("permissions:ui_prompt", (raw) => {
+  const event = raw as import("@gotgenes/pi-permission-system").PermissionUiPromptEvent;
+  console.log(event.surface, event.value, event.message);
+  // e.g. "bash" "git push" "Allow git push?"
+});
+```
+
+### Payload Fields
+
+| Field              | Type             | Description                                                                                                      |
+| ------------------ | ---------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `protocolVersion`  | `number`         | Cross-extension event protocol version                                                                           |
+| `requestId`        | `string`         | Unique ID for the permission request being prompted                                                              |
+| `source`           | `PermissionUiPromptSource` | Prompt source: `"tool_call"`, `"skill_input"`, `"skill_read"`, `"rpc_prompt"`, or `"forwarded_permission"` |
+| `surface`          | `string \| null` | Permission surface being evaluated, when known                                                                   |
+| `value`            | `string \| null` | Value being evaluated: command, path, skill name, tool target, etc.                                              |
+| `agentName`        | `string \| null` | Active/requesting agent name when known                                                                          |
+| `message`          | `string`         | Message displayed in the permission prompt                                                                       |
+| `toolCallId`       | `string \| null` | Tool call ID when the prompt is for a tool call                                                                  |
+| `toolName`         | `string \| null` | Tool name when the prompt is for a tool call                                                                     |
+| `skillName`        | `string \| null` | Skill name when the prompt is for a skill request                                                                |
+| `path`             | `string \| null` | Path being evaluated, when available                                                                             |
+| `command`          | `string \| null` | Command being evaluated, when available                                                                          |
+| `target`           | `string \| null` | Generic target being evaluated, when available                                                                   |
+| `toolInputPreview` | `string \| null` | Tool input preview shown in logs/prompts, when available                                                         |
+| `sessionLabel`     | `string \| null` | Override label for the "for this session" dialog option                                                          |
 
 ---
 

--- a/packages/pi-permission-system/docs/cross-extension-api.md
+++ b/packages/pi-permission-system/docs/cross-extension-api.md
@@ -242,7 +242,11 @@ The extension also emits events on Pi's `pi.events` bus so other extensions can 
 ## Stability Guarantee
 
 Fields may be added to any payload, but existing fields will not be removed or renamed without a semver-major version bump.
-The protocol version constant is exported from `src/permission-events.ts` and embedded in every RPC reply.
+The broadcast contract is defined by the published TypeScript types plus package semver — broadcast payloads (`permissions:ready`, `permissions:ui_prompt`, `permissions:decision`) carry no `protocolVersion`.
+The `PERMISSIONS_PROTOCOL_VERSION` constant is exported from `src/permission-events.ts` and embedded only in the RPC reply envelope, where per-call request/reply negotiation is load-bearing.
+Consumers should read broadcast payloads defensively (field-presence checks) rather than version-gating — that is robust to any shape skew between independently-versioned sibling extensions.
+
+All three broadcasts are best-effort: a throwing listener cannot block permission handling, session startup, or gate resolution.
 
 ## Channel Reference
 
@@ -265,34 +269,50 @@ This event is for integrations such as notification extensions that should alert
 It is not a generic "permission request entered waiting state" event, and it does not imply the prompt will be approved.
 Policy decisions that resolve without an active UI prompt, such as `policy_allow`, `policy_deny`, `session_approved`, `infrastructure_auto_allowed`, or `auto_approved`, do not emit this event.
 Non-UI child sessions also do not emit this event when they create a forwarded permission request; the parent UI session emits it immediately before showing the forwarded permission dialog.
+Forwarded prompts are not degraded: the parent emits the child's original `source` and the same `surface`/`value` display projection, plus a populated `forwarding` context identifying the requesting subagent.
+
+The payload is lean by design — `surface`/`value` are the normalized display projection a notification consumer reads, not a mirror of the internal review log.
+Read defensively rather than version-gating: broadcast payloads carry no `protocolVersion`.
 
 ```typescript
+import type { PermissionUiPromptEvent } from "@gotgenes/pi-permission-system";
+
 pi.events.on("permissions:ui_prompt", (raw) => {
-  const event = raw as import("@gotgenes/pi-permission-system").PermissionUiPromptEvent;
-  console.log(event.surface, event.value, event.message);
+  const event = raw as PermissionUiPromptEvent;
+  // Defensive read: tolerate any shape skew between sibling extensions.
+  if (typeof event.value !== "string" && typeof event.message !== "string") {
+    return;
+  }
+  notify(event.surface, event.value, event.message);
   // e.g. "bash" "git push" "Allow git push?"
 });
 ```
 
 ### Payload Fields
 
-| Field              | Type             | Description                                                                                                      |
-| ------------------ | ---------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `protocolVersion`  | `number`         | Cross-extension event protocol version                                                                           |
-| `requestId`        | `string`         | Unique ID for the permission request being prompted                                                              |
-| `source`           | `PermissionUiPromptSource` | Prompt source: `"tool_call"`, `"skill_input"`, `"skill_read"`, `"rpc_prompt"`, or `"forwarded_permission"` |
-| `surface`          | `string \| null` | Permission surface being evaluated, when known                                                                   |
-| `value`            | `string \| null` | Value being evaluated: command, path, skill name, tool target, etc.                                              |
-| `agentName`        | `string \| null` | Active/requesting agent name when known                                                                          |
-| `message`          | `string`         | Message displayed in the permission prompt                                                                       |
-| `toolCallId`       | `string \| null` | Tool call ID when the prompt is for a tool call                                                                  |
-| `toolName`         | `string \| null` | Tool name when the prompt is for a tool call                                                                     |
-| `skillName`        | `string \| null` | Skill name when the prompt is for a skill request                                                                |
-| `path`             | `string \| null` | Path being evaluated, when available                                                                             |
-| `command`          | `string \| null` | Command being evaluated, when available                                                                          |
-| `target`           | `string \| null` | Generic target being evaluated, when available                                                                   |
-| `toolInputPreview` | `string \| null` | Tool input preview shown in logs/prompts, when available                                                         |
-| `sessionLabel`     | `string \| null` | Override label for the "for this session" dialog option                                                          |
+| Field        | Type                             | Description                                                                      |
+| ------------ | -------------------------------- | -------------------------------------------------------------------------------- |
+| `requestId`  | `string`                         | Unique ID for the permission request being prompted                              |
+| `source`     | `PermissionUiPromptSource`       | Prompt origin: `"tool_call"`, `"skill_input"`, `"skill_read"`, or `"rpc_prompt"` |
+| `surface`    | `string \| null`                 | Normalized display surface (e.g. `"bash"`, `"skill"`), when known                |
+| `value`      | `string \| null`                 | Normalized display value (command, path, skill name, etc.), when known           |
+| `agentName`  | `string \| null`                 | Active/requesting agent name, when known                                         |
+| `message`    | `string`                         | Message displayed in the permission prompt                                       |
+| `forwarding` | `ForwardedPromptContext \| null` | Forwarding context, or `null` for a direct prompt                                |
+
+Forwarding is orthogonal to origin: a forwarded subagent prompt keeps its original `source` and is identified by a non-null `forwarding` field, not by a dedicated source value.
+
+#### `ForwardedPromptContext`
+
+Present only when the prompt was forwarded from a non-UI subagent.
+
+| Field                | Type             | Description                                    |
+| -------------------- | ---------------- | ---------------------------------------------- |
+| `requesterAgentName` | `string \| null` | Requesting subagent's display name, when known |
+| `requesterSessionId` | `string \| null` | Requesting subagent's session id, when known   |
+
+The `surface`/`value` pair is a deliberate display projection that replaces the redundant per-source fields (`command`/`path`/`target`/`skillName`/`toolName`/`toolCallId`/`toolInputPreview`/`sessionLabel`) from earlier drafts — none of which the notification use case reads.
+The stability guarantee is additive, so any can be reintroduced in a later minor when a concrete consumer needs them.
 
 ---
 
@@ -444,9 +464,17 @@ The extension emits `permissions:ready` at `session_start`, right after the serv
 It fires once per `session_start` (including `/reload`).
 Consumers that start after the extension can check via a ping-style RPC check — the `permissions:rpc:check` handler is active as long as the extension is loaded.
 
+The payload is intentionally empty (`Record<string, never>`): the channel is a pure readiness signal.
+It carries no `protocolVersion` — version negotiation lives in the RPC reply envelope, and the broadcast contract is defined by the published types plus package semver.
+
 ```typescript
-pi.events.on("permissions:ready", (raw) => {
-  const event = raw as import("@gotgenes/pi-permission-system").PermissionsReadyEvent;
-  console.log("Permission system loaded, protocol version:", event.protocolVersion);
+pi.events.on("permissions:ready", () => {
+  void (async () => {
+    const { getPermissionsService } = await import(
+      "@gotgenes/pi-permission-system"
+    );
+    const permissions = getPermissionsService();
+    // The service is published just before this fires — resolve it now.
+  })();
 });
 ```

--- a/packages/pi-permission-system/docs/plans/0292-permission-ui-prompt-contract.md
+++ b/packages/pi-permission-system/docs/plans/0292-permission-ui-prompt-contract.md
@@ -1,0 +1,247 @@
+---
+issue: 292
+issue_title: "Harden the permissions:ui_prompt broadcast contract"
+---
+
+# Harden the `permissions:ui_prompt` broadcast contract
+
+## Context
+
+PR #292 (`moekyo:feature/permission-prompt-contract`) adds a new cross-extension broadcast, `permissions:ui_prompt`, that fires immediately before the permission system invokes the active user-facing permission UI.
+It supersedes PR #253 (`permissions:prompt`); the final tree on #292 contains no trace of the intermediate channel.
+The motivating consumer is a notification extension that must alert the user only when they actually need to return and respond to a permission prompt — a boundary that the existing `permissions:decision` event cannot express, because `permissions:decision` fires after resolution and also fires for auto-resolved paths where no human was ever prompted.
+
+The direction, the event-bus composition pattern, the `ctx.hasUI` emit boundary, the exclusion of auto-resolved paths, and the best-effort emission are all correct and align with our design goals.
+This plan hardens the contract before adoption.
+Delivery: a working branch based on the #292 head, so moekyo's commits remain at the base and their authorship is preserved in history (see Execution starting point).
+
+## Problem statement
+
+The contract as proposed in #292 has five structural issues, ordered by adoption impact.
+
+1. The 14-field payload is hand-constructed in three emit sites (`permission-prompter.ts` via `buildUiPromptEvent`, `permission-event-rpc.ts` inline, `forwarded-permissions/polling.ts` inline) with subtly different rules.
+   A public contract's construction must live in one place or it will drift by source.
+2. The payload mirrors the internal review-log entry (`writeReviewEntry` writes the same 14 fields): most are `null` for any given source, and `value` is a derived duplicate of `command ?? path ?? target ?? skillName ?? toolName`.
+   Forcing the public contract to mirror the internal audit log is an interface-segregation violation and invites the derived field to drift from its sources.
+3. Forwarded subagent prompts emit a degraded payload.
+   The child holds the structured metadata (`command`/`path`/`toolName`), but it is dropped at the file-forwarding boundary, so the parent emits with `surface: null`, `command: null`, `value: request.message`.
+   A consumer sees rich fields for direct prompts and a near-empty payload for forwarded ones.
+4. `protocolVersion` is inconsistent across the broadcast family: `permissions:ready` and `permissions:ui_prompt` carry it, `permissions:decision` does not.
+   The deeper issue is that a per-payload version on a fire-and-forget broadcast adds little: the published TypeScript types plus package semver define the contract, and a defensive consumer (field-presence checks) is robust to skew without it.
+   Version negotiation is only load-bearing for the request/reply RPC envelope.
+5. `confirmPermission` gained an emit side effect and a fifth parameter (`uiPromptEvent`), turning a pure routing function into one that also broadcasts, with `message` duplicated between the `message` param and `uiPromptEvent.message`.
+
+## Goals
+
+- Centralize payload construction behind a single tested builder.
+- Model the payload as a lean flat interface with a typed `source` discriminant, carrying only the fields the consumer reads.
+- Make forwarded prompts carry the same display fields as direct prompts by persisting `source` + `surface` + `value` in the forwarding request.
+- Remove `protocolVersion` from all broadcast payloads (it stays only in the RPC envelope), and make every broadcast emit best-effort.
+- Remove the emit side effect from `confirmPermission`.
+- Keep README, `docs/cross-extension-api.md`, schema/types, and tests aligned.
+
+## Non-goals
+
+- No behavioral change to `permissions:decision` or `permissions:ready` beyond removing `protocolVersion` from their payloads.
+- No change to the RPC channels or the RPC envelope (which keeps `protocolVersion`).
+- No new permission surface, policy field, or config key.
+- No change to the `/permission-system` command name.
+- No change to the forwarding directory layout or poll/timeout constants.
+
+## Decisions
+
+These were settled before planning and are fixed inputs to implementation.
+
+| #   | Decision            | Choice                                                   | Rationale                                                                                                            |
+| --- | ------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| D1  | Construction        | Single tested builder module                             | One source of truth for a public contract                                                                            |
+| D2  | Payload shape       | Lean flat interface, typed `source` discriminant         | No speculative fields; grow later under the additive stability guarantee                                             |
+| D3  | Forwarded prompts   | Must not degrade                                         | Notification parity between direct and forwarded                                                                     |
+| D4  | Forwarded modeling  | Preserve original `source` + forwarding context          | A forwarded `tool_call` stays `source: "tool_call"` and gains a `forwarding` field                                   |
+| D5  | `protocolVersion`   | Remove from all broadcast payloads; keep in RPC envelope | Types + semver define the broadcast contract; per-payload version is ceremony. Breaking for `ready` — no sacred cows |
+| D6  | `confirmPermission` | Remove emit side effect                                  | Restore single responsibility                                                                                        |
+| D7  | Emit resilience     | All three broadcasts best-effort                         | A throwing listener must not block permission handling                                                               |
+
+## Design
+
+### Event shape: lean flat payload
+
+The payload carries only what the consumer reads — the notify-now signal, a display pair, and forwarding context.
+It is a single flat interface with a typed `source` discriminant; there is no union and no per-source `null` fields.
+`source` keeps its narrow set; `forwarded_permission` is not a `source` value, because per D4 the forwarding nature is carried orthogonally by the `forwarding` field.
+
+```typescript
+export type PermissionUiPromptSource =
+  | "tool_call"
+  | "skill_input"
+  | "skill_read"
+  | "rpc_prompt";
+
+/** Present only when the prompt was forwarded from a non-UI subagent. */
+export interface ForwardedPromptContext {
+  requesterAgentName: string | null;
+  requesterSessionId: string | null;
+}
+
+export interface PermissionUiPromptEvent {
+  requestId: string;
+  source: PermissionUiPromptSource;
+  /** Normalized display surface (e.g. "bash", "skill"). */
+  surface: string | null;
+  /** Normalized display value (command, path, skill name, etc.). */
+  value: string | null;
+  agentName: string | null;
+  message: string;
+  forwarding: ForwardedPromptContext | null;
+}
+```
+
+This is the whole contract.
+The `surface`/`value` pair is the deliberate display projection that replaces the redundant `command`/`path`/`target`/`skillName`/`toolName`/`toolCallId`/`toolInputPreview`/`sessionLabel` fields from #292 — none of which the notification use case reads.
+The stability guarantee is additive, so any of those can be reintroduced in a later minor when a concrete consumer needs them; shipping them now would be speculative fields the package skill flags as a maintenance trap.
+Confirm at step 1 that the projection is sufficient for the notification use case before deleting the extra fields.
+
+### Centralized builder
+
+Add `src/permission-ui-prompt.ts` exporting pure builders that map domain inputs to the lean `PermissionUiPromptEvent`, plus the `surface`/`value` normalization currently inlined as `promptSurface`/`promptValue` in the prompter.
+
+- `buildDirectUiPrompt(details: PromptPermissionDetails): PermissionUiPromptEvent` — covers `tool_call` / `skill_input` / `skill_read`.
+- `buildRpcUiPrompt(request): PermissionUiPromptEvent` — the `rpc_prompt` source.
+- `buildForwardedUiPrompt(request: ForwardedPermissionRequest): PermissionUiPromptEvent` — reconstructs the original source plus `forwarding` context from the persisted request.
+
+All three set the normalized `surface`/`value`.
+The three emit sites call a builder and pass the result to `emitUiPromptEvent`; no site hand-rolls the object.
+These builders warrant their own tests (they encode normalization and source mapping), which is why they live in a module rather than as file-local helpers.
+
+### Forwarded round-trip: stop the degradation
+
+The metadata is dropped at exactly one point: `confirmPermission` calls `waitForForwardedPermissionApproval(ctx, message, deps)` with only `message`, and the persisted `ForwardedPermissionRequest` carries only `{ id, createdAt, requesterSessionId, targetSessionId, requesterAgentName, message }`.
+
+Fix in three coordinated edits:
+
+1. Extend `ForwardedPermissionRequest` (in `src/permission-forwarding.ts`) with three optional fields — `source`, `surface`, `value` — alongside the existing `message` and `requesterAgentName`.
+   The lean payload needs nothing more to reconstruct a full event on the parent side.
+   Keep the fields optional and the reader tolerant of their absence: a parent on a newer version may read a request written by an older child during an upgrade.
+   When `source` is absent, default it to `"tool_call"` (the dominant forwarded origin) with `surface`/`value` left `null` — the consumer still gets the notify-now signal, `message`, and `forwarding` context.
+2. Thread `source`/`surface`/`value` from the prompter through `confirmPermission` into `waitForForwardedPermissionApproval`, which writes them into the request file.
+   Consolidate `message` and these display fields into one cohesive `ForwardedPromptInput` object so the relay through `confirmPermission` is a single parameter, not four (see D6).
+3. In `processForwardedPermissionRequests`, build the emitted event with `buildForwardedUiPrompt(request)` so the parent emits the original `source`, the `surface`/`value` pair, and a populated `forwarding` context — instead of the degraded inline payload.
+
+### `confirmPermission`: remove the side effect
+
+Restore `confirmPermission` to routing only.
+
+- The direct UI-prompt emit moves to `PermissionPrompter.prompt`, gated on `ctx.hasUI` (the same condition `confirmPermission` branches on), using `buildDirectUiPrompt`.
+  When `ctx.hasUI` is false the prompter does not emit; the parent emits later from the forwarded path.
+- `confirmPermission` no longer takes `uiPromptEvent` and no longer emits.
+  It takes the consolidated `ForwardedPromptInput` (message + `source`/`surface`/`value`) so the forwarded branch can persist it; the UI branch ignores the display fields.
+- The RPC handler keeps emitting directly via `buildRpcUiPrompt` (it never routed through `confirmPermission`).
+
+This removes the duplicated `message`, drops the fifth positional parameter, and keeps each emit at its correct boundary: prompter for direct UI, RPC handler for RPC, `processForwardedPermissionRequests` for forwarded.
+
+### `protocolVersion`: remove from broadcasts, keep in the RPC envelope
+
+Remove `protocolVersion` from `PermissionUiPromptEvent` (unreleased) and from `PermissionsReadyEvent` (shipped), and do not add it to `PermissionDecisionEvent`.
+Drop it from `emitReadyEvent`'s payload accordingly.
+Keep `PERMISSIONS_PROTOCOL_VERSION` exported and keep it in the RPC reply envelope (`PermissionsRpcReply`), where per-call request/reply negotiation is genuinely load-bearing.
+
+Rationale: a per-payload version on a fire-and-forget broadcast is ceremony.
+The broadcast contract is defined by the package's published TypeScript types plus semver — a breaking change to any payload is a major version bump.
+The one gap is that the publisher and a consumer are independently-versioned sibling extensions, so the consumer cannot observe the publisher's installed version at runtime (type-only imports do not constrain a separately-installed sibling; jiti isolates the modules).
+But a runtime version number is the weaker fix for that gap: a defensive consumer that checks field presence is robust to *any* shape skew, not just version-numbered breaks, and needs no version field.
+Version negotiation stays where it earns its keep — the request/reply RPC envelope.
+
+Removing `protocolVersion` from `PermissionsReadyEvent` is a breaking change to a released payload, so this lands as a major version bump (see Backwards compatibility).
+No sacred cows: `ready` is almost certainly unused as a version source today, and grandfathering it would leave a permanently inconsistent family.
+
+Document for consumers in `docs/cross-extension-api.md`: rely on package semver for the contract, and read defensively rather than version-gating.
+
+```typescript
+pi.events.on("permissions:ui_prompt", (raw) => {
+  const event = raw as PermissionUiPromptEvent;
+  if (typeof event.value !== "string" && typeof event.message !== "string") return;
+  notify(event.surface, event.value, event.message);
+});
+```
+
+### Documentation and exports
+
+- `src/service.ts` already re-exports the prompt types; update them to the lean `PermissionUiPromptEvent`, `PermissionUiPromptSource`, and `ForwardedPromptContext`, and drop the removed variant/field type exports.
+- `docs/cross-extension-api.md`: replace the 14-row field table with the lean field table, document `surface`/`value` as the display projection and the `forwarding` field, note that broadcast payloads no longer carry `protocolVersion` (it lives in the RPC envelope), and show the defensive-read consumer pattern above.
+  Update the channel reference and any `PermissionsReadyEvent` description that mentions `protocolVersion`.
+- `README.md`: keep the one-line feature bullet; ensure wording matches "active user-facing UI prompt".
+- `CHANGELOG.md` is owned by release-please — do not edit.
+
+## Execution starting point
+
+This plan is not greenfield: its steps transform the code #292 already added, rather than building from `main`.
+Running it from `main` would be incoherent — the 14-field type, the `uiPromptEvent` parameter, and the inline emit sites the steps reshape exist only on the PR branch.
+
+The baseline is therefore already set up on the branch `feat/permission-ui-prompt-contract`:
+
+- Created from the #292 head (`moekyo:feature/permission-prompt-contract`, locally `pr-292`) and rebased onto current `main`.
+- The rebase was clean (the only `main` change to this package beyond #292's base was an excluded retro doc).
+- moekyo's two commits sit at the base, so their authorship survives in history; our commits land on top.
+
+For each step below, the "before" state is #292's version of the file, not `main`'s.
+After implementation, review the net contract delta against `main`:
+
+```bash
+git diff main...HEAD -- packages/pi-permission-system
+```
+
+Delivery is this branch as its own PR, superseding #292 — no comment exchange required.
+Merge with **rebase**, not squash, so each commit's author is preserved on `main`: koxx12-dev (the original `permissions:prompt` commit) and moekyo (the hardening commit) at the base, our commits on top.
+The breaking change rides on the step-3 commit's `feat!:` / `BREAKING CHANGE:` footer, which release-please reads off `main` to cut the major — no squash commit or co-author trailers needed.
+Close #292 as superseded at ship time.
+
+## Implementation steps
+
+Each step is a TDD unit: write or extend the test first, then the code, then run the package check.
+
+1. Confirm the lean payload shape against this plan, then collapse the 14-field type in `src/permission-events.ts` to the lean `PermissionUiPromptEvent` + `PermissionUiPromptSource` + `ForwardedPromptContext`; update the re-exports in `src/service.ts`.
+   Test: type-level and constant tests in `test/permission-events.test.ts`.
+2. Add `src/permission-ui-prompt.ts` with `buildDirectUiPrompt`, `buildRpcUiPrompt`, `buildForwardedUiPrompt`, plus the `surface`/`value` normalization.
+   Test: new `test/permission-ui-prompt.test.ts` covering each source, the normalized projection, and the `forwarding` field.
+3. Remove `protocolVersion` from `PermissionUiPromptEvent` and `PermissionsReadyEvent` (and `emitReadyEvent`'s payload); leave the RPC envelope untouched.
+   `PermissionsReadyEvent` becomes empty — alias it to `Record<string, never>` (or drop the payload arg and emit `{}`) to avoid the empty-interface lint rule, and have `emitReadyEvent` emit `{}`.
+   Mark the commit breaking (`feat!:` / `BREAKING CHANGE:` footer) so release-please cuts a major.
+   Test: update `test/permission-events.test.ts` ready-event and constant assertions; confirm RPC envelope tests still assert `protocolVersion`.
+4. Refactor `PermissionPrompter.prompt` to emit directly via `buildDirectUiPrompt` gated on `ctx.hasUI`; stop building/passing `uiPromptEvent`.
+   Test: `test/permission-prompter.test.ts` — emits on UI, does not emit on non-UI.
+5. Extend `ForwardedPermissionRequest` with `source`/`surface`/`value` and consolidate `confirmPermission` / `waitForForwardedPermissionApproval` onto a single `ForwardedPromptInput`; persist the display fields; remove the emit from `confirmPermission`.
+   Test: `test/permission-forwarding.test.ts` — request file carries `source`/`surface`/`value`; tolerant read defaults `source` to `"tool_call"` when absent.
+6. Rebuild the parent emit in `processForwardedPermissionRequests` via `buildForwardedUiPrompt`.
+   Test: forwarded round-trip emits a non-degraded payload with original source + `forwarding` context (use the fire-without-await + poll-`requests/` pattern from the package skill).
+7. Update RPC handler to use `buildRpcUiPrompt`.
+   Test: `test/permission-event-rpc.test.ts` — payload has `source: "rpc_prompt"` and the lean fields.
+8. Update `docs/cross-extension-api.md` and `README.md`.
+   Verify the channel table, the lean field table, and the defensive-read example; run `pnpm --filter @gotgenes/pi-permission-system run lint:md`.
+9. Full verification: `pnpm --filter @gotgenes/pi-permission-system check`, `... test`, `pnpm -r run test`, `pnpm fallow dead-code` for the package.
+
+## Testing strategy
+
+- Negative coverage is the contract: auto-resolved paths (`policy_allow`, `policy_deny`, `session_approved`, `infrastructure_auto_allowed`, `auto_approved`) and non-UI child paths must not emit `permissions:ui_prompt`.
+  Preserve and extend the existing #292 regression tests.
+- Forwarded round-trip uses the documented harness pattern: fire the child `tool_call` without awaiting, poll the parent `requests/` dir, write the approval JSON, then await.
+- Builder tests assert the normalized `surface`/`value` projection across each `source` and a populated `forwarding` context for the forwarded builder.
+- Tolerant-read test: a `ForwardedPermissionRequest` lacking `source`/`surface`/`value` still produces a valid forwarded event (`source` defaulted to `"tool_call"`, `surface`/`value` `null`).
+
+## Backwards compatibility
+
+- `permissions:ui_prompt` is unreleased; reshaping it is free.
+- Removing `protocolVersion` from `PermissionsReadyEvent` is a breaking change to a released payload — this PR lands as a major version bump.
+  Commit with a `BREAKING CHANGE:` footer so release-please cuts the major.
+- `permissions:decision` is unchanged (it never carried `protocolVersion`).
+- The RPC envelope keeps `protocolVersion`; RPC consumers are unaffected.
+- `ForwardedPermissionRequest` gains optional `source`/`surface`/`value`; readers tolerate their absence, so a parent/child version skew during upgrade degrades gracefully (`source` defaults to `"tool_call"`, `surface`/`value` `null`) rather than failing.
+
+## Risks and open questions
+
+- Projection sufficiency: the lean payload bets that `surface`/`value`/`message` cover the notification use case and the dropped fields (`toolCallId`, `command`, `path`, etc.) are not needed.
+  Confirm at step 1 before deleting them; reintroducing one later is an additive, non-breaking change.
+- Relay surface: even consolidated into `ForwardedPromptInput`, the display fields still pass through `confirmPermission` to the forwarded writer.
+  This is acceptable because the two endpoints (prompter, forwarded writer) genuinely share the data and `confirmPermission` owns the branch; revisit only if a third forwarded caller appears.
+- Coordination: a heavy maintainer rewrite of an open PR should be flagged to moekyo before pushing onto the branch.
+</content>
+</invoke>

--- a/packages/pi-permission-system/docs/retro/0292-permission-ui-prompt-contract.md
+++ b/packages/pi-permission-system/docs/retro/0292-permission-ui-prompt-contract.md
@@ -66,4 +66,36 @@ After commit 5 — full verification (`check`, `lint`, full `test`, `pnpm fallow
 - `tsc` did not flag the test breakages in `permission-prompter.test.ts` / `permission-event-rpc.test.ts` (loose mock-call and `waitForReply` typing); they failed only at runtime.
   Always run the affected test files, not just `check`, after a payload-shape change.
 - The branch has no upstream, so the `/tdd-plan` `git pull --ff-only` step fails by design — proceed (baseline was freshly rebased onto `main`).
+
+## Stage: Implementation — TDD (2026-06-02T12:36:31Z) — COMPLETED
+
+### Session summary
+
+Resumed from the paused session and landed the remaining three implementation commits plus two docs commits and one CHANGELOG cleanup.
+Forwarded non-degradation (plan steps 5+6) and best-effort emits (D7) close out all nine plan steps.
+Test count went 1749 → 1753 (+4: two for the forwarded display-field relay, two for best-effort `ready`/`decision` emits).
+Full verification is green (`check`, `lint`, `pnpm -r run test` = 3264 tests, `pnpm fallow dead-code`, no lockfile drift), and the pre-completion reviewer returned PASS.
+
+### Commits landed this session
+
+1. `197deb56` `feat`: preserve display fields for forwarded prompts (plan steps 5+6, D3/D4).
+   `ForwardedPermissionRequest` gains optional `source`/`surface`/`value`; new `ForwardedPromptDisplay` relays them through `confirmPermission` → `waitForForwardedPermissionApproval` as one param; `PermissionPrompter.prompt` builds the event once and passes its display fields onward; `readForwardedPermissionRequest` does a tolerant read (`asUiPromptSource` / `asNullableDisplayString`) defaulting `source` to `"tool_call"` on absence.
+2. `601c7860` `feat`: make `ready` and `decision` broadcasts best-effort (D7) — wrapped `emitReadyEvent` and `emitDecisionEvent` in the same try/catch `emitUiPromptEvent` already used.
+3. `0d5c33ec` `docs`: lean `ui_prompt` contract in `docs/cross-extension-api.md` (lean field table, `ForwardedPromptContext`, no-`protocolVersion` stability note, defensive-read example, best-effort note, empty `PermissionsReadyEvent`).
+4. `b61d86c4` `docs`: update `docs/architecture/permission-prompter.md` data-flow for the broadcast emit + display-field relay.
+5. `aa921d4c` `fix`: drop the manual `## Unreleased` section from `CHANGELOG.md` (see Observations).
+
+### Observations
+
+- The reader (`readForwardedPermissionRequest`) reconstructs only known fields, so the persisted `source`/`surface`/`value` were silently dropped until I added them to the read path — the write side alone was not enough.
+  This was the one non-obvious step: a request shape change needs both the writer and the reconstructing reader updated.
+- Deviation from the plan's "bundle `message` too" (D6): kept `message` positional and added exactly one new `forwarded?: ForwardedPromptDisplay` param to `confirmPermission` (now 5 params).
+  This matches the worked-out design in the paused stage notes.
+  The pre-completion reviewer flagged the 5-param boundary as a non-blocking WARN — revisit only if a sixth param appears.
+- `README.md` needed no change — its feature bullet already read "active user-facing permission UI".
+- The inherited #292 commit (`e71b0d86`, moekyo) had added a manual `## Unreleased` section to `CHANGELOG.md`, which release-please owns.
+  User approved removing it in a new `fix:` commit (preserves moekyo's authorship on the original commit; release-please regenerates from the conventional commits).
+- Pre-completion reviewer: **PASS** — ready for `/ship-issue`.
+  One non-blocking WARN (`confirmPermission` 5 params, plan-documented).
+- Tolerant-source narrowing avoided casts via `find` over an `as const satisfies readonly PermissionUiPromptSource[]` array, sidestepping the biome/eslint assertion loop noted in AGENTS.md.
 </content>

--- a/packages/pi-permission-system/docs/retro/0292-permission-ui-prompt-contract.md
+++ b/packages/pi-permission-system/docs/retro/0292-permission-ui-prompt-contract.md
@@ -1,0 +1,69 @@
+---
+issue: 292
+issue_title: "Harden the permissions:ui_prompt broadcast contract"
+---
+
+# Retro: #292 — Harden the `permissions:ui_prompt` broadcast contract
+
+## Stage: Implementation — TDD (2026-06-01T23:30:00Z) — PAUSED (incomplete)
+
+### Session summary
+
+Began TDD execution of the plan on branch `feat/permission-ui-prompt-contract` (built from the #292 head, rebased onto `main`; koxx12-dev's and moekyo's commits sit at the base with authorship preserved).
+Landed the green baseline plus the first two of the planned implementation commits.
+Paused mid-implementation (context budget) with the working tree clean — commits 3–5, full verification, and pre-completion review remain.
+
+### Commits landed this session (on top of the plan + #292 commits)
+
+1. `3a0fc4e7` `style(...)`: green-baseline lint fixes — #292's last commit left lint red (the `&&` short-circuit in the `lint` script hid it).
+   Fixed biome `organizeImports` (sorted `service.ts` exports + two test import lists), eslint `no-deprecated` (dropped the unreleased deprecated RPC-check re-exports from the `service.ts` barrel), and rumdl MD060 (README table alignment).
+2. `1da4ef81` `feat!`: drop `protocolVersion` from `permissions:ready` (D5).
+   `PermissionsReadyEvent` → `Record<string, never>`; `emitReadyEvent` emits `{}`.
+   `PERMISSIONS_PROTOCOL_VERSION` kept for the RPC envelope.
+   Breaking — has the `BREAKING CHANGE:` footer.
+3. `9ec4ed34` `feat`: slim `ui_prompt` payload + centralize construction (plan steps 1, 2, 4, 7 + D6, merged).
+   Lean `PermissionUiPromptEvent` (`requestId, source, surface, value, agentName, message, forwarding`); `forwarded_permission` removed from `PermissionUiPromptSource`; new `ForwardedPromptContext`; new leaf module `src/permission-ui-prompt.ts` with `buildDirectUiPrompt` / `buildRpcUiPrompt` / `buildForwardedUiPrompt`; `confirmPermission` restored to pure routing (no emit, no `uiPromptEvent` param) with the direct emit moved to `PermissionPrompter.prompt` gated on `ctx.hasUI`.
+
+Baseline after commit 2: `check` clean, `lint` clean, full suite `1749 passed`.
+
+### Decisions made this session (refinements to the plan)
+
+- Commit slicing deviates from the plan's 9 micro-steps: the in-place type contraction forces every emit site and its tests to migrate together (testing-skill type-cascade rule), so plan steps 1/2/4/7 + D6 merged into commit `9ec4ed34`.
+  End state is unchanged.
+- Builders use **builder-owned narrow input types** (`DirectPromptInput`, `RpcPromptInput`, `ForwardedPromptInput`) that each call site satisfies structurally — chosen over taking `PromptPermissionDetails` to avoid a type-only import cycle and keep `permission-ui-prompt.ts` a true leaf. (User-confirmed.)
+- No `import/no-cycle` lint rule adopted — rely on clean layering. (User-confirmed; the repo only has `no-parent-relative-imports`.)
+- `protocolVersion` removed from **all** broadcast payloads including the shipped `ready` (no sacred cows — user-confirmed), making this PR a major bump.
+  It stays only in the RPC reply envelope.
+- `buildForwardedUiPrompt` defaults `source` to `"tool_call"` with null `surface`/`value` when the persisted request omits them (version-skew tolerance).
+
+### Remaining work (resume here)
+
+Commit 3 — forwarded non-degradation (plan steps 5+6), NOT yet started (working tree clean).
+Worked-out design:
+
+- `ForwardedPermissionRequest` (`src/permission-forwarding.ts`): add optional `source?: PermissionUiPromptSource`, `surface?: string | null`, `value?: string | null` (import `type PermissionUiPromptSource` from `./permission-events` — no cycle).
+- Thread the display fields child→parent.
+  In `PermissionPrompter.prompt`, build the event once (`const uiPrompt = buildDirectUiPrompt(details)`), emit it when `ctx.hasUI`, and pass `{ source, surface, value }` from `uiPrompt` to `confirmPermission` so normalization stays in one place (the builder).
+- `confirmPermission` gains one param `forwarded?: { source; surface; value }` (a named type, e.g. `ForwardedPromptDisplay`, distinct from the builder's `ForwardedPromptInput`); it relays `forwarded` to `waitForForwardedPermissionApproval`. (Minor deviation from the plan's "bundle `message` too": keep `message` positional since the UI and deny branches use it; add exactly one new param for the structured fields — still "one param, not three".)
+- `waitForForwardedPermissionApproval` writes `source`/`surface`/`value` into the request file when `forwarded` is provided.
+- `processForwardedPermissionRequests` passes `request.source/surface/value` into `buildForwardedUiPrompt` (already wired; just add the three fields) so the parent emits a non-degraded event.
+- Tests: prompter asserts the `{source,surface,value}` 5th arg to `confirmPermission`; `permission-forwarding.test.ts` gets a test for a request that carries the fields (non-degraded emit) alongside the existing fallback test; extend the composition-root forwarded round-trip (`test/composition-root.test.ts`, helper around line 148 simulates the parent responding) to assert the persisted request carries the fields.
+  Note: `waitForForwardedPermissionApproval` polls with a 10-min timeout — use the fire-without-await + write-response pattern (package skill).
+
+Commit 4 — best-effort emits (D7): wrap `emitReadyEvent` and `emitDecisionEvent` bodies in the same try/catch `emitUiPromptEvent` already uses.
+Update `test/permission-events.test.ts` (add swallow-error tests for both).
+
+Commit 5 — docs (step 8): `docs/cross-extension-api.md` (replace the 14-row field table with the lean table, document `surface`/`value` projection + `forwarding`, note broadcasts no longer carry `protocolVersion` — RPC envelope only, show the defensive-read consumer pattern, update the `PermissionsReadyEvent` description and channel table) and `README.md` (feature bullet wording).
+Run `lint:md`.
+Do not touch `CHANGELOG.md`.
+
+After commit 5 — full verification (`check`, `lint`, full `test`, `pnpm fallow dead-code` from repo root, `git diff --name-only pnpm-lock.yaml`), cross-check the plan's module table, then the pre-completion reviewer dispatch, summarize, and update this retro to a completed entry.
+
+### Observations
+
+- `pnpm run lint`'s `&&` chain (`biome && eslint && rumdl`) masks later failures behind the first.
+  When establishing a baseline, run each linter separately to see the full debt.
+- `tsc` did not flag the test breakages in `permission-prompter.test.ts` / `permission-event-rpc.test.ts` (loose mock-call and `waitForReply` typing); they failed only at runtime.
+  Always run the affected test files, not just `check`, after a payload-shape change.
+- The branch has no upstream, so the `/tdd-plan` `git pull --ff-only` step fails by design — proceed (baseline was freshly rebased onto `main`).
+</content>

--- a/packages/pi-permission-system/src/forwarded-permissions/io.ts
+++ b/packages/pi-permission-system/src/forwarded-permissions/io.ts
@@ -10,12 +10,36 @@ import {
 } from "node:fs";
 
 import { isPermissionDecisionState } from "#src/permission-dialog";
+import type { PermissionUiPromptSource } from "#src/permission-events";
 import {
   createPermissionForwardingLocation,
   type ForwardedPermissionRequest,
   type ForwardedPermissionResponse,
   type PermissionForwardingLocation,
 } from "#src/permission-forwarding";
+
+/** Valid `permissions:ui_prompt` source values, for tolerant request reads. */
+const UI_PROMPT_SOURCES = [
+  "tool_call",
+  "skill_input",
+  "skill_read",
+  "rpc_prompt",
+] as const satisfies readonly PermissionUiPromptSource[];
+
+/** Narrow an unknown value to a valid prompt source, or `undefined`. */
+function asUiPromptSource(
+  value: unknown,
+): PermissionUiPromptSource | undefined {
+  return UI_PROMPT_SOURCES.find((source) => source === value);
+}
+
+/** Narrow an unknown value to a nullable display string, or `undefined`. */
+function asNullableDisplayString(value: unknown): string | null | undefined {
+  if (value === null || typeof value === "string") {
+    return value;
+  }
+  return undefined;
+}
 
 type LogFn = (event: string, details: Record<string, unknown>) => void;
 
@@ -285,6 +309,11 @@ export function readForwardedPermissionRequest(
       targetSessionId: parsed.targetSessionId,
       requesterAgentName: parsed.requesterAgentName,
       message: parsed.message,
+      // Tolerant read: display fields are optional and may be absent (older
+      // child) or malformed; reconstruct only the well-formed ones.
+      source: asUiPromptSource(parsed.source),
+      surface: asNullableDisplayString(parsed.surface),
+      value: asNullableDisplayString(parsed.value),
     };
   } catch (error) {
     logPermissionForwardingWarning(

--- a/packages/pi-permission-system/src/forwarded-permissions/polling.ts
+++ b/packages/pi-permission-system/src/forwarded-permissions/polling.ts
@@ -18,6 +18,7 @@ import {
 import {
   type ForwardedPermissionRequest,
   type ForwardedPermissionResponse,
+  type ForwardedPromptDisplay,
   isForwardedPermissionRequestForSession,
   PERMISSION_FORWARDING_POLL_INTERVAL_MS,
   PERMISSION_FORWARDING_TIMEOUT_MS,
@@ -110,6 +111,7 @@ export async function waitForForwardedPermissionApproval(
   ctx: ExtensionContext,
   message: string,
   deps: PermissionForwardingDeps,
+  forwarded?: ForwardedPromptDisplay,
 ): Promise<PermissionPromptDecision> {
   const requesterSessionId = getSessionId(ctx);
   const targetSessionId = resolvePermissionForwardingTargetSessionId({
@@ -162,6 +164,13 @@ export async function waitForForwardedPermissionApproval(
     targetSessionId,
     requesterAgentName,
     message,
+    ...(forwarded
+      ? {
+          source: forwarded.source,
+          surface: forwarded.surface,
+          value: forwarded.value,
+        }
+      : {}),
   };
 
   const requestPath = join(location.requestsDir, `${requestId}.json`);
@@ -312,6 +321,9 @@ export async function processForwardedPermissionRequests(
               message: forwardedMessage,
               requesterAgentName: request.requesterAgentName || null,
               requesterSessionId: request.requesterSessionId || null,
+              source: request.source ?? null,
+              surface: request.surface ?? null,
+              value: request.value ?? null,
             }),
           );
         }
@@ -378,6 +390,7 @@ export async function confirmPermission(
   message: string,
   deps: PermissionForwardingDeps,
   options?: RequestPermissionOptions,
+  forwarded?: ForwardedPromptDisplay,
 ): Promise<PermissionPromptDecision> {
   if (ctx.hasUI) {
     return deps.requestPermissionDecisionFromUi(
@@ -394,5 +407,5 @@ export async function confirmPermission(
     return { approved: false, state: "denied" };
   }
 
-  return waitForForwardedPermissionApproval(ctx, message, deps);
+  return waitForForwardedPermissionApproval(ctx, message, deps, forwarded);
 }

--- a/packages/pi-permission-system/src/forwarded-permissions/polling.ts
+++ b/packages/pi-permission-system/src/forwarded-permissions/polling.ts
@@ -12,6 +12,12 @@ import type {
   RequestPermissionOptions,
 } from "#src/permission-dialog";
 import {
+  emitUiPromptEvent,
+  PERMISSIONS_PROTOCOL_VERSION,
+  type PermissionEventBus,
+  type PermissionUiPromptEvent,
+} from "#src/permission-events";
+import {
   type ForwardedPermissionRequest,
   type ForwardedPermissionResponse,
   isForwardedPermissionRequestForSession,
@@ -43,6 +49,8 @@ export interface PermissionForwardingDeps {
   subagentSessionsDir: string;
   /** In-process subagent session registry for detection and forwarding target resolution. */
   registry?: SubagentSessionRegistry;
+  /** Event bus used for UI prompt broadcasts. */
+  events?: PermissionEventBus;
   logger: ForwardedPermissionLogger;
   writeReviewLog: (event: string, details: Record<string, unknown>) => void;
   requestPermissionDecisionFromUi: (
@@ -296,6 +304,26 @@ export async function processForwardedPermissionRequests(
         forwardedPermissionLogDetails,
       );
       try {
+        if (deps.events) {
+          const message = formatForwardedPermissionPrompt(request);
+          emitUiPromptEvent(deps.events, {
+            protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
+            requestId: request.id,
+            source: "forwarded_permission",
+            surface: null,
+            value: request.message,
+            agentName: request.requesterAgentName || null,
+            message,
+            toolCallId: null,
+            toolName: null,
+            skillName: null,
+            path: null,
+            command: null,
+            target: request.message,
+            toolInputPreview: null,
+            sessionLabel: null,
+          });
+        }
         decision = await deps.requestPermissionDecisionFromUi(
           ctx.ui,
           "Permission Required (Subagent)",
@@ -359,8 +387,12 @@ export async function confirmPermission(
   message: string,
   deps: PermissionForwardingDeps,
   options?: RequestPermissionOptions,
+  uiPromptEvent?: PermissionUiPromptEvent,
 ): Promise<PermissionPromptDecision> {
   if (ctx.hasUI) {
+    if (deps.events && uiPromptEvent) {
+      emitUiPromptEvent(deps.events, uiPromptEvent);
+    }
     return deps.requestPermissionDecisionFromUi(
       ctx.ui,
       "Permission Required",

--- a/packages/pi-permission-system/src/forwarded-permissions/polling.ts
+++ b/packages/pi-permission-system/src/forwarded-permissions/polling.ts
@@ -13,9 +13,7 @@ import type {
 } from "#src/permission-dialog";
 import {
   emitUiPromptEvent,
-  PERMISSIONS_PROTOCOL_VERSION,
   type PermissionEventBus,
-  type PermissionUiPromptEvent,
 } from "#src/permission-events";
 import {
   type ForwardedPermissionRequest,
@@ -26,6 +24,7 @@ import {
   resolvePermissionForwardingTargetSessionId,
   SUBAGENT_PARENT_SESSION_ENV_CANDIDATES,
 } from "#src/permission-forwarding";
+import { buildForwardedUiPrompt } from "#src/permission-ui-prompt";
 import { isSubagentExecutionContext } from "#src/subagent-context";
 import type { SubagentSessionRegistry } from "#src/subagent-registry";
 
@@ -304,30 +303,22 @@ export async function processForwardedPermissionRequests(
         forwardedPermissionLogDetails,
       );
       try {
+        const forwardedMessage = formatForwardedPermissionPrompt(request);
         if (deps.events) {
-          const message = formatForwardedPermissionPrompt(request);
-          emitUiPromptEvent(deps.events, {
-            protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
-            requestId: request.id,
-            source: "forwarded_permission",
-            surface: null,
-            value: request.message,
-            agentName: request.requesterAgentName || null,
-            message,
-            toolCallId: null,
-            toolName: null,
-            skillName: null,
-            path: null,
-            command: null,
-            target: request.message,
-            toolInputPreview: null,
-            sessionLabel: null,
-          });
+          emitUiPromptEvent(
+            deps.events,
+            buildForwardedUiPrompt({
+              requestId: request.id,
+              message: forwardedMessage,
+              requesterAgentName: request.requesterAgentName || null,
+              requesterSessionId: request.requesterSessionId || null,
+            }),
+          );
         }
         decision = await deps.requestPermissionDecisionFromUi(
           ctx.ui,
           "Permission Required (Subagent)",
-          formatForwardedPermissionPrompt(request),
+          forwardedMessage,
         );
       } catch (error) {
         logPermissionForwardingError(
@@ -387,12 +378,8 @@ export async function confirmPermission(
   message: string,
   deps: PermissionForwardingDeps,
   options?: RequestPermissionOptions,
-  uiPromptEvent?: PermissionUiPromptEvent,
 ): Promise<PermissionPromptDecision> {
   if (ctx.hasUI) {
-    if (deps.events && uiPromptEvent) {
-      emitUiPromptEvent(deps.events, uiPromptEvent);
-    }
     return deps.requestPermissionDecisionFromUi(
       ctx.ui,
       "Permission Required",

--- a/packages/pi-permission-system/src/index.ts
+++ b/packages/pi-permission-system/src/index.ts
@@ -62,6 +62,7 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
     forwardingDir: runtime.forwardingDir,
     subagentSessionsDir: runtime.subagentSessionsDir,
     registry: subagentRegistry,
+    events: pi.events,
     logger: {
       writeReviewLog: runtime.writeReviewLog.bind(runtime),
       writeDebugLog: runtime.writeDebugLog.bind(runtime),

--- a/packages/pi-permission-system/src/index.ts
+++ b/packages/pi-permission-system/src/index.ts
@@ -54,6 +54,7 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
     subagentSessionsDir: runtime.subagentSessionsDir,
     forwardingDir: runtime.forwardingDir,
     registry: subagentRegistry,
+    events: pi.events,
     requestPermissionDecisionFromUi,
   });
 

--- a/packages/pi-permission-system/src/permission-event-rpc.ts
+++ b/packages/pi-permission-system/src/permission-event-rpc.ts
@@ -21,7 +21,7 @@ import type {
   PermissionsRpcReply,
 } from "./permission-events";
 import {
-  emitPromptEvent,
+  emitUiPromptEvent,
   PERMISSIONS_PROTOCOL_VERSION,
   PERMISSIONS_RPC_CHECK_CHANNEL,
   PERMISSIONS_RPC_PROMPT_CHANNEL,
@@ -156,9 +156,12 @@ async function handlePromptRpc(
       ? `Permission request${agentName ? ` from ${agentName}` : ""}`
       : "Permission request";
 
-    emitPromptEvent(events, {
+    emitUiPromptEvent(events, {
+      protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
       requestId,
       source: "rpc_prompt",
+      surface: surface ?? null,
+      value: value ?? null,
       agentName: agentName ?? null,
       message,
       toolCallId: null,

--- a/packages/pi-permission-system/src/permission-event-rpc.ts
+++ b/packages/pi-permission-system/src/permission-event-rpc.ts
@@ -27,6 +27,7 @@ import {
   PERMISSIONS_RPC_PROMPT_CHANNEL,
 } from "./permission-events";
 import type { PermissionManager } from "./permission-manager";
+import { buildRpcUiPrompt } from "./permission-ui-prompt";
 import type { Rule } from "./rule";
 
 /** Dependencies injected into the RPC handler registry. */
@@ -156,23 +157,10 @@ async function handlePromptRpc(
       ? `Permission request${agentName ? ` from ${agentName}` : ""}`
       : "Permission request";
 
-    emitUiPromptEvent(events, {
-      protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
-      requestId,
-      source: "rpc_prompt",
-      surface: surface ?? null,
-      value: value ?? null,
-      agentName: agentName ?? null,
-      message,
-      toolCallId: null,
-      toolName: null,
-      skillName: null,
-      path: null,
-      command: null,
-      target: value ?? null,
-      toolInputPreview: null,
-      sessionLabel: sessionLabel ?? null,
-    });
+    emitUiPromptEvent(
+      events,
+      buildRpcUiPrompt({ requestId, surface, value, agentName, message }),
+    );
 
     const decision = await deps.requestPermissionDecisionFromUi(
       ctx.ui,

--- a/packages/pi-permission-system/src/permission-event-rpc.ts
+++ b/packages/pi-permission-system/src/permission-event-rpc.ts
@@ -21,6 +21,7 @@ import type {
   PermissionsRpcReply,
 } from "./permission-events";
 import {
+  emitPromptEvent,
   PERMISSIONS_PROTOCOL_VERSION,
   PERMISSIONS_RPC_CHECK_CHANNEL,
   PERMISSIONS_RPC_PROMPT_CHANNEL,
@@ -154,6 +155,21 @@ async function handlePromptRpc(
     const title = surface
       ? `Permission request${agentName ? ` from ${agentName}` : ""}`
       : "Permission request";
+
+    emitPromptEvent(events, {
+      requestId,
+      source: "rpc_prompt",
+      agentName: agentName ?? null,
+      message,
+      toolCallId: null,
+      toolName: null,
+      skillName: null,
+      path: null,
+      command: null,
+      target: value ?? null,
+      toolInputPreview: null,
+      sessionLabel: sessionLabel ?? null,
+    });
 
     const decision = await deps.requestPermissionDecisionFromUi(
       ctx.ui,

--- a/packages/pi-permission-system/src/permission-events.ts
+++ b/packages/pi-permission-system/src/permission-events.ts
@@ -27,8 +27,8 @@ export const PERMISSIONS_PROTOCOL_VERSION = 1;
 /** Emitted at `session_start`, after the service is published. */
 export const PERMISSIONS_READY_CHANNEL = "permissions:ready";
 
-/** Emitted when the user is being prompted for a permission decision. */
-export const PERMISSIONS_PROMPT_CHANNEL = "permissions:prompt";
+/** Emitted when a permission request is committed to the active UI prompt path. */
+export const PERMISSIONS_UI_PROMPT_CHANNEL = "permissions:ui_prompt";
 
 /** Emitted after every permission gate resolution. */
 export const PERMISSIONS_DECISION_CHANNEL = "permissions:decision";
@@ -69,14 +69,27 @@ export interface PermissionsReadyEvent {
   protocolVersion: number;
 }
 
-// ── permissions:prompt ─────────────────────────────────────────────────────
+// ── permissions:ui_prompt ──────────────────────────────────────────────────
 
-/** Payload emitted on `permissions:prompt`. */
-export interface PermissionPromptEvent {
+/** Payload emitted on `permissions:ui_prompt`. */
+export type PermissionUiPromptSource =
+  | "tool_call"
+  | "skill_input"
+  | "skill_read"
+  | "rpc_prompt"
+  | "forwarded_permission";
+
+export interface PermissionUiPromptEvent {
+  /** Protocol version for the cross-extension event contract. */
+  protocolVersion: number;
   /** Unique ID for the permission request being prompted. */
   requestId: string;
   /** Prompt source: tool call, skill input/read, RPC, forwarded subagent request, etc. */
-  source: string;
+  source: PermissionUiPromptSource;
+  /** Permission surface being evaluated, when known. */
+  surface: string | null;
+  /** Value being evaluated: command, path, skill name, tool target, etc. */
+  value: string | null;
   /** Agent name (when known). */
   agentName: string | null;
   /** Message displayed to the user. */
@@ -204,14 +217,19 @@ export function emitReadyEvent(events: PermissionEventBus): void {
 }
 
 /**
- * Emit a `permissions:prompt` broadcast.
- * Call immediately before showing or forwarding a permission prompt.
+ * Emit a `permissions:ui_prompt` broadcast.
+ * Call immediately before invoking the active user-facing permission UI.
  */
-export function emitPromptEvent(
+export function emitUiPromptEvent(
   events: PermissionEventBus,
-  event: PermissionPromptEvent,
+  event: PermissionUiPromptEvent,
 ): void {
-  events.emit(PERMISSIONS_PROMPT_CHANNEL, event);
+  try {
+    events.emit(PERMISSIONS_UI_PROMPT_CHANNEL, event);
+  } catch {
+    // UI-prompt broadcasts are observational. A consumer failure must not block
+    // the permission dialog itself.
+  }
 }
 
 /**

--- a/packages/pi-permission-system/src/permission-events.ts
+++ b/packages/pi-permission-system/src/permission-events.ts
@@ -64,10 +64,14 @@ export type PermissionsRpcReply<T = void> =
 
 // ── permissions:ready ──────────────────────────────────────────────────────
 
-/** Payload emitted on `permissions:ready`. */
-export interface PermissionsReadyEvent {
-  protocolVersion: number;
-}
+/**
+ * Payload emitted on `permissions:ready`.
+ *
+ * Intentionally empty: the channel is a readiness signal. Version negotiation
+ * lives in the RPC envelope (`PermissionsRpcReply`), not in broadcast payloads —
+ * the published types plus package semver define the broadcast contract.
+ */
+export type PermissionsReadyEvent = Record<string, never>;
 
 // ── permissions:ui_prompt ──────────────────────────────────────────────────
 
@@ -210,9 +214,7 @@ export interface PermissionsPromptReplyData {
  * reacting to ready can immediately resolve `getPermissionsService()`.
  */
 export function emitReadyEvent(events: PermissionEventBus): void {
-  const payload: PermissionsReadyEvent = {
-    protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
-  };
+  const payload: PermissionsReadyEvent = {};
   events.emit(PERMISSIONS_READY_CHANNEL, payload);
 }
 

--- a/packages/pi-permission-system/src/permission-events.ts
+++ b/packages/pi-permission-system/src/permission-events.ts
@@ -222,7 +222,12 @@ export interface PermissionsPromptReplyData {
  */
 export function emitReadyEvent(events: PermissionEventBus): void {
   const payload: PermissionsReadyEvent = {};
-  events.emit(PERMISSIONS_READY_CHANNEL, payload);
+  try {
+    events.emit(PERMISSIONS_READY_CHANNEL, payload);
+  } catch {
+    // Broadcasts are best-effort. A throwing listener must not block the
+    // permission system from completing session startup.
+  }
 }
 
 /**
@@ -249,5 +254,10 @@ export function emitDecisionEvent(
   events: PermissionEventBus,
   event: PermissionDecisionEvent,
 ): void {
-  events.emit(PERMISSIONS_DECISION_CHANNEL, event);
+  try {
+    events.emit(PERMISSIONS_DECISION_CHANNEL, event);
+  } catch {
+    // Broadcasts are best-effort. A throwing listener must not block the
+    // permission gate from resolving.
+  }
 }

--- a/packages/pi-permission-system/src/permission-events.ts
+++ b/packages/pi-permission-system/src/permission-events.ts
@@ -27,6 +27,9 @@ export const PERMISSIONS_PROTOCOL_VERSION = 1;
 /** Emitted at `session_start`, after the service is published. */
 export const PERMISSIONS_READY_CHANNEL = "permissions:ready";
 
+/** Emitted when the user is being prompted for a permission decision. */
+export const PERMISSIONS_PROMPT_CHANNEL = "permissions:prompt";
+
 /** Emitted after every permission gate resolution. */
 export const PERMISSIONS_DECISION_CHANNEL = "permissions:decision";
 
@@ -64,6 +67,36 @@ export type PermissionsRpcReply<T = void> =
 /** Payload emitted on `permissions:ready`. */
 export interface PermissionsReadyEvent {
   protocolVersion: number;
+}
+
+// ── permissions:prompt ─────────────────────────────────────────────────────
+
+/** Payload emitted on `permissions:prompt`. */
+export interface PermissionPromptEvent {
+  /** Unique ID for the permission request being prompted. */
+  requestId: string;
+  /** Prompt source: tool call, skill input/read, RPC, forwarded subagent request, etc. */
+  source: string;
+  /** Agent name (when known). */
+  agentName: string | null;
+  /** Message displayed to the user. */
+  message: string;
+  /** Tool call ID (when the prompt is for a tool call). */
+  toolCallId: string | null;
+  /** Tool name (when the prompt is for a tool call). */
+  toolName: string | null;
+  /** Skill name (when the prompt is for a skill request). */
+  skillName: string | null;
+  /** Path being evaluated (when available). */
+  path: string | null;
+  /** Command being evaluated (when available). */
+  command: string | null;
+  /** Target being evaluated (when available). */
+  target: string | null;
+  /** Tool input preview shown in logs/prompts (when available). */
+  toolInputPreview: string | null;
+  /** Override label for the "for this session" dialog option. */
+  sessionLabel: string | null;
 }
 
 // ── permissions:decision ───────────────────────────────────────────────────
@@ -168,6 +201,17 @@ export function emitReadyEvent(events: PermissionEventBus): void {
     protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
   };
   events.emit(PERMISSIONS_READY_CHANNEL, payload);
+}
+
+/**
+ * Emit a `permissions:prompt` broadcast.
+ * Call immediately before showing or forwarding a permission prompt.
+ */
+export function emitPromptEvent(
+  events: PermissionEventBus,
+  event: PermissionPromptEvent,
+): void {
+  events.emit(PERMISSIONS_PROMPT_CHANNEL, event);
 }
 
 /**

--- a/packages/pi-permission-system/src/permission-events.ts
+++ b/packages/pi-permission-system/src/permission-events.ts
@@ -75,45 +75,52 @@ export type PermissionsReadyEvent = Record<string, never>;
 
 // ── permissions:ui_prompt ──────────────────────────────────────────────────
 
-/** Payload emitted on `permissions:ui_prompt`. */
+/**
+ * Origin of a UI prompt.
+ *
+ * Forwarding is orthogonal to origin: a forwarded subagent prompt keeps its
+ * original source and is identified by a non-null `forwarding` field, not by a
+ * dedicated source value.
+ */
 export type PermissionUiPromptSource =
   | "tool_call"
   | "skill_input"
   | "skill_read"
-  | "rpc_prompt"
-  | "forwarded_permission";
+  | "rpc_prompt";
 
+/** Forwarding context, present only when a prompt was forwarded from a non-UI subagent. */
+export interface ForwardedPromptContext {
+  /** Requesting subagent's display name, when known. */
+  requesterAgentName: string | null;
+  /** Requesting subagent's session id, when known. */
+  requesterSessionId: string | null;
+}
+
+/**
+ * Payload emitted on `permissions:ui_prompt`, immediately before the active
+ * user-facing permission UI is shown.
+ *
+ * Lean by design: `surface`/`value` are the normalized display projection a
+ * notification consumer reads; `source` is the origin; `forwarding` is non-null
+ * only for forwarded subagent prompts. There is no `protocolVersion` — the
+ * published types plus package semver define the broadcast contract, and
+ * consumers should read defensively.
+ */
 export interface PermissionUiPromptEvent {
-  /** Protocol version for the cross-extension event contract. */
-  protocolVersion: number;
   /** Unique ID for the permission request being prompted. */
   requestId: string;
-  /** Prompt source: tool call, skill input/read, RPC, forwarded subagent request, etc. */
+  /** Prompt origin. */
   source: PermissionUiPromptSource;
-  /** Permission surface being evaluated, when known. */
+  /** Normalized display surface (e.g. "bash", "skill"), when known. */
   surface: string | null;
-  /** Value being evaluated: command, path, skill name, tool target, etc. */
+  /** Normalized display value (command, path, skill name, etc.), when known. */
   value: string | null;
   /** Agent name (when known). */
   agentName: string | null;
   /** Message displayed to the user. */
   message: string;
-  /** Tool call ID (when the prompt is for a tool call). */
-  toolCallId: string | null;
-  /** Tool name (when the prompt is for a tool call). */
-  toolName: string | null;
-  /** Skill name (when the prompt is for a skill request). */
-  skillName: string | null;
-  /** Path being evaluated (when available). */
-  path: string | null;
-  /** Command being evaluated (when available). */
-  command: string | null;
-  /** Target being evaluated (when available). */
-  target: string | null;
-  /** Tool input preview shown in logs/prompts (when available). */
-  toolInputPreview: string | null;
-  /** Override label for the "for this session" dialog option. */
-  sessionLabel: string | null;
+  /** Forwarding context, or null for a direct prompt. */
+  forwarding: ForwardedPromptContext | null;
 }
 
 // ── permissions:decision ───────────────────────────────────────────────────

--- a/packages/pi-permission-system/src/permission-forwarding.ts
+++ b/packages/pi-permission-system/src/permission-forwarding.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 
 import type { PermissionDecisionState } from "./permission-dialog";
+import type { PermissionUiPromptSource } from "./permission-events";
 import type { SubagentSessionRegistry } from "./subagent-registry";
 
 export const PERMISSION_FORWARDING_POLL_INTERVAL_MS = 250;
@@ -38,6 +39,19 @@ const SESSION_FORWARDING_ROOT_DIRECTORY_NAME = "sessions";
 const SESSION_FORWARDING_REQUESTS_DIRECTORY_NAME = "requests";
 const SESSION_FORWARDING_RESPONSES_DIRECTORY_NAME = "responses";
 
+/**
+ * Display fields relayed from a forwarding child to the parent UI so the parent
+ * can emit a non-degraded `permissions:ui_prompt` event.
+ *
+ * Carried separately from the prompt message because the parent reconstructs
+ * the original event through `buildForwardedUiPrompt`, not from the message text.
+ */
+export interface ForwardedPromptDisplay {
+  source: PermissionUiPromptSource;
+  surface: string | null;
+  value: string | null;
+}
+
 export type ForwardedPermissionRequest = {
   id: string;
   createdAt: number;
@@ -45,6 +59,15 @@ export type ForwardedPermissionRequest = {
   targetSessionId: string;
   requesterAgentName: string;
   message: string;
+  /**
+   * Original prompt display fields, persisted so the parent emits a
+   * non-degraded event. Optional for version-skew tolerance: a parent on a
+   * newer version may read a request written by an older child during an
+   * upgrade, in which case the reader defaults `source` to `"tool_call"`.
+   */
+  source?: PermissionUiPromptSource;
+  surface?: string | null;
+  value?: string | null;
 };
 
 export type ForwardedPermissionResponse = {

--- a/packages/pi-permission-system/src/permission-prompter.ts
+++ b/packages/pi-permission-system/src/permission-prompter.ts
@@ -9,8 +9,11 @@ import type {
   PermissionPromptDecision,
   RequestPermissionOptions,
 } from "./permission-dialog";
-import type { PermissionEventBus } from "./permission-events";
-import { emitPromptEvent } from "./permission-events";
+import {
+  PERMISSIONS_PROTOCOL_VERSION,
+  type PermissionEventBus,
+  type PermissionUiPromptEvent,
+} from "./permission-events";
 import type { SubagentSessionRegistry } from "./subagent-registry";
 import { shouldAutoApprovePermissionState } from "./yolo-mode";
 
@@ -31,6 +34,46 @@ export interface PromptPermissionDetails {
   toolInputPreview?: string;
   /** Override label for the "for this session" dialog option. */
   sessionLabel?: string;
+}
+
+function promptSurface(details: PromptPermissionDetails): string | null {
+  if (details.source === "skill_input" || details.source === "skill_read") {
+    return "skill";
+  }
+  return details.toolName ?? null;
+}
+
+function promptValue(details: PromptPermissionDetails): string | null {
+  return (
+    details.command ??
+    details.path ??
+    details.target ??
+    details.skillName ??
+    details.toolName ??
+    null
+  );
+}
+
+function buildUiPromptEvent(
+  details: PromptPermissionDetails,
+): PermissionUiPromptEvent {
+  return {
+    protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
+    requestId: details.requestId,
+    source: details.source,
+    surface: promptSurface(details),
+    value: promptValue(details),
+    agentName: details.agentName,
+    message: details.message,
+    toolCallId: details.toolCallId ?? null,
+    toolName: details.toolName ?? null,
+    skillName: details.skillName ?? null,
+    path: details.path ?? null,
+    command: details.command ?? null,
+    target: details.target ?? null,
+    toolInputPreview: details.toolInputPreview ?? null,
+    sessionLabel: details.sessionLabel ?? null,
+  };
 }
 
 /** Mockable contract for permission prompting. */
@@ -59,7 +102,7 @@ export interface PermissionPrompterDeps {
   forwardingDir: string;
   /** In-process subagent session registry for detection and forwarding target resolution. */
   registry?: SubagentSessionRegistry;
-  /** Event bus used for permission prompt broadcasts. */
+  /** Event bus used for UI prompt broadcasts. */
   events: PermissionEventBus;
   /** Show the interactive permission dialog in the UI. */
   requestPermissionDecisionFromUi(
@@ -94,26 +137,13 @@ export class PermissionPrompter implements PermissionPrompterApi {
     }
 
     this.writeReviewEntry("permission_request.waiting", details);
-    emitPromptEvent(this.deps.events, {
-      requestId: details.requestId,
-      source: details.source,
-      agentName: details.agentName,
-      message: details.message,
-      toolCallId: details.toolCallId ?? null,
-      toolName: details.toolName ?? null,
-      skillName: details.skillName ?? null,
-      path: details.path ?? null,
-      command: details.command ?? null,
-      target: details.target ?? null,
-      toolInputPreview: details.toolInputPreview ?? null,
-      sessionLabel: details.sessionLabel ?? null,
-    });
 
     const decision = await confirmPermission(
       ctx,
       details.message,
       this.buildForwardingDeps(),
       details.sessionLabel ? { sessionLabel: details.sessionLabel } : undefined,
+      buildUiPromptEvent(details),
     );
 
     this.writeReviewEntry(
@@ -177,6 +207,7 @@ export class PermissionPrompter implements PermissionPrompterApi {
       forwardingDir: deps.forwardingDir,
       subagentSessionsDir: deps.subagentSessionsDir,
       registry: deps.registry,
+      events: deps.events,
       logger,
       // eslint-disable-next-line @typescript-eslint/unbound-method -- logger methods are plain function closures; no this-binding issue
       writeReviewLog: deps.writeReviewLog,

--- a/packages/pi-permission-system/src/permission-prompter.ts
+++ b/packages/pi-permission-system/src/permission-prompter.ts
@@ -98,11 +98,13 @@ export class PermissionPrompter implements PermissionPrompterApi {
 
     this.writeReviewEntry("permission_request.waiting", details);
 
-    // Emit the UI-prompt broadcast only when this session shows the dialog
-    // itself. Non-UI (forwarded) prompts are emitted by the parent that
-    // actually renders the forwarded dialog, not here.
+    // Build the event once. When this session has UI it broadcasts directly;
+    // when it does not (a forwarding subagent), the display fields ride along
+    // to the parent so the parent emits a non-degraded event from the
+    // forwarded path instead of here.
+    const uiPrompt = buildDirectUiPrompt(details);
     if (ctx.hasUI) {
-      emitUiPromptEvent(this.deps.events, buildDirectUiPrompt(details));
+      emitUiPromptEvent(this.deps.events, uiPrompt);
     }
 
     const decision = await confirmPermission(
@@ -110,6 +112,11 @@ export class PermissionPrompter implements PermissionPrompterApi {
       details.message,
       this.buildForwardingDeps(),
       details.sessionLabel ? { sessionLabel: details.sessionLabel } : undefined,
+      {
+        source: uiPrompt.source,
+        surface: uiPrompt.surface,
+        value: uiPrompt.value,
+      },
     );
 
     this.writeReviewEntry(

--- a/packages/pi-permission-system/src/permission-prompter.ts
+++ b/packages/pi-permission-system/src/permission-prompter.ts
@@ -9,6 +9,8 @@ import type {
   PermissionPromptDecision,
   RequestPermissionOptions,
 } from "./permission-dialog";
+import type { PermissionEventBus } from "./permission-events";
+import { emitPromptEvent } from "./permission-events";
 import type { SubagentSessionRegistry } from "./subagent-registry";
 import { shouldAutoApprovePermissionState } from "./yolo-mode";
 
@@ -57,6 +59,8 @@ export interface PermissionPrompterDeps {
   forwardingDir: string;
   /** In-process subagent session registry for detection and forwarding target resolution. */
   registry?: SubagentSessionRegistry;
+  /** Event bus used for permission prompt broadcasts. */
+  events: PermissionEventBus;
   /** Show the interactive permission dialog in the UI. */
   requestPermissionDecisionFromUi(
     ui: ExtensionContext["ui"],
@@ -90,6 +94,20 @@ export class PermissionPrompter implements PermissionPrompterApi {
     }
 
     this.writeReviewEntry("permission_request.waiting", details);
+    emitPromptEvent(this.deps.events, {
+      requestId: details.requestId,
+      source: details.source,
+      agentName: details.agentName,
+      message: details.message,
+      toolCallId: details.toolCallId ?? null,
+      toolName: details.toolName ?? null,
+      skillName: details.skillName ?? null,
+      path: details.path ?? null,
+      command: details.command ?? null,
+      target: details.target ?? null,
+      toolInputPreview: details.toolInputPreview ?? null,
+      sessionLabel: details.sessionLabel ?? null,
+    });
 
     const decision = await confirmPermission(
       ctx,

--- a/packages/pi-permission-system/src/permission-prompter.ts
+++ b/packages/pi-permission-system/src/permission-prompter.ts
@@ -10,10 +10,10 @@ import type {
   RequestPermissionOptions,
 } from "./permission-dialog";
 import {
-  PERMISSIONS_PROTOCOL_VERSION,
+  emitUiPromptEvent,
   type PermissionEventBus,
-  type PermissionUiPromptEvent,
 } from "./permission-events";
+import { buildDirectUiPrompt } from "./permission-ui-prompt";
 import type { SubagentSessionRegistry } from "./subagent-registry";
 import { shouldAutoApprovePermissionState } from "./yolo-mode";
 
@@ -34,46 +34,6 @@ export interface PromptPermissionDetails {
   toolInputPreview?: string;
   /** Override label for the "for this session" dialog option. */
   sessionLabel?: string;
-}
-
-function promptSurface(details: PromptPermissionDetails): string | null {
-  if (details.source === "skill_input" || details.source === "skill_read") {
-    return "skill";
-  }
-  return details.toolName ?? null;
-}
-
-function promptValue(details: PromptPermissionDetails): string | null {
-  return (
-    details.command ??
-    details.path ??
-    details.target ??
-    details.skillName ??
-    details.toolName ??
-    null
-  );
-}
-
-function buildUiPromptEvent(
-  details: PromptPermissionDetails,
-): PermissionUiPromptEvent {
-  return {
-    protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
-    requestId: details.requestId,
-    source: details.source,
-    surface: promptSurface(details),
-    value: promptValue(details),
-    agentName: details.agentName,
-    message: details.message,
-    toolCallId: details.toolCallId ?? null,
-    toolName: details.toolName ?? null,
-    skillName: details.skillName ?? null,
-    path: details.path ?? null,
-    command: details.command ?? null,
-    target: details.target ?? null,
-    toolInputPreview: details.toolInputPreview ?? null,
-    sessionLabel: details.sessionLabel ?? null,
-  };
 }
 
 /** Mockable contract for permission prompting. */
@@ -138,12 +98,18 @@ export class PermissionPrompter implements PermissionPrompterApi {
 
     this.writeReviewEntry("permission_request.waiting", details);
 
+    // Emit the UI-prompt broadcast only when this session shows the dialog
+    // itself. Non-UI (forwarded) prompts are emitted by the parent that
+    // actually renders the forwarded dialog, not here.
+    if (ctx.hasUI) {
+      emitUiPromptEvent(this.deps.events, buildDirectUiPrompt(details));
+    }
+
     const decision = await confirmPermission(
       ctx,
       details.message,
       this.buildForwardingDeps(),
       details.sessionLabel ? { sessionLabel: details.sessionLabel } : undefined,
-      buildUiPromptEvent(details),
     );
 
     this.writeReviewEntry(

--- a/packages/pi-permission-system/src/permission-ui-prompt.ts
+++ b/packages/pi-permission-system/src/permission-ui-prompt.ts
@@ -1,0 +1,127 @@
+/**
+ * Centralized construction for `permissions:ui_prompt` payloads.
+ *
+ * Every emit site builds its event through one of these functions, so the
+ * public contract's shape — including the normalized `surface`/`value`
+ * projection — lives in exactly one place and cannot drift by source.
+ *
+ * This module is a leaf: it owns narrow input types that each call site's
+ * domain object satisfies structurally, so it imports nothing from the
+ * prompter, RPC, or forwarding modules (no import cycles, correct layering).
+ */
+
+import type {
+  PermissionUiPromptEvent,
+  PermissionUiPromptSource,
+} from "./permission-events";
+
+/** Input for a direct (non-forwarded) tool or skill prompt. */
+export interface DirectPromptInput {
+  requestId: string;
+  source: "tool_call" | "skill_input" | "skill_read";
+  agentName: string | null;
+  message: string;
+  toolName?: string;
+  skillName?: string;
+  path?: string;
+  command?: string;
+  target?: string;
+}
+
+/** Input for a `permissions:rpc:prompt` forwarded UI prompt. */
+export interface RpcPromptInput {
+  requestId: string;
+  surface?: string | null;
+  value?: string | null;
+  agentName?: string | null;
+  message: string;
+}
+
+/** Input for a file-forwarded subagent prompt shown by the parent UI. */
+export interface ForwardedPromptInput {
+  requestId: string;
+  message: string;
+  requesterAgentName: string | null;
+  requesterSessionId: string | null;
+  /** Original prompt origin, when the forwarded request carries it. */
+  source?: PermissionUiPromptSource | null;
+  /** Original normalized surface, when the forwarded request carries it. */
+  surface?: string | null;
+  /** Original normalized value, when the forwarded request carries it. */
+  value?: string | null;
+}
+
+/** Normalized display surface for a direct prompt. */
+function directSurface(input: DirectPromptInput): string | null {
+  if (input.source === "skill_input" || input.source === "skill_read") {
+    return "skill";
+  }
+  return input.toolName ?? null;
+}
+
+/** Normalized display value for a direct prompt. */
+function directValue(input: DirectPromptInput): string | null {
+  return (
+    input.command ??
+    input.path ??
+    input.target ??
+    input.skillName ??
+    input.toolName ??
+    null
+  );
+}
+
+/** Build the UI prompt event for a direct tool/skill prompt. */
+export function buildDirectUiPrompt(
+  input: DirectPromptInput,
+): PermissionUiPromptEvent {
+  return {
+    requestId: input.requestId,
+    source: input.source,
+    surface: directSurface(input),
+    value: directValue(input),
+    agentName: input.agentName,
+    message: input.message,
+    forwarding: null,
+  };
+}
+
+/** Build the UI prompt event for an RPC-forwarded prompt. */
+export function buildRpcUiPrompt(
+  input: RpcPromptInput,
+): PermissionUiPromptEvent {
+  return {
+    requestId: input.requestId,
+    source: "rpc_prompt",
+    surface: input.surface ?? null,
+    value: input.value ?? null,
+    agentName: input.agentName ?? null,
+    message: input.message,
+    forwarding: null,
+  };
+}
+
+/**
+ * Build the UI prompt event for a file-forwarded subagent prompt.
+ *
+ * `source` defaults to `"tool_call"` (the dominant forwarded origin) when the
+ * persisted request predates carrying it — a parent on a newer version may read
+ * a request written by an older child during an upgrade. The consumer still
+ * receives the notify-now signal, message, and forwarding context.
+ */
+export function buildForwardedUiPrompt(
+  input: ForwardedPromptInput,
+): PermissionUiPromptEvent {
+  return {
+    requestId: input.requestId,
+    source: input.source ?? "tool_call",
+    surface: input.surface ?? null,
+    value: input.value ?? null,
+    agentName: input.requesterAgentName,
+    message: input.message,
+    forwarding: {
+      requesterAgentName: input.requesterAgentName,
+      requesterSessionId: input.requesterSessionId,
+    },
+  };
+}

--- a/packages/pi-permission-system/src/service.ts
+++ b/packages/pi-permission-system/src/service.ts
@@ -15,6 +15,25 @@ import type { ToolInputFormatter } from "./tool-input-formatter-registry";
 import type { PermissionCheckResult, PermissionState } from "./types";
 
 export type { PermissionCheckResult, PermissionState, ToolInputFormatter };
+export {
+  PERMISSIONS_DECISION_CHANNEL,
+  PERMISSIONS_PROTOCOL_VERSION,
+  PERMISSIONS_READY_CHANNEL,
+  PERMISSIONS_RPC_CHECK_CHANNEL,
+  PERMISSIONS_RPC_PROMPT_CHANNEL,
+  PERMISSIONS_UI_PROMPT_CHANNEL,
+} from "./permission-events";
+export type {
+  PermissionDecisionEvent,
+  PermissionsCheckReplyData,
+  PermissionsCheckRequest,
+  PermissionsPromptReplyData,
+  PermissionsPromptRequest,
+  PermissionsReadyEvent,
+  PermissionsRpcReply,
+  PermissionUiPromptEvent,
+  PermissionUiPromptSource,
+} from "./permission-events";
 
 /** Process-global key for the service slot. */
 const SERVICE_KEY = Symbol.for("@gotgenes/pi-permission-system:service");

--- a/packages/pi-permission-system/src/service.ts
+++ b/packages/pi-permission-system/src/service.ts
@@ -14,19 +14,8 @@
 import type { ToolInputFormatter } from "./tool-input-formatter-registry";
 import type { PermissionCheckResult, PermissionState } from "./types";
 
-export type { PermissionCheckResult, PermissionState, ToolInputFormatter };
-export {
-  PERMISSIONS_DECISION_CHANNEL,
-  PERMISSIONS_PROTOCOL_VERSION,
-  PERMISSIONS_READY_CHANNEL,
-  PERMISSIONS_RPC_CHECK_CHANNEL,
-  PERMISSIONS_RPC_PROMPT_CHANNEL,
-  PERMISSIONS_UI_PROMPT_CHANNEL,
-} from "./permission-events";
 export type {
   PermissionDecisionEvent,
-  PermissionsCheckReplyData,
-  PermissionsCheckRequest,
   PermissionsPromptReplyData,
   PermissionsPromptRequest,
   PermissionsReadyEvent,
@@ -34,6 +23,14 @@ export type {
   PermissionUiPromptEvent,
   PermissionUiPromptSource,
 } from "./permission-events";
+export {
+  PERMISSIONS_DECISION_CHANNEL,
+  PERMISSIONS_PROTOCOL_VERSION,
+  PERMISSIONS_READY_CHANNEL,
+  PERMISSIONS_RPC_PROMPT_CHANNEL,
+  PERMISSIONS_UI_PROMPT_CHANNEL,
+} from "./permission-events";
+export type { PermissionCheckResult, PermissionState, ToolInputFormatter };
 
 /** Process-global key for the service slot. */
 const SERVICE_KEY = Symbol.for("@gotgenes/pi-permission-system:service");

--- a/packages/pi-permission-system/src/service.ts
+++ b/packages/pi-permission-system/src/service.ts
@@ -15,6 +15,7 @@ import type { ToolInputFormatter } from "./tool-input-formatter-registry";
 import type { PermissionCheckResult, PermissionState } from "./types";
 
 export type {
+  ForwardedPromptContext,
   PermissionDecisionEvent,
   PermissionsPromptReplyData,
   PermissionsPromptRequest,

--- a/packages/pi-permission-system/test/composition-root.test.ts
+++ b/packages/pi-permission-system/test/composition-root.test.ts
@@ -256,6 +256,11 @@ describe("subagent registry sharing across factory instances", () => {
     );
     expect(request.targetSessionId).toBe(parentSessionId);
     expect(request.requesterSessionId).toBe(childSessionId);
+    // The child persists the original display fields so the parent emits a
+    // non-degraded `permissions:ui_prompt` event (forwarded non-degradation).
+    expect(request.source).toBe("tool_call");
+    expect(request.surface).toBe("read");
+    expect(request.value).toBe(join(externalDir, "secret.txt"));
 
     const result = (await firePromise) as { block?: true };
     expect(result.block).toBeUndefined();

--- a/packages/pi-permission-system/test/permission-event-rpc.test.ts
+++ b/packages/pi-permission-system/test/permission-event-rpc.test.ts
@@ -11,9 +11,9 @@ import type {
 } from "#src/permission-events";
 import {
   PERMISSIONS_PROTOCOL_VERSION,
-  PERMISSIONS_PROMPT_CHANNEL,
   PERMISSIONS_RPC_CHECK_CHANNEL,
   PERMISSIONS_RPC_PROMPT_CHANNEL,
+  PERMISSIONS_UI_PROMPT_CHANNEL,
 } from "#src/permission-events";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -318,7 +318,7 @@ describe("registerPermissionRpcHandlers — permissions:rpc:prompt", () => {
     }
   });
 
-  it("emits a prompt broadcast before awaiting the UI decision", async () => {
+  it("emits a UI prompt broadcast before awaiting the UI decision", async () => {
     const bus = createEventBus();
     const ctx = makeCtxWithUi();
     const requestUi = vi
@@ -330,7 +330,7 @@ describe("registerPermissionRpcHandlers — permissions:rpc:prompt", () => {
     });
     registerPermissionRpcHandlers(bus, deps);
 
-    const promptPromise = waitForReply(bus, PERMISSIONS_PROMPT_CHANNEL);
+    const promptPromise = waitForReply(bus, PERMISSIONS_UI_PROMPT_CHANNEL);
     const replyPromise = waitForReply(
       bus,
       `${PERMISSIONS_RPC_PROMPT_CHANNEL}:reply:req-prompt-broadcast`,
@@ -345,8 +345,11 @@ describe("registerPermissionRpcHandlers — permissions:rpc:prompt", () => {
     });
 
     await expect(promptPromise).resolves.toEqual({
+      protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
       requestId: "req-prompt-broadcast",
       source: "rpc_prompt",
+      surface: "bash",
+      value: "git push",
       agentName: "Worker",
       message: "Allow git push?",
       toolCallId: null,

--- a/packages/pi-permission-system/test/permission-event-rpc.test.ts
+++ b/packages/pi-permission-system/test/permission-event-rpc.test.ts
@@ -11,6 +11,7 @@ import type {
 } from "#src/permission-events";
 import {
   PERMISSIONS_PROTOCOL_VERSION,
+  PERMISSIONS_PROMPT_CHANNEL,
   PERMISSIONS_RPC_CHECK_CHANNEL,
   PERMISSIONS_RPC_PROMPT_CHANNEL,
 } from "#src/permission-events";
@@ -315,6 +316,49 @@ describe("registerPermissionRpcHandlers — permissions:rpc:prompt", () => {
       expect(reply.data?.approved).toBe(true);
       expect(reply.data?.state).toBe("approved");
     }
+  });
+
+  it("emits a prompt broadcast before awaiting the UI decision", async () => {
+    const bus = createEventBus();
+    const ctx = makeCtxWithUi();
+    const requestUi = vi
+      .fn()
+      .mockResolvedValue({ approved: true, state: "approved" as const });
+    const deps = makeDeps({
+      getRuntimeContext: vi.fn().mockReturnValue(ctx),
+      requestPermissionDecisionFromUi: requestUi,
+    });
+    registerPermissionRpcHandlers(bus, deps);
+
+    const promptPromise = waitForReply(bus, PERMISSIONS_PROMPT_CHANNEL);
+    const replyPromise = waitForReply(
+      bus,
+      `${PERMISSIONS_RPC_PROMPT_CHANNEL}:reply:req-prompt-broadcast`,
+    );
+    bus.emit(PERMISSIONS_RPC_PROMPT_CHANNEL, {
+      requestId: "req-prompt-broadcast",
+      surface: "bash",
+      value: "git push",
+      message: "Allow git push?",
+      agentName: "Worker",
+      sessionLabel: "Allow git *",
+    });
+
+    await expect(promptPromise).resolves.toEqual({
+      requestId: "req-prompt-broadcast",
+      source: "rpc_prompt",
+      agentName: "Worker",
+      message: "Allow git push?",
+      toolCallId: null,
+      toolName: null,
+      skillName: null,
+      path: null,
+      command: null,
+      target: "git push",
+      toolInputPreview: null,
+      sessionLabel: "Allow git *",
+    });
+    await replyPromise;
   });
 
   it("passes the message to requestPermissionDecisionFromUi", async () => {

--- a/packages/pi-permission-system/test/permission-event-rpc.test.ts
+++ b/packages/pi-permission-system/test/permission-event-rpc.test.ts
@@ -345,21 +345,13 @@ describe("registerPermissionRpcHandlers — permissions:rpc:prompt", () => {
     });
 
     await expect(promptPromise).resolves.toEqual({
-      protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
       requestId: "req-prompt-broadcast",
       source: "rpc_prompt",
       surface: "bash",
       value: "git push",
       agentName: "Worker",
       message: "Allow git push?",
-      toolCallId: null,
-      toolName: null,
-      skillName: null,
-      path: null,
-      command: null,
-      target: "git push",
-      toolInputPreview: null,
-      sessionLabel: "Allow git *",
+      forwarding: null,
     });
     await replyPromise;
   });

--- a/packages/pi-permission-system/test/permission-events.test.ts
+++ b/packages/pi-permission-system/test/permission-events.test.ts
@@ -56,20 +56,18 @@ describe("constants", () => {
 // ── emitReadyEvent ─────────────────────────────────────────────────────────
 
 describe("emitReadyEvent", () => {
-  it("emits on the permissions:ready channel with protocol version", () => {
+  it("emits an empty payload on the permissions:ready channel", () => {
     const bus = makeEventBus();
     emitReadyEvent(bus);
     expect(bus.emit).toHaveBeenCalledOnce();
-    expect(bus.emit).toHaveBeenCalledWith("permissions:ready", {
-      protocolVersion: 1,
-    });
+    expect(bus.emit).toHaveBeenCalledWith("permissions:ready", {});
   });
 
-  it("emitted payload satisfies PermissionsReadyEvent shape", () => {
+  it("carries no protocolVersion (version lives in the RPC envelope)", () => {
     const bus = makeEventBus();
     emitReadyEvent(bus);
     const payload = bus.emit.mock.calls[0][1] as PermissionsReadyEvent;
-    expect(typeof payload.protocolVersion).toBe("number");
+    expect(payload).not.toHaveProperty("protocolVersion");
   });
 });
 
@@ -342,7 +340,7 @@ describe("piPermissionSystemExtension ready event wiring", () => {
     rmSync(baseDir, { recursive: true, force: true });
   });
 
-  it("emits permissions:ready with protocolVersion at session_start", async () => {
+  it("emits permissions:ready at session_start", async () => {
     const emitSpy = vi.fn();
     const handlers = new Map<
       string,
@@ -387,8 +385,6 @@ describe("piPermissionSystemExtension ready event wiring", () => {
       ([channel]) => channel === PERMISSIONS_READY_CHANNEL,
     );
     expect(readyCalls).toHaveLength(1);
-    expect(readyCalls[0][1]).toEqual({
-      protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
-    });
+    expect(readyCalls[0][1]).toEqual({});
   });
 });

--- a/packages/pi-permission-system/test/permission-events.test.ts
+++ b/packages/pi-permission-system/test/permission-events.test.ts
@@ -8,7 +8,7 @@ import { getGlobalConfigPath } from "#src/config-paths";
 import piPermissionSystemExtension from "#src/index";
 import type {
   PermissionDecisionEvent,
-  PermissionPromptEvent,
+  PermissionUiPromptEvent,
   PermissionsCheckReplyData,
   PermissionsCheckRequest,
   PermissionsPromptReplyData,
@@ -18,14 +18,14 @@ import type {
 } from "#src/permission-events";
 import {
   emitDecisionEvent,
-  emitPromptEvent,
   emitReadyEvent,
+  emitUiPromptEvent,
   PERMISSIONS_DECISION_CHANNEL,
-  PERMISSIONS_PROMPT_CHANNEL,
   PERMISSIONS_PROTOCOL_VERSION,
   PERMISSIONS_READY_CHANNEL,
   PERMISSIONS_RPC_CHECK_CHANNEL,
   PERMISSIONS_RPC_PROMPT_CHANNEL,
+  PERMISSIONS_UI_PROMPT_CHANNEL,
 } from "#src/permission-events";
 
 // ── Minimal EventBus stub ──────────────────────────────────────────────────
@@ -46,7 +46,7 @@ describe("constants", () => {
 
   it("channel names have the correct values", () => {
     expect(PERMISSIONS_READY_CHANNEL).toBe("permissions:ready");
-    expect(PERMISSIONS_PROMPT_CHANNEL).toBe("permissions:prompt");
+    expect(PERMISSIONS_UI_PROMPT_CHANNEL).toBe("permissions:ui_prompt");
     expect(PERMISSIONS_DECISION_CHANNEL).toBe("permissions:decision");
     expect(PERMISSIONS_RPC_CHECK_CHANNEL).toBe("permissions:rpc:check");
     expect(PERMISSIONS_RPC_PROMPT_CHANNEL).toBe("permissions:rpc:prompt");
@@ -73,15 +73,18 @@ describe("emitReadyEvent", () => {
   });
 });
 
-// ── emitPromptEvent ────────────────────────────────────────────────────────
+// ── emitUiPromptEvent ──────────────────────────────────────────────────────
 
-describe("emitPromptEvent", () => {
-  function makePromptEvent(
-    overrides: Partial<PermissionPromptEvent> = {},
-  ): PermissionPromptEvent {
+describe("emitUiPromptEvent", () => {
+  function makeUiPromptEvent(
+    overrides: Partial<PermissionUiPromptEvent> = {},
+  ): PermissionUiPromptEvent {
     return {
+      protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
       requestId: "req-123",
       source: "tool_call",
+      surface: "bash",
+      value: "git status",
       agentName: "Explore",
       message: "Allow git status?",
       toolCallId: "call-123",
@@ -96,18 +99,36 @@ describe("emitPromptEvent", () => {
     };
   }
 
-  it("emits on the permissions:prompt channel", () => {
+  it("emits on the permissions:ui_prompt channel", () => {
     const bus = makeEventBus();
-    emitPromptEvent(bus, makePromptEvent());
+    emitUiPromptEvent(bus, makeUiPromptEvent());
     expect(bus.emit).toHaveBeenCalledOnce();
-    expect(bus.emit.mock.calls[0][0]).toBe("permissions:prompt");
+    expect(bus.emit.mock.calls[0][0]).toBe("permissions:ui_prompt");
   });
 
   it("forwards the full payload unchanged", () => {
     const bus = makeEventBus();
-    const event = makePromptEvent({ sessionLabel: "Allow for session" });
-    emitPromptEvent(bus, event);
+    const event = makeUiPromptEvent({ sessionLabel: "Allow for session" });
+    emitUiPromptEvent(bus, event);
     expect(bus.emit.mock.calls[0][1]).toEqual(event);
+  });
+
+  it("includes the protocol version in UI prompt events", () => {
+    const bus = makeEventBus();
+    emitUiPromptEvent(bus, makeUiPromptEvent());
+    const payload = bus.emit.mock.calls[0][1] as PermissionUiPromptEvent;
+    expect(payload.protocolVersion).toBe(PERMISSIONS_PROTOCOL_VERSION);
+  });
+
+  it("swallows event bus errors because UI prompt broadcasts are observational", () => {
+    const bus = {
+      emit: vi.fn(() => {
+        throw new Error("listener failed");
+      }),
+      on: vi.fn().mockReturnValue(() => undefined),
+    };
+
+    expect(() => emitUiPromptEvent(bus, makeUiPromptEvent())).not.toThrow();
   });
 });
 

--- a/packages/pi-permission-system/test/permission-events.test.ts
+++ b/packages/pi-permission-system/test/permission-events.test.ts
@@ -8,6 +8,7 @@ import { getGlobalConfigPath } from "#src/config-paths";
 import piPermissionSystemExtension from "#src/index";
 import type {
   PermissionDecisionEvent,
+  PermissionPromptEvent,
   PermissionsCheckReplyData,
   PermissionsCheckRequest,
   PermissionsPromptReplyData,
@@ -17,8 +18,10 @@ import type {
 } from "#src/permission-events";
 import {
   emitDecisionEvent,
+  emitPromptEvent,
   emitReadyEvent,
   PERMISSIONS_DECISION_CHANNEL,
+  PERMISSIONS_PROMPT_CHANNEL,
   PERMISSIONS_PROTOCOL_VERSION,
   PERMISSIONS_READY_CHANNEL,
   PERMISSIONS_RPC_CHECK_CHANNEL,
@@ -43,6 +46,7 @@ describe("constants", () => {
 
   it("channel names have the correct values", () => {
     expect(PERMISSIONS_READY_CHANNEL).toBe("permissions:ready");
+    expect(PERMISSIONS_PROMPT_CHANNEL).toBe("permissions:prompt");
     expect(PERMISSIONS_DECISION_CHANNEL).toBe("permissions:decision");
     expect(PERMISSIONS_RPC_CHECK_CHANNEL).toBe("permissions:rpc:check");
     expect(PERMISSIONS_RPC_PROMPT_CHANNEL).toBe("permissions:rpc:prompt");
@@ -66,6 +70,44 @@ describe("emitReadyEvent", () => {
     emitReadyEvent(bus);
     const payload = bus.emit.mock.calls[0][1] as PermissionsReadyEvent;
     expect(typeof payload.protocolVersion).toBe("number");
+  });
+});
+
+// ── emitPromptEvent ────────────────────────────────────────────────────────
+
+describe("emitPromptEvent", () => {
+  function makePromptEvent(
+    overrides: Partial<PermissionPromptEvent> = {},
+  ): PermissionPromptEvent {
+    return {
+      requestId: "req-123",
+      source: "tool_call",
+      agentName: "Explore",
+      message: "Allow git status?",
+      toolCallId: "call-123",
+      toolName: "bash",
+      skillName: null,
+      path: null,
+      command: "git status",
+      target: null,
+      toolInputPreview: null,
+      sessionLabel: null,
+      ...overrides,
+    };
+  }
+
+  it("emits on the permissions:prompt channel", () => {
+    const bus = makeEventBus();
+    emitPromptEvent(bus, makePromptEvent());
+    expect(bus.emit).toHaveBeenCalledOnce();
+    expect(bus.emit.mock.calls[0][0]).toBe("permissions:prompt");
+  });
+
+  it("forwards the full payload unchanged", () => {
+    const bus = makeEventBus();
+    const event = makePromptEvent({ sessionLabel: "Allow for session" });
+    emitPromptEvent(bus, event);
+    expect(bus.emit.mock.calls[0][1]).toEqual(event);
   });
 });
 

--- a/packages/pi-permission-system/test/permission-events.test.ts
+++ b/packages/pi-permission-system/test/permission-events.test.ts
@@ -78,21 +78,13 @@ describe("emitUiPromptEvent", () => {
     overrides: Partial<PermissionUiPromptEvent> = {},
   ): PermissionUiPromptEvent {
     return {
-      protocolVersion: PERMISSIONS_PROTOCOL_VERSION,
       requestId: "req-123",
       source: "tool_call",
       surface: "bash",
       value: "git status",
       agentName: "Explore",
       message: "Allow git status?",
-      toolCallId: "call-123",
-      toolName: "bash",
-      skillName: null,
-      path: null,
-      command: "git status",
-      target: null,
-      toolInputPreview: null,
-      sessionLabel: null,
+      forwarding: null,
       ...overrides,
     };
   }
@@ -106,16 +98,11 @@ describe("emitUiPromptEvent", () => {
 
   it("forwards the full payload unchanged", () => {
     const bus = makeEventBus();
-    const event = makeUiPromptEvent({ sessionLabel: "Allow for session" });
+    const event = makeUiPromptEvent({
+      forwarding: { requesterAgentName: "Worker", requesterSessionId: "child" },
+    });
     emitUiPromptEvent(bus, event);
     expect(bus.emit.mock.calls[0][1]).toEqual(event);
-  });
-
-  it("includes the protocol version in UI prompt events", () => {
-    const bus = makeEventBus();
-    emitUiPromptEvent(bus, makeUiPromptEvent());
-    const payload = bus.emit.mock.calls[0][1] as PermissionUiPromptEvent;
-    expect(payload.protocolVersion).toBe(PERMISSIONS_PROTOCOL_VERSION);
   });
 
   it("swallows event bus errors because UI prompt broadcasts are observational", () => {

--- a/packages/pi-permission-system/test/permission-events.test.ts
+++ b/packages/pi-permission-system/test/permission-events.test.ts
@@ -8,13 +8,13 @@ import { getGlobalConfigPath } from "#src/config-paths";
 import piPermissionSystemExtension from "#src/index";
 import type {
   PermissionDecisionEvent,
-  PermissionUiPromptEvent,
   PermissionsCheckReplyData,
   PermissionsCheckRequest,
   PermissionsPromptReplyData,
   PermissionsPromptRequest,
   PermissionsReadyEvent,
   PermissionsRpcReply,
+  PermissionUiPromptEvent,
 } from "#src/permission-events";
 import {
   emitDecisionEvent,

--- a/packages/pi-permission-system/test/permission-events.test.ts
+++ b/packages/pi-permission-system/test/permission-events.test.ts
@@ -69,6 +69,17 @@ describe("emitReadyEvent", () => {
     const payload = bus.emit.mock.calls[0][1] as PermissionsReadyEvent;
     expect(payload).not.toHaveProperty("protocolVersion");
   });
+
+  it("swallows event bus errors because broadcasts are best-effort", () => {
+    const bus = {
+      emit: vi.fn(() => {
+        throw new Error("listener failed");
+      }),
+      on: vi.fn().mockReturnValue(() => undefined),
+    };
+
+    expect(() => emitReadyEvent(bus)).not.toThrow();
+  });
 });
 
 // ── emitUiPromptEvent ──────────────────────────────────────────────────────
@@ -190,6 +201,17 @@ describe("emitDecisionEvent", () => {
     expect(payload.origin).toBeNull();
     expect(payload.agentName).toBeNull();
     expect(payload.matchedPattern).toBeNull();
+  });
+
+  it("swallows event bus errors because broadcasts are best-effort", () => {
+    const bus = {
+      emit: vi.fn(() => {
+        throw new Error("listener failed");
+      }),
+      on: vi.fn().mockReturnValue(() => undefined),
+    };
+
+    expect(() => emitDecisionEvent(bus, makeDecisionEvent())).not.toThrow();
   });
 });
 

--- a/packages/pi-permission-system/test/permission-forwarding.test.ts
+++ b/packages/pi-permission-system/test/permission-forwarding.test.ts
@@ -322,6 +322,80 @@ describe("processForwardedPermissionRequests", () => {
     }
   });
 
+  test("emits a non-degraded UI prompt event when the request carries display fields", async () => {
+    const root = mkdtempSync(join(tmpdir(), "permission-forwarding-"));
+    try {
+      const forwardingDir = join(root, "forwarding");
+      const location = createPermissionForwardingLocation(
+        forwardingDir,
+        "parent-session",
+      );
+      mkdirSync(location.requestsDir, { recursive: true });
+      mkdirSync(location.responsesDir, { recursive: true });
+      writeFileSync(
+        join(location.requestsDir, "req-forwarded-rich.json"),
+        JSON.stringify({
+          id: "req-forwarded-rich",
+          createdAt: Date.now(),
+          requesterSessionId: "child-session",
+          targetSessionId: "parent-session",
+          requesterAgentName: "Explore",
+          message: "Allow git push?",
+          source: "tool_call",
+          surface: "bash",
+          value: "git push",
+        }),
+        "utf-8",
+      );
+
+      const events = {
+        emit: vi.fn(),
+        on: vi.fn().mockReturnValue(() => undefined),
+      };
+      const requestPermissionDecisionFromUi = vi
+        .fn()
+        .mockResolvedValue({ approved: true, state: "approved" as const });
+
+      await processForwardedPermissionRequests(
+        {
+          hasUI: true,
+          ui: { select: vi.fn(), input: vi.fn() },
+          sessionManager: {
+            getSessionId: vi.fn().mockReturnValue("parent-session"),
+          },
+        } as unknown as ExtensionContext,
+        {
+          forwardingDir,
+          subagentSessionsDir: join(root, "subagents"),
+          events,
+          logger: { writeReviewLog: vi.fn(), writeDebugLog: vi.fn() },
+          writeReviewLog: vi.fn(),
+          requestPermissionDecisionFromUi,
+          shouldAutoApprove: () => false,
+        },
+      );
+
+      expect(events.emit).toHaveBeenCalledWith(
+        "permissions:ui_prompt",
+        expect.objectContaining({
+          requestId: "req-forwarded-rich",
+          source: "tool_call",
+          surface: "bash",
+          value: "git push",
+          agentName: "Explore",
+          message: expect.stringContaining("Allow git push?"),
+          forwarding: {
+            requesterAgentName: "Explore",
+            requesterSessionId: "child-session",
+          },
+        }),
+      );
+      expect(requestPermissionDecisionFromUi).toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test("does not emit a UI prompt event when forwarded permission auto-approves", async () => {
     const root = mkdtempSync(join(tmpdir(), "permission-forwarding-"));
     try {

--- a/packages/pi-permission-system/test/permission-forwarding.test.ts
+++ b/packages/pi-permission-system/test/permission-forwarding.test.ts
@@ -1,9 +1,19 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
+  confirmPermission,
+  processForwardedPermissionRequests,
+} from "#src/forwarded-permissions/polling";
+import {
+  createPermissionForwardingLocation,
   resolvePermissionForwardingTargetSessionId,
   SUBAGENT_PARENT_SESSION_ENV_CANDIDATES,
   SUBAGENT_PARENT_SESSION_ENV_KEY,
 } from "#src/permission-forwarding";
+import type { PermissionUiPromptEvent } from "#src/permission-events";
 import { SubagentSessionRegistry } from "#src/subagent-registry";
 
 afterEach(() => {
@@ -238,5 +248,223 @@ describe("resolvePermissionForwardingTargetSessionId — registry resolution", (
         env: { PI_AGENT_ROUTER_PARENT_SESSION_ID: "parent-from-env" },
       }),
     ).toBe("parent-from-env");
+  });
+});
+
+describe("processForwardedPermissionRequests", () => {
+  test("emits a UI prompt event before showing a forwarded permission dialog", async () => {
+    const root = mkdtempSync(join(tmpdir(), "permission-forwarding-"));
+    try {
+      const forwardingDir = join(root, "forwarding");
+      const location = createPermissionForwardingLocation(
+        forwardingDir,
+        "parent-session",
+      );
+      mkdirSync(location.requestsDir, { recursive: true });
+      mkdirSync(location.responsesDir, { recursive: true });
+      writeFileSync(
+        join(location.requestsDir, "req-forwarded.json"),
+        JSON.stringify({
+          id: "req-forwarded",
+          createdAt: Date.now(),
+          requesterSessionId: "child-session",
+          targetSessionId: "parent-session",
+          requesterAgentName: "Explore",
+          message: "Allow git push?",
+        }),
+        "utf-8",
+      );
+
+      const events = {
+        emit: vi.fn(),
+        on: vi.fn().mockReturnValue(() => undefined),
+      };
+      const requestPermissionDecisionFromUi = vi
+        .fn()
+        .mockResolvedValue({ approved: true, state: "approved" as const });
+
+      await processForwardedPermissionRequests(
+        {
+          hasUI: true,
+          ui: { select: vi.fn(), input: vi.fn() },
+          sessionManager: {
+            getSessionId: vi.fn().mockReturnValue("parent-session"),
+          },
+        } as unknown as ExtensionContext,
+        {
+          forwardingDir,
+          subagentSessionsDir: join(root, "subagents"),
+          events,
+          logger: { writeReviewLog: vi.fn(), writeDebugLog: vi.fn() },
+          writeReviewLog: vi.fn(),
+          requestPermissionDecisionFromUi,
+          shouldAutoApprove: () => false,
+        },
+      );
+
+      expect(events.emit).toHaveBeenCalledWith(
+        "permissions:ui_prompt",
+        expect.objectContaining({
+          protocolVersion: 1,
+          requestId: "req-forwarded",
+          source: "forwarded_permission",
+          surface: null,
+          value: "Allow git push?",
+          agentName: "Explore",
+          target: "Allow git push?",
+        }),
+      );
+      expect(requestPermissionDecisionFromUi).toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("does not emit a UI prompt event when forwarded permission auto-approves", async () => {
+    const root = mkdtempSync(join(tmpdir(), "permission-forwarding-"));
+    try {
+      const forwardingDir = join(root, "forwarding");
+      const location = createPermissionForwardingLocation(
+        forwardingDir,
+        "parent-session",
+      );
+      mkdirSync(location.requestsDir, { recursive: true });
+      mkdirSync(location.responsesDir, { recursive: true });
+      writeFileSync(
+        join(location.requestsDir, "req-forwarded-auto.json"),
+        JSON.stringify({
+          id: "req-forwarded-auto",
+          createdAt: Date.now(),
+          requesterSessionId: "child-session",
+          targetSessionId: "parent-session",
+          requesterAgentName: "Explore",
+          message: "Allow git push?",
+        }),
+        "utf-8",
+      );
+
+      const events = {
+        emit: vi.fn(),
+        on: vi.fn().mockReturnValue(() => undefined),
+      };
+      const requestPermissionDecisionFromUi = vi.fn();
+
+      await processForwardedPermissionRequests(
+        {
+          hasUI: true,
+          ui: { select: vi.fn(), input: vi.fn() },
+          sessionManager: {
+            getSessionId: vi.fn().mockReturnValue("parent-session"),
+          },
+        } as unknown as ExtensionContext,
+        {
+          forwardingDir,
+          subagentSessionsDir: join(root, "subagents"),
+          events,
+          logger: { writeReviewLog: vi.fn(), writeDebugLog: vi.fn() },
+          writeReviewLog: vi.fn(),
+          requestPermissionDecisionFromUi,
+          shouldAutoApprove: () => true,
+        },
+      );
+
+      expect(events.emit).not.toHaveBeenCalledWith(
+        "permissions:ui_prompt",
+        expect.anything(),
+      );
+      expect(requestPermissionDecisionFromUi).not.toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("confirmPermission", () => {
+  const uiPromptEvent: PermissionUiPromptEvent = {
+    protocolVersion: 1,
+    requestId: "req-ui",
+    source: "tool_call",
+    surface: "bash",
+    value: "git push",
+    agentName: null,
+    message: "Allow git push?",
+    toolCallId: "call-ui",
+    toolName: "bash",
+    skillName: null,
+    path: null,
+    command: "git push",
+    target: null,
+    toolInputPreview: null,
+    sessionLabel: null,
+  };
+
+  test("emits a UI prompt event only when the active UI prompt path is used", async () => {
+    const events = {
+      emit: vi.fn(),
+      on: vi.fn().mockReturnValue(() => undefined),
+    };
+    const requestPermissionDecisionFromUi = vi
+      .fn()
+      .mockResolvedValue({ approved: true, state: "approved" as const });
+
+    await confirmPermission(
+      {
+        hasUI: true,
+        ui: { select: vi.fn(), input: vi.fn() },
+      } as unknown as ExtensionContext,
+      "Allow git push?",
+      {
+        forwardingDir: "/tmp/forwarding",
+        subagentSessionsDir: "/tmp/subagents",
+        events,
+        logger: { writeReviewLog: vi.fn(), writeDebugLog: vi.fn() },
+        writeReviewLog: vi.fn(),
+        requestPermissionDecisionFromUi,
+        shouldAutoApprove: () => false,
+      },
+      undefined,
+      uiPromptEvent,
+    );
+
+    expect(events.emit).toHaveBeenCalledWith(
+      "permissions:ui_prompt",
+      uiPromptEvent,
+    );
+    expect(requestPermissionDecisionFromUi).toHaveBeenCalled();
+  });
+
+  test("does not emit a UI prompt event when no active UI prompt exists", async () => {
+    const events = {
+      emit: vi.fn(),
+      on: vi.fn().mockReturnValue(() => undefined),
+    };
+    const requestPermissionDecisionFromUi = vi.fn();
+
+    await confirmPermission(
+      {
+        hasUI: false,
+        sessionManager: {
+          getSessionDir: vi.fn().mockReturnValue(null),
+        },
+      } as unknown as ExtensionContext,
+      "Allow git push?",
+      {
+        forwardingDir: "/tmp/forwarding",
+        subagentSessionsDir: "/tmp/subagents",
+        events,
+        logger: { writeReviewLog: vi.fn(), writeDebugLog: vi.fn() },
+        writeReviewLog: vi.fn(),
+        requestPermissionDecisionFromUi,
+        shouldAutoApprove: () => false,
+      },
+      undefined,
+      uiPromptEvent,
+    );
+
+    expect(events.emit).not.toHaveBeenCalledWith(
+      "permissions:ui_prompt",
+      expect.anything(),
+    );
+    expect(requestPermissionDecisionFromUi).not.toHaveBeenCalled();
   });
 });

--- a/packages/pi-permission-system/test/permission-forwarding.test.ts
+++ b/packages/pi-permission-system/test/permission-forwarding.test.ts
@@ -7,13 +7,13 @@ import {
   confirmPermission,
   processForwardedPermissionRequests,
 } from "#src/forwarded-permissions/polling";
+import type { PermissionUiPromptEvent } from "#src/permission-events";
 import {
   createPermissionForwardingLocation,
   resolvePermissionForwardingTargetSessionId,
   SUBAGENT_PARENT_SESSION_ENV_CANDIDATES,
   SUBAGENT_PARENT_SESSION_ENV_KEY,
 } from "#src/permission-forwarding";
-import type { PermissionUiPromptEvent } from "#src/permission-events";
 import { SubagentSessionRegistry } from "#src/subagent-registry";
 
 afterEach(() => {

--- a/packages/pi-permission-system/test/permission-forwarding.test.ts
+++ b/packages/pi-permission-system/test/permission-forwarding.test.ts
@@ -7,7 +7,6 @@ import {
   confirmPermission,
   processForwardedPermissionRequests,
 } from "#src/forwarded-permissions/polling";
-import type { PermissionUiPromptEvent } from "#src/permission-events";
 import {
   createPermissionForwardingLocation,
   resolvePermissionForwardingTargetSessionId,
@@ -305,13 +304,16 @@ describe("processForwardedPermissionRequests", () => {
       expect(events.emit).toHaveBeenCalledWith(
         "permissions:ui_prompt",
         expect.objectContaining({
-          protocolVersion: 1,
           requestId: "req-forwarded",
-          source: "forwarded_permission",
+          source: "tool_call",
           surface: null,
-          value: "Allow git push?",
+          value: null,
           agentName: "Explore",
-          target: "Allow git push?",
+          message: expect.stringContaining("Allow git push?"),
+          forwarding: {
+            requesterAgentName: "Explore",
+            requesterSessionId: "child-session",
+          },
         }),
       );
       expect(requestPermissionDecisionFromUi).toHaveBeenCalled();
@@ -380,25 +382,7 @@ describe("processForwardedPermissionRequests", () => {
 });
 
 describe("confirmPermission", () => {
-  const uiPromptEvent: PermissionUiPromptEvent = {
-    protocolVersion: 1,
-    requestId: "req-ui",
-    source: "tool_call",
-    surface: "bash",
-    value: "git push",
-    agentName: null,
-    message: "Allow git push?",
-    toolCallId: "call-ui",
-    toolName: "bash",
-    skillName: null,
-    path: null,
-    command: "git push",
-    target: null,
-    toolInputPreview: null,
-    sessionLabel: null,
-  };
-
-  test("emits a UI prompt event only when the active UI prompt path is used", async () => {
+  test("shows the UI dialog but does not emit a UI prompt event (the prompter does)", async () => {
     const events = {
       emit: vi.fn(),
       on: vi.fn().mockReturnValue(() => undefined),
@@ -422,18 +406,16 @@ describe("confirmPermission", () => {
         requestPermissionDecisionFromUi,
         shouldAutoApprove: () => false,
       },
-      undefined,
-      uiPromptEvent,
     );
 
-    expect(events.emit).toHaveBeenCalledWith(
-      "permissions:ui_prompt",
-      uiPromptEvent,
-    );
     expect(requestPermissionDecisionFromUi).toHaveBeenCalled();
+    expect(events.emit).not.toHaveBeenCalledWith(
+      "permissions:ui_prompt",
+      expect.anything(),
+    );
   });
 
-  test("does not emit a UI prompt event when no active UI prompt exists", async () => {
+  test("does not show a dialog or emit when there is no active UI", async () => {
     const events = {
       emit: vi.fn(),
       on: vi.fn().mockReturnValue(() => undefined),
@@ -457,8 +439,6 @@ describe("confirmPermission", () => {
         requestPermissionDecisionFromUi,
         shouldAutoApprove: () => false,
       },
-      undefined,
-      uiPromptEvent,
     );
 
     expect(events.emit).not.toHaveBeenCalledWith(

--- a/packages/pi-permission-system/test/permission-prompter.test.ts
+++ b/packages/pi-permission-system/test/permission-prompter.test.ts
@@ -339,6 +339,30 @@ describe("PermissionPrompter", () => {
         expect.any(String),
         expect.anything(),
         { sessionLabel: "Yes, for 'read' tool" },
+        { source: "tool_call", surface: "read", value: "read" },
+      );
+    });
+
+    it("passes the display fields (source/surface/value) to confirmPermission", async () => {
+      mockConfirmPermission.mockResolvedValue({
+        approved: true,
+        state: "approved",
+      });
+      const deps = makeDeps();
+      const prompter = new PermissionPrompter(deps);
+      const details = makeDetails({
+        toolName: "bash",
+        command: "git push",
+      });
+
+      await prompter.prompt(makeCtx(false), details);
+
+      expect(mockConfirmPermission).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(String),
+        expect.anything(),
+        undefined,
+        { source: "tool_call", surface: "bash", value: "git push" },
       );
     });
 
@@ -357,6 +381,7 @@ describe("PermissionPrompter", () => {
         expect.any(String),
         expect.anything(),
         undefined,
+        { source: "tool_call", surface: "read", value: "read" },
       );
     });
 
@@ -376,6 +401,7 @@ describe("PermissionPrompter", () => {
         "Allow bash: git status?",
         expect.anything(),
         undefined,
+        { source: "tool_call", surface: "read", value: "read" },
       );
     });
   });

--- a/packages/pi-permission-system/test/permission-prompter.test.ts
+++ b/packages/pi-permission-system/test/permission-prompter.test.ts
@@ -72,8 +72,13 @@ describe("PermissionPrompter", () => {
 
   describe("yolo-mode auto-approve", () => {
     it("returns approved without calling confirmPermission when yoloMode is true", async () => {
+      const events = {
+        emit: vi.fn(),
+        on: vi.fn().mockReturnValue(() => undefined),
+      };
       const deps = makeDeps({
         getConfig: () => ({ ...DEFAULT_EXTENSION_CONFIG, yoloMode: true }),
+        events,
       });
       const prompter = new PermissionPrompter(deps);
 
@@ -85,6 +90,10 @@ describe("PermissionPrompter", () => {
         autoApproved: true,
       });
       expect(mockConfirmPermission).not.toHaveBeenCalled();
+      expect(events.emit).not.toHaveBeenCalledWith(
+        "permissions:ui_prompt",
+        expect.anything(),
+      );
     });
 
     it("logs permission_request.auto_approved in yolo mode", async () => {
@@ -152,6 +161,75 @@ describe("PermissionPrompter", () => {
       ).toBeGreaterThanOrEqual(0);
       expect(calls.indexOf("permission_request.waiting")).toBeLessThan(
         calls.indexOf("permission_request.approved"),
+      );
+    });
+
+    it("passes a UI prompt event with normalized surface and value to confirmPermission", async () => {
+      const events = {
+        emit: vi.fn(),
+        on: vi.fn().mockReturnValue(() => undefined),
+      };
+      mockConfirmPermission.mockResolvedValue({
+        approved: true,
+        state: "approved",
+      });
+      const deps = makeDeps({ events });
+      const prompter = new PermissionPrompter(deps);
+
+      await prompter.prompt(
+        makeCtx(true),
+        makeDetails({
+          toolName: "bash",
+          command: "git push",
+          toolInputPreview: "git push",
+        }),
+      );
+
+      expect(events.emit).not.toHaveBeenCalled();
+      expect(mockConfirmPermission.mock.calls[0][4]).toEqual(
+        expect.objectContaining({
+          protocolVersion: 1,
+          requestId: "req-123",
+          source: "tool_call",
+          surface: "bash",
+          value: "git push",
+          toolName: "bash",
+          command: "git push",
+          toolInputPreview: "git push",
+        }),
+      );
+    });
+
+    it("normalizes skill UI prompt events to the skill surface", async () => {
+      const events = {
+        emit: vi.fn(),
+        on: vi.fn().mockReturnValue(() => undefined),
+      };
+      mockConfirmPermission.mockResolvedValue({
+        approved: true,
+        state: "approved",
+      });
+      const deps = makeDeps({ events });
+      const prompter = new PermissionPrompter(deps);
+
+      await prompter.prompt(
+        makeCtx(true),
+        makeDetails({
+          source: "skill_input",
+          toolName: undefined,
+          skillName: "deploy-helper",
+        }),
+      );
+
+      expect(events.emit).not.toHaveBeenCalled();
+      expect(mockConfirmPermission.mock.calls[0][4]).toEqual(
+        expect.objectContaining({
+          protocolVersion: 1,
+          source: "skill_input",
+          surface: "skill",
+          value: "deploy-helper",
+          skillName: "deploy-helper",
+        }),
       );
     });
 
@@ -246,6 +324,7 @@ describe("PermissionPrompter", () => {
         expect.any(String),
         expect.anything(),
         { sessionLabel: "Yes, for 'read' tool" },
+        expect.objectContaining({ sessionLabel: "Yes, for 'read' tool" }),
       );
     });
 
@@ -264,6 +343,7 @@ describe("PermissionPrompter", () => {
         expect.any(String),
         expect.anything(),
         undefined,
+        expect.objectContaining({ sessionLabel: null }),
       );
     });
 
@@ -283,6 +363,7 @@ describe("PermissionPrompter", () => {
         "Allow bash: git status?",
         expect.anything(),
         undefined,
+        expect.objectContaining({ message: "Allow bash: git status?" }),
       );
     });
   });

--- a/packages/pi-permission-system/test/permission-prompter.test.ts
+++ b/packages/pi-permission-system/test/permission-prompter.test.ts
@@ -164,7 +164,7 @@ describe("PermissionPrompter", () => {
       );
     });
 
-    it("passes a UI prompt event with normalized surface and value to confirmPermission", async () => {
+    it("emits a UI prompt event with normalized surface and value when the session has UI", async () => {
       const events = {
         emit: vi.fn(),
         on: vi.fn().mockReturnValue(() => undefined),
@@ -185,19 +185,15 @@ describe("PermissionPrompter", () => {
         }),
       );
 
-      expect(events.emit).not.toHaveBeenCalled();
-      expect(mockConfirmPermission.mock.calls[0][4]).toEqual(
-        expect.objectContaining({
-          protocolVersion: 1,
-          requestId: "req-123",
-          source: "tool_call",
-          surface: "bash",
-          value: "git push",
-          toolName: "bash",
-          command: "git push",
-          toolInputPreview: "git push",
-        }),
-      );
+      expect(events.emit).toHaveBeenCalledWith("permissions:ui_prompt", {
+        requestId: "req-123",
+        source: "tool_call",
+        surface: "bash",
+        value: "git push",
+        agentName: "test-agent",
+        message: "Allow read?",
+        forwarding: null,
+      });
     });
 
     it("normalizes skill UI prompt events to the skill surface", async () => {
@@ -221,15 +217,34 @@ describe("PermissionPrompter", () => {
         }),
       );
 
-      expect(events.emit).not.toHaveBeenCalled();
-      expect(mockConfirmPermission.mock.calls[0][4]).toEqual(
-        expect.objectContaining({
-          protocolVersion: 1,
-          source: "skill_input",
-          surface: "skill",
-          value: "deploy-helper",
-          skillName: "deploy-helper",
-        }),
+      expect(events.emit).toHaveBeenCalledWith("permissions:ui_prompt", {
+        requestId: "req-123",
+        source: "skill_input",
+        surface: "skill",
+        value: "deploy-helper",
+        agentName: "test-agent",
+        message: "Allow read?",
+        forwarding: null,
+      });
+    });
+
+    it("does not emit a UI prompt event when the session has no UI", async () => {
+      const events = {
+        emit: vi.fn(),
+        on: vi.fn().mockReturnValue(() => undefined),
+      };
+      mockConfirmPermission.mockResolvedValue({
+        approved: true,
+        state: "approved",
+      });
+      const deps = makeDeps({ events });
+      const prompter = new PermissionPrompter(deps);
+
+      await prompter.prompt(makeCtx(false), makeDetails());
+
+      expect(events.emit).not.toHaveBeenCalledWith(
+        "permissions:ui_prompt",
+        expect.anything(),
       );
     });
 
@@ -324,7 +339,6 @@ describe("PermissionPrompter", () => {
         expect.any(String),
         expect.anything(),
         { sessionLabel: "Yes, for 'read' tool" },
-        expect.objectContaining({ sessionLabel: "Yes, for 'read' tool" }),
       );
     });
 
@@ -343,7 +357,6 @@ describe("PermissionPrompter", () => {
         expect.any(String),
         expect.anything(),
         undefined,
-        expect.objectContaining({ sessionLabel: null }),
       );
     });
 
@@ -363,7 +376,6 @@ describe("PermissionPrompter", () => {
         "Allow bash: git status?",
         expect.anything(),
         undefined,
-        expect.objectContaining({ message: "Allow bash: git status?" }),
       );
     });
   });

--- a/packages/pi-permission-system/test/permission-prompter.test.ts
+++ b/packages/pi-permission-system/test/permission-prompter.test.ts
@@ -53,6 +53,7 @@ function makeDeps(
     writeReviewLog: vi.fn(),
     subagentSessionsDir: "/sessions/subagents",
     forwardingDir: "/sessions/permission-forwarding",
+    events: { emit: vi.fn(), on: vi.fn().mockReturnValue(() => undefined) },
     requestPermissionDecisionFromUi: vi
       .fn()
       .mockResolvedValue({ approved: true, state: "approved" }),

--- a/packages/pi-permission-system/test/permission-ui-prompt.test.ts
+++ b/packages/pi-permission-system/test/permission-ui-prompt.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDirectUiPrompt,
+  buildForwardedUiPrompt,
+  buildRpcUiPrompt,
+} from "#src/permission-ui-prompt";
+
+describe("buildDirectUiPrompt", () => {
+  it("maps a tool_call prompt to the tool surface and command value", () => {
+    expect(
+      buildDirectUiPrompt({
+        requestId: "req-1",
+        source: "tool_call",
+        agentName: "Explore",
+        message: "Allow git push?",
+        toolName: "bash",
+        command: "git push",
+      }),
+    ).toEqual({
+      requestId: "req-1",
+      source: "tool_call",
+      surface: "bash",
+      value: "git push",
+      agentName: "Explore",
+      message: "Allow git push?",
+      forwarding: null,
+    });
+  });
+
+  it("normalizes a skill prompt to the skill surface and skill-name value", () => {
+    expect(
+      buildDirectUiPrompt({
+        requestId: "req-2",
+        source: "skill_input",
+        agentName: null,
+        message: "Allow skill?",
+        skillName: "deploy-helper",
+      }),
+    ).toEqual({
+      requestId: "req-2",
+      source: "skill_input",
+      surface: "skill",
+      value: "deploy-helper",
+      agentName: null,
+      message: "Allow skill?",
+      forwarding: null,
+    });
+  });
+
+  it("derives value with command > path > target > skillName > toolName precedence", () => {
+    expect(
+      buildDirectUiPrompt({
+        requestId: "req-3",
+        source: "tool_call",
+        agentName: null,
+        message: "m",
+        toolName: "read",
+        path: "/etc/hosts",
+        target: "ignored",
+      }).value,
+    ).toBe("/etc/hosts");
+  });
+});
+
+describe("buildRpcUiPrompt", () => {
+  it("maps an RPC prompt to the rpc_prompt source with passthrough surface/value", () => {
+    expect(
+      buildRpcUiPrompt({
+        requestId: "req-rpc",
+        surface: "bash",
+        value: "git push",
+        agentName: "Worker",
+        message: "Allow git push?",
+      }),
+    ).toEqual({
+      requestId: "req-rpc",
+      source: "rpc_prompt",
+      surface: "bash",
+      value: "git push",
+      agentName: "Worker",
+      message: "Allow git push?",
+      forwarding: null,
+    });
+  });
+
+  it("defaults missing surface, value, and agentName to null", () => {
+    expect(
+      buildRpcUiPrompt({ requestId: "req-rpc-2", message: "Allow?" }),
+    ).toEqual({
+      requestId: "req-rpc-2",
+      source: "rpc_prompt",
+      surface: null,
+      value: null,
+      agentName: null,
+      message: "Allow?",
+      forwarding: null,
+    });
+  });
+});
+
+describe("buildForwardedUiPrompt", () => {
+  it("populates forwarding context and carries the original source/surface/value", () => {
+    expect(
+      buildForwardedUiPrompt({
+        requestId: "req-fwd",
+        message: "Subagent 'Explore' requested permission.\n\nAllow git push?",
+        requesterAgentName: "Explore",
+        requesterSessionId: "child-session",
+        source: "tool_call",
+        surface: "bash",
+        value: "git push",
+      }),
+    ).toEqual({
+      requestId: "req-fwd",
+      source: "tool_call",
+      surface: "bash",
+      value: "git push",
+      agentName: "Explore",
+      message: "Subagent 'Explore' requested permission.\n\nAllow git push?",
+      forwarding: {
+        requesterAgentName: "Explore",
+        requesterSessionId: "child-session",
+      },
+    });
+  });
+
+  it("falls back to source tool_call with null surface/value when the request omits them", () => {
+    expect(
+      buildForwardedUiPrompt({
+        requestId: "req-fwd-old",
+        message: "Allow?",
+        requesterAgentName: null,
+        requesterSessionId: null,
+      }),
+    ).toEqual({
+      requestId: "req-fwd-old",
+      source: "tool_call",
+      surface: null,
+      value: null,
+      agentName: null,
+      message: "Allow?",
+      forwarding: { requesterAgentName: null, requesterSessionId: null },
+    });
+  });
+});


### PR DESCRIPTION
Closes #292

Supersedes PR #292 from `moekyo:feature/permission-prompt-contract` — those commits sit at the base with original authorship preserved; our commits land on top.

## Summary

Hardens the `permissions:ui_prompt` broadcast contract before adoption:

- **Centralized construction** — single `src/permission-ui-prompt.ts` module with `buildDirectUiPrompt` / `buildRpcUiPrompt` / `buildForwardedUiPrompt`; no emit site hand-rolls the payload.
- **Lean flat payload** — `PermissionUiPromptEvent` carries 7 fields (`requestId`, `source`, `surface`, `value`, `agentName`, `message`, `forwarding`); replaces the 14-field draft.
- **Forwarded non-degradation** — child persists `source`/`surface`/`value` in the forwarding request; parent emits the original source + display projection instead of a degraded payload.
- **Remove `protocolVersion` from all broadcasts** — lives only in the RPC reply envelope; broadcast contract is defined by published types + package semver. **BREAKING** for `PermissionsReadyEvent`.
- **Restore `confirmPermission` to pure routing** — direct emit moved to `PermissionPrompter.prompt` gated on `ctx.hasUI`.
- **Best-effort emits** — all three broadcasts (`ready`, `ui_prompt`, `decision`) wrapped in try/catch.

## Merge instructions

**Rebase merge** — preserves koxx12-dev's and moekyo's original commit authorship at the base of the history. Do not squash.