### PR TITLE
fix(pi-permission-system): preserve runtime knobs through config merge

### DIFF
--- a/packages/pi-permission-system/src/config-loader.ts
+++ b/packages/pi-permission-system/src/config-loader.ts
@@ -21,10 +21,34 @@ export interface UnifiedPermissionConfig {
   debugLog?: boolean;
   permissionReviewLog?: boolean;
   yoloMode?: boolean;
+  piInfrastructureReadPaths?: string[];
+  toolInputPreviewMaxLength?: number;
+  toolTextSummaryMaxLength?: number;
 
   // Flat permission policy
   permission?: FlatPermissionConfig;
 }
+
+const BOOLEAN_RUNTIME_KNOB_KEYS = [
+  "debugLog",
+  "permissionReviewLog",
+  "yoloMode",
+] as const;
+
+const STRING_ARRAY_RUNTIME_KNOB_KEYS = ["piInfrastructureReadPaths"] as const;
+
+const POSITIVE_INT_RUNTIME_KNOB_KEYS = [
+  "toolInputPreviewMaxLength",
+  "toolTextSummaryMaxLength",
+] as const;
+
+const RUNTIME_KNOB_KEYS = [
+  ...BOOLEAN_RUNTIME_KNOB_KEYS,
+  ...STRING_ARRAY_RUNTIME_KNOB_KEYS,
+  ...POSITIVE_INT_RUNTIME_KNOB_KEYS,
+] as const;
+
+type RuntimeKnobKey = (typeof RUNTIME_KNOB_KEYS)[number];
 
 export interface UnifiedConfigLoadResult {
   config: UnifiedPermissionConfig;
@@ -117,6 +141,19 @@ function normalizeOptionalBoolean(value: unknown): boolean | undefined {
   return undefined;
 }
 
+function normalizeOptionalStringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value) &&
+    value.every((entry): entry is string => typeof entry === "string")
+    ? value
+    : undefined;
+}
+
+function normalizeOptionalPositiveInt(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
 /**
  * Normalize a raw `permission` value from parsed JSON into a FlatPermissionConfig.
  * Drops non-object top-level values, invalid PermissionState strings, and
@@ -171,17 +208,26 @@ export function normalizeUnifiedConfig(raw: unknown): {
   const config: UnifiedPermissionConfig = {};
 
   // Runtime knobs
-  const debugLog = normalizeOptionalBoolean(record.debugLog);
-  if (debugLog !== undefined) config.debugLog = debugLog;
+  for (const key of BOOLEAN_RUNTIME_KNOB_KEYS) {
+    const value = normalizeOptionalBoolean(record[key]);
+    if (value !== undefined) {
+      config[key] = value;
+    }
+  }
 
-  const permissionReviewLog = normalizeOptionalBoolean(
-    record.permissionReviewLog,
-  );
-  if (permissionReviewLog !== undefined)
-    config.permissionReviewLog = permissionReviewLog;
+  for (const key of STRING_ARRAY_RUNTIME_KNOB_KEYS) {
+    const value = normalizeOptionalStringArray(record[key]);
+    if (value !== undefined) {
+      config[key] = value;
+    }
+  }
 
-  const yoloMode = normalizeOptionalBoolean(record.yoloMode);
-  if (yoloMode !== undefined) config.yoloMode = yoloMode;
+  for (const key of POSITIVE_INT_RUNTIME_KNOB_KEYS) {
+    const value = normalizeOptionalPositiveInt(record[key]);
+    if (value !== undefined) {
+      config[key] = value;
+    }
+  }
 
   // Flat permission policy
   const permission = normalizeFlatPermissionValue(record.permission);
@@ -193,8 +239,7 @@ export function normalizeUnifiedConfig(raw: unknown): {
 /**
  * Merge two unified configs.
  * - `permission` is deep-shallow merged (surface-level object maps are shallow-merged).
- * - Scalar fields (debugLog, permissionReviewLog, yoloMode) are replaced when
- *   present in the override.
+ * - Runtime knobs are replaced when present in the override.
  */
 export function mergeUnifiedConfigs(
   base: UnifiedPermissionConfig,
@@ -202,13 +247,7 @@ export function mergeUnifiedConfigs(
 ): UnifiedPermissionConfig {
   const merged: UnifiedPermissionConfig = {};
 
-  // Scalars: override replaces base when defined
-  for (const key of ["debugLog", "permissionReviewLog", "yoloMode"] as const) {
-    const value = override[key] ?? base[key];
-    if (value !== undefined) {
-      merged[key] = value;
-    }
-  }
+  mergeRuntimeKnobs(merged, base, override);
 
   // Permission: deep-shallow merge
   const basePerm = base.permission;
@@ -222,6 +261,26 @@ export function mergeUnifiedConfigs(
   }
 
   return merged;
+}
+
+function mergeRuntimeKnobs(
+  merged: UnifiedPermissionConfig,
+  base: UnifiedPermissionConfig,
+  override: UnifiedPermissionConfig,
+): void {
+  for (const key of RUNTIME_KNOB_KEYS) {
+    assignRuntimeKnob(merged, key, override[key] ?? base[key]);
+  }
+}
+
+function assignRuntimeKnob<Key extends RuntimeKnobKey>(
+  config: UnifiedPermissionConfig,
+  key: Key,
+  value: UnifiedPermissionConfig[Key] | undefined,
+): void {
+  if (value !== undefined) {
+    config[key] = value;
+  }
 }
 
 export interface MergedConfigResult {

--- a/packages/pi-permission-system/src/config-store.ts
+++ b/packages/pi-permission-system/src/config-store.ts
@@ -69,6 +69,38 @@ export interface ConfigStoreDeps {
   logger: DebugReviewLogger;
 }
 
+type RuntimeConfigSaveFields = Pick<
+  PermissionSystemExtensionConfig,
+  "debugLog" | "permissionReviewLog" | "yoloMode"
+> &
+  Partial<
+    Pick<
+      PermissionSystemExtensionConfig,
+      | "piInfrastructureReadPaths"
+      | "toolInputPreviewMaxLength"
+      | "toolTextSummaryMaxLength"
+    >
+  >;
+
+function pickRuntimeConfigSaveFields(
+  config: PermissionSystemExtensionConfig,
+): RuntimeConfigSaveFields {
+  return {
+    debugLog: config.debugLog,
+    permissionReviewLog: config.permissionReviewLog,
+    yoloMode: config.yoloMode,
+    ...(config.piInfrastructureReadPaths !== undefined && {
+      piInfrastructureReadPaths: config.piInfrastructureReadPaths,
+    }),
+    ...(config.toolInputPreviewMaxLength !== undefined && {
+      toolInputPreviewMaxLength: config.toolInputPreviewMaxLength,
+    }),
+    ...(config.toolTextSummaryMaxLength !== undefined && {
+      toolTextSummaryMaxLength: config.toolTextSummaryMaxLength,
+    }),
+  };
+}
+
 /**
  * Owns the mutable extension config and the operations that read/write it.
  *
@@ -124,9 +156,7 @@ export class ConfigStore implements SessionConfigStore, CommandConfigStore {
 
     this.deps.logger.debug("config.loaded", {
       warning: warning ?? null,
-      debugLog: runtimeConfig.debugLog,
-      permissionReviewLog: runtimeConfig.permissionReviewLog,
-      yoloMode: runtimeConfig.yoloMode,
+      ...pickRuntimeConfigSaveFields(runtimeConfig),
     });
   }
 
@@ -148,9 +178,7 @@ export class ConfigStore implements SessionConfigStore, CommandConfigStore {
     const existing = loadUnifiedConfig(globalPath);
     const merged = {
       ...existing.config,
-      debugLog: normalized.debugLog,
-      permissionReviewLog: normalized.permissionReviewLog,
-      yoloMode: normalized.yoloMode,
+      ...pickRuntimeConfigSaveFields(normalized),
     };
 
     const tmpPath = `${globalPath}.tmp`;
@@ -178,11 +206,10 @@ export class ConfigStore implements SessionConfigStore, CommandConfigStore {
     syncPermissionSystemStatus(ctx, normalized);
     this.lastConfigWarning = null;
 
-    this.deps.logger.debug("config.saved", {
-      debugLog: normalized.debugLog,
-      permissionReviewLog: normalized.permissionReviewLog,
-      yoloMode: normalized.yoloMode,
-    });
+    this.deps.logger.debug(
+      "config.saved",
+      pickRuntimeConfigSaveFields(normalized),
+    );
   }
 
   /**

--- a/packages/pi-permission-system/test/config-loader.test.ts
+++ b/packages/pi-permission-system/test/config-loader.test.ts
@@ -7,6 +7,7 @@ import {
   loadAndMergeConfigs,
   loadUnifiedConfig,
   mergeUnifiedConfigs,
+  normalizeUnifiedConfig,
   stripJsonComments,
 } from "#src/config-loader";
 
@@ -219,6 +220,36 @@ describe("loadUnifiedConfig", () => {
     });
   });
 
+  it("preserves optional runtime knobs", () => {
+    const configPath = join(tempDir, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        piInfrastructureReadPaths: ["~/.local/share/mise/installs/pi"],
+        toolInputPreviewMaxLength: 400,
+        toolTextSummaryMaxLength: 120,
+      }),
+    );
+
+    const result = loadUnifiedConfig(configPath);
+    expect(result.config).toEqual({
+      piInfrastructureReadPaths: ["~/.local/share/mise/installs/pi"],
+      toolInputPreviewMaxLength: 400,
+      toolTextSummaryMaxLength: 120,
+    });
+  });
+
+  it("drops invalid optional runtime knobs", () => {
+    const result = normalizeUnifiedConfig({
+      piInfrastructureReadPaths: ["/ok", 42],
+      toolInputPreviewMaxLength: 0,
+      toolTextSummaryMaxLength: 80.5,
+    });
+
+    expect(result.config).toEqual({});
+    expect(result.issues).toEqual([]);
+  });
+
   it("accepts permission as object with mixed string and object values", () => {
     const configPath = join(tempDir, "config.json");
     writeFileSync(
@@ -322,6 +353,26 @@ describe("mergeUnifiedConfigs", () => {
     expect(merged.yoloMode).toBe(true);
   });
 
+  it("replaces optional runtime knobs when overrides define them", () => {
+    const merged = mergeUnifiedConfigs(
+      {
+        piInfrastructureReadPaths: ["/global/pi"],
+        toolInputPreviewMaxLength: 400,
+        toolTextSummaryMaxLength: 120,
+      },
+      {
+        piInfrastructureReadPaths: ["/project/pi"],
+        toolTextSummaryMaxLength: 240,
+      },
+    );
+
+    expect(merged).toEqual({
+      piInfrastructureReadPaths: ["/project/pi"],
+      toolInputPreviewMaxLength: 400,
+      toolTextSummaryMaxLength: 240,
+    });
+  });
+
   it("returns base unchanged when override is empty", () => {
     const base = {
       debugLog: true,
@@ -418,6 +469,26 @@ describe("loadAndMergeConfigs", () => {
       "*": "allow",
       read: "allow",
       write: "deny",
+    });
+  });
+
+  it("merges optional runtime knobs from new-layout configs", () => {
+    writeGlobal({
+      piInfrastructureReadPaths: ["/global/pi"],
+      toolInputPreviewMaxLength: 400,
+      toolTextSummaryMaxLength: 120,
+    });
+    writeProject({
+      piInfrastructureReadPaths: ["/project/pi"],
+      toolTextSummaryMaxLength: 240,
+    });
+
+    const result = loadAndMergeConfigs(agentDir, cwd, extensionRoot);
+    expect(result.issues).toEqual([]);
+    expect(result.merged).toEqual({
+      piInfrastructureReadPaths: ["/project/pi"],
+      toolInputPreviewMaxLength: 400,
+      toolTextSummaryMaxLength: 240,
     });
   });
 

--- a/packages/pi-permission-system/test/config-store.test.ts
+++ b/packages/pi-permission-system/test/config-store.test.ts
@@ -192,6 +192,28 @@ describe("ConfigStore", () => {
       expect(store.current().permissionReviewLog).toBe(false);
     });
 
+    it("keeps optional runtime knobs from merged config", () => {
+      const { store } = makeStore();
+      mockLoadAndMergeConfigs.mockReturnValue({
+        merged: {
+          ...DEFAULT_EXTENSION_CONFIG,
+          piInfrastructureReadPaths: ["/opt/pi"],
+          toolInputPreviewMaxLength: 400,
+          toolTextSummaryMaxLength: 120,
+        },
+        issues: [],
+      });
+
+      store.refresh();
+
+      expect(store.current()).toEqual({
+        ...DEFAULT_EXTENSION_CONFIG,
+        piInfrastructureReadPaths: ["/opt/pi"],
+        toolInputPreviewMaxLength: 400,
+        toolTextSummaryMaxLength: 120,
+      });
+    });
+
     it("writes config.loaded debug log", () => {
       const { store, logger } = makeStore();
       store.refresh();
@@ -312,6 +334,36 @@ describe("ConfigStore", () => {
         "utf-8",
       );
       expect(mockRenameSync).toHaveBeenCalled();
+    });
+
+    it("writes optional runtime knobs without dropping existing permission", () => {
+      const { store } = makeStore();
+      mockLoadUnifiedConfig.mockReturnValue({
+        config: { permission: { "*": "ask" } },
+      });
+      const next = {
+        ...DEFAULT_EXTENSION_CONFIG,
+        piInfrastructureReadPaths: ["/opt/pi"],
+        toolInputPreviewMaxLength: 400,
+        toolTextSummaryMaxLength: 120,
+      };
+
+      store.save(next, makeCommandCtx());
+
+      const [, written] = mockWriteFileSync.mock.calls[0] as [
+        string,
+        string,
+        string,
+      ];
+      expect(JSON.parse(written)).toEqual({
+        permission: { "*": "ask" },
+        debugLog: false,
+        permissionReviewLog: true,
+        yoloMode: false,
+        piInfrastructureReadPaths: ["/opt/pi"],
+        toolInputPreviewMaxLength: 400,
+        toolTextSummaryMaxLength: 120,
+      });
     });
 
     it("updates current() after a successful save", () => {


### PR DESCRIPTION
## Summary

- Preserve `piInfrastructureReadPaths` through the unified config load/merge pipeline so configured Pi infrastructure read paths are not silently dropped.
- Preserve optional tool preview runtime knobs during config load, merge, refresh, and save.
- Add regression coverage for runtime knob normalization, merge precedence, refresh behavior, and saving without dropping existing permission config.

## Tests

- `pnpm --filter @gotgenes/pi-permission-system run lint`
- `pnpm --filter @gotgenes/pi-permission-system run check`
- `pnpm --filter @gotgenes/pi-permission-system test`

Closes #347