### PR TITLE
feat(pi-permission-system): respect pi default active tool set

### DIFF
--- a/packages/pi-permission-system/src/handlers/before-agent-start.ts
+++ b/packages/pi-permission-system/src/handlers/before-agent-start.ts
@@ -56,7 +56,7 @@ export class AgentPrepHandler {
     this.session.refreshConfig(ctx);
 
     const agentName = this.session.resolveAgentName(ctx, event.systemPrompt);
-    const allTools = this.toolRegistry.getAll();
+    const allTools = this.toolRegistry.getActive();
     const allowedTools: string[] = [];
 
     for (const tool of allTools) {

--- a/packages/pi-permission-system/src/index.ts
+++ b/packages/pi-permission-system/src/index.ts
@@ -152,6 +152,7 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
 
   const toolRegistry = {
     getAll: () => pi.getAllTools(),
+    getActive: () => pi.getActiveTools(),
     setActive: (names: string[]) => pi.setActiveTools(names),
   };
 

--- a/packages/pi-permission-system/src/tool-registry.ts
+++ b/packages/pi-permission-system/src/tool-registry.ts
@@ -3,6 +3,7 @@ import { getNonEmptyString, toRecord } from "./common";
 /** Narrow interface for the Pi tool API subset used by handler classes. */
 export interface ToolRegistry {
   getAll(): unknown[];
+  getActive(): unknown[];
   setActive(names: string[]): void;
 }
 

--- a/packages/pi-permission-system/test/handlers/before-agent-start.test.ts
+++ b/packages/pi-permission-system/test/handlers/before-agent-start.test.ts
@@ -31,6 +31,7 @@ function makeEvent(systemPrompt = "You are an assistant.") {
 function makeToolRegistry(overrides: Partial<ToolRegistry> = {}): ToolRegistry {
   return {
     getAll: vi.fn().mockReturnValue([]),
+    getActive: vi.fn().mockReturnValue([]),
     setActive: vi.fn(),
     ...overrides,
   };
@@ -126,7 +127,9 @@ describe("AgentPrepHandler.handle", () => {
     const { handler, toolRegistry } = makeSetup({
       toolPermission: "deny",
       toolRegistry: {
-        getAll: vi.fn().mockReturnValue([{ name: "write" }, { name: "read" }]),
+        getActive: vi
+          .fn()
+          .mockReturnValue([{ name: "write" }, { name: "read" }]),
       },
     });
     await handler.handle(makeEvent(), makeCtx());
@@ -136,7 +139,9 @@ describe("AgentPrepHandler.handle", () => {
   it("includes allowed and ask tools in the active list", async () => {
     const { handler, toolRegistry } = makeSetup({
       toolRegistry: {
-        getAll: vi.fn().mockReturnValue([{ name: "read" }, { name: "write" }]),
+        getActive: vi
+          .fn()
+          .mockReturnValue([{ name: "read" }, { name: "write" }]),
       },
     });
     await handler.handle(makeEvent(), makeCtx());
@@ -146,7 +151,7 @@ describe("AgentPrepHandler.handle", () => {
   it("calls setActive once across repeated calls with the same allowed tools", async () => {
     const { handler, toolRegistry } = makeSetup({
       toolRegistry: {
-        getAll: vi.fn().mockReturnValue([{ name: "read" }]),
+        getActive: vi.fn().mockReturnValue([{ name: "read" }]),
       },
     });
     await handler.handle(makeEvent(), makeCtx());

--- a/packages/pi-permission-system/test/handlers/external-directory-session-dedup.test.ts
+++ b/packages/pi-permission-system/test/handlers/external-directory-session-dedup.test.ts
@@ -123,6 +123,14 @@ function makeDeduplicatingHandler(prompter?: GatePrompter): {
           { name: "edit" },
           { name: "bash" },
         ]),
+      getActive: vi
+        .fn()
+        .mockReturnValue([
+          { name: "read" },
+          { name: "write" },
+          { name: "edit" },
+          { name: "bash" },
+        ]),
     }),
     new ToolCallGatePipeline(resolver, session),
     new SkillInputGatePipeline(resolver),
@@ -365,6 +373,7 @@ describe("session shutdown clears external-directory approvals", () => {
       session,
       makeToolRegistry({
         getAll: vi.fn().mockReturnValue([{ name: "read" }]),
+        getActive: vi.fn().mockReturnValue([{ name: "read" }]),
       }),
       new ToolCallGatePipeline(resolver, session),
       new SkillInputGatePipeline(resolver),

--- a/packages/pi-permission-system/test/handlers/tool-call.test.ts
+++ b/packages/pi-permission-system/test/handlers/tool-call.test.ts
@@ -119,6 +119,7 @@ describe("handleToolCall — skill-read gate", () => {
       },
       toolRegistry: {
         getAll: vi.fn().mockReturnValue([{ toolName: "read" }]),
+        getActive: vi.fn().mockReturnValue([{ toolName: "read" }]),
       },
     });
     const event = {
@@ -146,6 +147,7 @@ describe("handleToolCall — skill-read gate", () => {
       },
       toolRegistry: {
         getAll: vi.fn().mockReturnValue([{ toolName: "read" }]),
+        getActive: vi.fn().mockReturnValue([{ toolName: "read" }]),
       },
     });
     const event = {

--- a/packages/pi-permission-system/test/helpers/handler-fixtures.ts
+++ b/packages/pi-permission-system/test/helpers/handler-fixtures.ts
@@ -123,6 +123,7 @@ export function makeToolRegistry(
 ): ToolRegistry {
   return {
     getAll: vi.fn().mockReturnValue([{ name: "read" }, { name: "bash" }]),
+    getActive: vi.fn().mockReturnValue([{ name: "read" }, { name: "bash" }]),
     setActive: vi.fn(),
     ...overrides,
   };

--- a/packages/pi-permission-system/test/helpers/make-fake-pi.ts
+++ b/packages/pi-permission-system/test/helpers/make-fake-pi.ts
@@ -42,6 +42,7 @@ export interface FakePi {
   fire(event: string, input?: unknown, ctx?: unknown): Promise<unknown>;
   /** Minimal tool registry — returns the configured tool names. */
   getAllTools(): { name: string }[];
+  getActiveTools(): { name: string }[];
   setActiveTools(names: string[]): void;
 }
 
@@ -78,6 +79,9 @@ export function makeFakePi(options: MakeFakePiOptions = {}): FakePi {
       return Promise.resolve(handler(input, ctx));
     },
     getAllTools(): { name: string }[] {
+      return toolNames.map((name) => ({ name }));
+    },
+    getActiveTools(): { name: string }[] {
       return toolNames.map((name) => ({ name }));
     },
     setActiveTools: vi.fn(),

--- a/packages/pi-permission-system/test/permission-events.test.ts
+++ b/packages/pi-permission-system/test/permission-events.test.ts
@@ -363,6 +363,7 @@ describe("piPermissionSystemExtension ready event wiring", () => {
       ),
       registerCommand: vi.fn(),
       getAllTools: vi.fn().mockReturnValue([]),
+      getActiveTools: vi.fn().mockReturnValue([]),
       setActiveTools: vi.fn(),
       registerProvider: vi.fn(),
       events: { emit: emitSpy, on: vi.fn().mockReturnValue(() => undefined) },

--- a/packages/pi-permission-system/test/session-start.test.ts
+++ b/packages/pi-permission-system/test/session-start.test.ts
@@ -56,6 +56,7 @@ describe("session_start handler consolidation", () => {
       },
       registerCommand: (): void => {},
       getAllTools: (): Array<{ name: string }> => [],
+      getActiveTools: (): Array<{ name: string }> => [],
       setActiveTools: (): void => {},
       registerProvider: (): void => {},
       events: {
@@ -79,6 +80,7 @@ describe("session_start handler consolidation", () => {
       },
       registerCommand: (): void => {},
       getAllTools: (): Array<{ name: string }> => [],
+      getActiveTools: (): Array<{ name: string }> => [],
       setActiveTools: (): void => {},
       registerProvider: (): void => {},
       events: {


### PR DESCRIPTION
## Summary

`AgentPrepHandler.handle()` in `before-agent-start.ts` uses `pi.getAllTools()` to determine which tools to expose, then calls `pi.setActiveTools()` with every tool that isn't explicitly denied. This activates built-in tools like `find`, `grep`, and `ls` that pi deliberately leaves inactive by default (pi's default active set is `read`, `bash`, `edit`, `write`).

## Problem

Pi ships `find`, `grep`, and `ls` as built-in tools that are off by default. The subagent system uses these tools in agent definitions via the `tools:` frontmatter (e.g., `tools: read, grep, find, ls`), which controls which tools are passed to `createAgentSession(tools: [...])`. This works because subagents are separate sessions with their own tool set.

But `pi-permission-system`'s `before_agent_start` handler overrides the active tool set for every session — including the main session — by activating all non-denied tools. This means:

1. The main session always sees `find`, `grep`, `ls`, defeating pi's default of keeping them off.
2. Denying these tools globally (`"find": "deny"`) also blocks subagents that explicitly request them, since `before_agent_start` fires for subagent sessions too.
3. The only workaround is per-agent `.md` overrides to re-allow the tools for each subagent type, which is verbose and fragile.

## Proposed change

Use `pi.getActiveTools()` instead of `pi.getAllTools()` as the base set in the `before_agent_start` handler. This way the permission system only removes tools (deny) or keeps already-active ones — it never activates tools that pi itself left off.

Changes:
- Add `getActive()` to `ToolRegistry` interface
- Wire `getActive` to `pi.getActiveTools()` in `index.ts`
- Change `AgentPrepHandler` to call `getActive()` instead of `getAll()`
- Update test mocks to include `getActive`

Ref: #385
