### PR TITLE
feat(pi-permission-system): deny patterns with custom reason

### DIFF
--- a/packages/pi-permission-system/config/config.example.json
+++ b/packages/pi-permission-system/config/config.example.json
@@ -25,7 +25,8 @@
       "*": "ask",
       "git *": "ask",
       "git status": "allow",
-      "git diff": "allow"
+      "git diff": "allow",
+      "npm *": { "action": "deny", "reason": "Use pnpm instead" }
     },
     "mcp": { "*": "ask", "mcp_status": "allow", "mcp_list": "allow" },
     "skill": { "*": "ask" },

--- a/packages/pi-permission-system/docs/configuration.md
+++ b/packages/pi-permission-system/docs/configuration.md
@@ -58,7 +58,13 @@ Scalar fields (`debugLog`, `permissionReviewLog`, `yoloMode`) use simple replace
     "read": "allow",
     "write": "deny",
     "edit": "deny",
-    "bash": { "git *": "ask", "git status": "allow" },
+    "bash": {
+      "*": "ask",
+      "git *": "ask",
+      "git status": "allow",
+      "git diff": "allow",
+      "npm *": { "action": "deny", "reason": "Use pnpm instead" }
+    },
     "mcp": { "mcp_status": "allow" },
     "skill": { "*": "ask" },
     "external_directory": "ask"
@@ -122,6 +128,8 @@ Omitting `"*"` defaults to `"ask"` (least privilege).
 
 Any registered tool name can be a surface key.
 A string value is a catch-all for that surface.
+For `deny` rules, the value can also be an object with an optional `reason`: `{ "action": "deny", "reason": "..." }`.
+The reason is shown to the agent when the command is blocked.
 
 | Surface example                               | Description                         |
 | --------------------------------------------- | ----------------------------------- |
@@ -214,7 +222,8 @@ Place a more specific pattern *after* it to carve out exceptions — the later m
       "git *": "ask",
       "git status": "allow",
       "git diff": "allow",
-      "rm -rf *": "deny"
+      "rm -rf *": "deny",
+      "npm *": { "action": "deny", "reason": "Use pnpm instead" }
     }
   }
 }

--- a/packages/pi-permission-system/schemas/permissions.schema.json
+++ b/packages/pi-permission-system/schemas/permissions.schema.json
@@ -112,6 +112,23 @@
         {
           "const": "ask",
           "description": "Prompt the user for confirmation via the interactive UI before proceeding."
+        },
+        {
+          "type": "object",
+          "description": "Deny with an optional custom reason.",
+          "properties": {
+            "action": {
+              "const": "deny",
+              "description": "The permission decision — must be \"deny\"."
+            },
+            "reason": {
+              "type": "string",
+              "maxLength": 500,
+              "description": "Optional reason shown to the agent when this action is denied."
+            }
+          },
+          "required": ["action"],
+          "additionalProperties": false
         }
       ]
     },

--- a/packages/pi-permission-system/src/config-loader.ts
+++ b/packages/pi-permission-system/src/config-loader.ts
@@ -126,9 +126,25 @@ function normalizeOptionalBoolean(value: unknown): boolean | undefined {
 }
 
 /**
+ * Narrow type guard: a raw JSON value that represents a deny-with-reason object.
+ */
+function isDenyWithReason(
+  value: unknown,
+): value is { action: "deny"; reason?: string } {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    record.action === "deny" &&
+    (record.reason === undefined || typeof record.reason === "string")
+  );
+}
+
+/**
  * Normalize a raw `permission` value from parsed JSON into a FlatPermissionConfig.
- * Drops non-object top-level values, invalid PermissionState strings, and
- * invalid action values inside object maps.
+ * Accepts PermissionState strings and DenyWithReason objects inside pattern maps.
+ * Drops non-object top-level values and invalid action values.
  */
 function normalizeFlatPermissionValue(
   value: unknown,
@@ -147,13 +163,19 @@ function normalizeFlatPermissionValue(
         hasAny = true;
       }
     } else if (typeof val === "object" && val !== null && !Array.isArray(val)) {
-      const map: Record<string, import("./types").PermissionState> = {};
+      const map: Record<
+        string,
+        import("./types").PermissionState | { action: "deny"; reason?: string }
+      > = {};
       let mapHasAny = false;
-      for (const [pattern, action] of Object.entries(
+      for (const [pattern, rawAction] of Object.entries(
         val as Record<string, unknown>,
       )) {
-        if (isPermissionState(action)) {
-          map[pattern] = action;
+        if (isDenyWithReason(rawAction)) {
+          map[pattern] = rawAction;
+          mapHasAny = true;
+        } else if (isPermissionState(rawAction)) {
+          map[pattern] = rawAction;
           mapHasAny = true;
         }
       }

--- a/packages/pi-permission-system/src/denial-messages.ts
+++ b/packages/pi-permission-system/src/denial-messages.ts
@@ -126,7 +126,14 @@ function buildToolDenyBody(
     parts.push(qualifier);
   }
 
-  return `${parts.join(" ")}.`;
+  let message = `${parts.join(" ")}.`;
+
+  // Append custom denial reason after the sentence-ending period.
+  if (check.reason) {
+    message += ` Reason: ${check.reason}.`;
+  }
+
+  return message;
 }
 
 /**

--- a/packages/pi-permission-system/src/normalize.ts
+++ b/packages/pi-permission-system/src/normalize.ts
@@ -1,12 +1,30 @@
 import { isPermissionState } from "./common";
 import type { Rule, Ruleset } from "./rule";
-import type { FlatPermissionConfig } from "./types";
+import type { DenyWithReason, FlatPermissionConfig } from "./types";
+
+/**
+ * Narrow type guard: a raw JSON value that represents a DenyWithReason.
+ * Accepts both `{ action: "deny" }` and `{ action: "deny", reason: "..." }`.
+ * Rejects non-string `reason` values to prevent type pollution from malformed config.
+ */
+function isDenyWithReason(value: unknown): value is DenyWithReason {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    record.action === "deny" &&
+    (record.reason === undefined || typeof record.reason === "string")
+  );
+}
 
 /**
  * Convert a flat permission config into a Ruleset.
  *
  * Each key is a surface name. A string value is shorthand for
  * `{ "*": action }`. An object value maps patterns to actions.
+ * Pattern values can be a plain PermissionState string or a
+ * `DenyWithReason` object (`{ action: "deny", reason?: string }`).
  * Invalid action values are silently skipped.
  *
  * The universal fallback key `"*"` is included if present — callers
@@ -22,9 +40,22 @@ export function normalizeFlatConfig(permission: FlatPermissionConfig): Ruleset {
       }
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive null check; value type does not include null but runtime JSON may
     } else if (typeof value === "object" && value !== null) {
-      for (const [pattern, action] of Object.entries(value)) {
-        if (isPermissionState(action)) {
-          rules.push({ surface, pattern, action, origin: "builtin" });
+      for (const [pattern, rawAction] of Object.entries(value)) {
+        if (isDenyWithReason(rawAction)) {
+          rules.push({
+            surface,
+            pattern,
+            action: "deny",
+            reason: rawAction.reason,
+            origin: "builtin",
+          });
+        } else if (isPermissionState(rawAction)) {
+          rules.push({
+            surface,
+            pattern,
+            action: rawAction,
+            origin: "builtin",
+          });
         }
       }
     }

--- a/packages/pi-permission-system/src/permission-manager.ts
+++ b/packages/pi-permission-system/src/permission-manager.ts
@@ -322,6 +322,7 @@ function buildCheckResult(
   return {
     toolName,
     state: rule.action,
+    reason: rule.reason,
     matchedPattern:
       rule.layer === "config" || rule.layer === "session"
         ? rule.pattern

--- a/packages/pi-permission-system/src/rule.ts
+++ b/packages/pi-permission-system/src/rule.ts
@@ -27,6 +27,8 @@ export interface Rule {
   pattern: string;
   /** The permission decision. */
   action: PermissionState;
+  /** Custom denial reason for deny rules (optional). */
+  reason?: string;
   /**
    * Origin layer — used to derive PermissionCheckResult.source after evaluation.
    * Not used by evaluate(); purely informational metadata.

--- a/packages/pi-permission-system/src/types.ts
+++ b/packages/pi-permission-system/src/types.ts
@@ -5,13 +5,28 @@ import type { RuleOrigin } from "./rule";
 export type { RuleOrigin };
 
 /**
+ * A deny action with an optional reason annotation.
+ * Used when a pattern maps to an object instead of a plain string.
+ */
+export interface DenyWithReason {
+  action: "deny";
+  reason?: string;
+}
+
+/**
+ * A pattern value can be a simple PermissionState string
+ * OR a DenyWithReason object for annotating deny decisions.
+ */
+export type PatternValue = PermissionState | DenyWithReason;
+
+/**
  * The on-disk permission shape inside the `"permission"` key.
  * Each key is a surface name; values are either a PermissionState string
  * (shorthand for `{ "*": action }`) or a pattern→action map.
  */
 export type FlatPermissionConfig = Record<
   string,
-  PermissionState | Record<string, PermissionState>
+  PatternValue | Record<string, PatternValue>
 >;
 
 /**
@@ -34,6 +49,8 @@ export type BashCommandContext =
 export interface PermissionCheckResult {
   toolName: string;
   state: PermissionState;
+  /** Custom denial reason from a deny-with-reason pattern. */
+  reason?: string;
   matchedPattern?: string;
   command?: string;
   target?: string;

--- a/packages/pi-permission-system/test/denial-messages.test.ts
+++ b/packages/pi-permission-system/test/denial-messages.test.ts
@@ -98,6 +98,67 @@ describe("formatDenyReason", () => {
       );
     });
 
+    test("bash with custom reason appended to the message", () => {
+      expect(
+        formatDenyReason(
+          toolCtx(
+            toolCheck("bash", {
+              command: "npm install",
+              matchedPattern: "npm *",
+              reason: "Use pnpm instead",
+            }),
+          ),
+        ),
+      ).toBe(
+        "[pi-permission-system] is not permitted to run 'bash' command 'npm install' (matched 'npm *'). Reason: Use pnpm instead.",
+      );
+    });
+
+    test("generic tool with custom reason but no matched pattern", () => {
+      expect(
+        formatDenyReason(
+          toolCtx(
+            toolCheck("write", {
+              reason: "Write access is disabled for security",
+            }),
+          ),
+        ),
+      ).toBe(
+        "[pi-permission-system] is not permitted to run 'write'. Reason: Write access is disabled for security.",
+      );
+    });
+
+    test("reason with agent name is included", () => {
+      expect(
+        formatDenyReason(
+          toolCtx(
+            toolCheck("bash", {
+              command: "yarn build",
+              matchedPattern: "yarn *",
+              reason: "Use pnpm instead",
+            }),
+            "dev-agent",
+          ),
+        ),
+      ).toBe(
+        "[pi-permission-system] Agent 'dev-agent' is not permitted to run 'bash' command 'yarn build' (matched 'yarn *'). Reason: Use pnpm instead.",
+      );
+    });
+
+    test("MCP target with custom reason", () => {
+      expect(
+        formatDenyReason(
+          toolCtx(
+            mcpCheck("server:deploy", {
+              reason: "Deploy requires approval from a senior engineer",
+            }),
+          ),
+        ),
+      ).toBe(
+        "[pi-permission-system] is not permitted to run MCP target 'server:deploy'. Reason: Deploy requires approval from a senior engineer.",
+      );
+    });
+
     test("bash with nested execution context", () => {
       expect(
         formatDenyReason(

--- a/packages/pi-permission-system/test/normalize.test.ts
+++ b/packages/pi-permission-system/test/normalize.test.ts
@@ -163,4 +163,103 @@ describe("normalizeFlatConfig", () => {
       ]);
     });
   });
+
+  describe("deny with reason", () => {
+    test("{ action: 'deny', reason: 'msg' } produces a rule with reason", () => {
+      const result = normalizeFlatConfig({
+        bash: { "npm *": { action: "deny", reason: "Use pnpm instead" } },
+      });
+      expect(result).toEqual([
+        {
+          surface: "bash",
+          pattern: "npm *",
+          action: "deny",
+          reason: "Use pnpm instead",
+          origin: "builtin",
+        },
+      ]);
+    });
+
+    test("{ action: 'deny' } without reason produces a rule without reason", () => {
+      const result = normalizeFlatConfig({
+        bash: { "rm -rf *": { action: "deny" } },
+      });
+      expect(result).toEqual([
+        {
+          surface: "bash",
+          pattern: "rm -rf *",
+          action: "deny",
+          origin: "builtin",
+        },
+      ]);
+    });
+
+    test("deny-with-reason and plain strings can coexist in the same surface", () => {
+      const result = normalizeFlatConfig({
+        bash: {
+          "git *": "allow",
+          "npm *": { action: "deny", reason: "Use pnpm" },
+          "yarn *": { action: "deny", reason: "Use pnpm or npm" },
+          "*": "ask",
+        },
+      });
+      expect(result).toEqual([
+        {
+          surface: "bash",
+          pattern: "git *",
+          action: "allow",
+          origin: "builtin",
+        },
+        {
+          surface: "bash",
+          pattern: "npm *",
+          action: "deny",
+          reason: "Use pnpm",
+          origin: "builtin",
+        },
+        {
+          surface: "bash",
+          pattern: "yarn *",
+          action: "deny",
+          reason: "Use pnpm or npm",
+          origin: "builtin",
+        },
+        {
+          surface: "bash",
+          pattern: "*",
+          action: "ask",
+          origin: "builtin",
+        },
+      ]);
+    });
+
+    test("top-level DenyWithReason object is treated as pattern map (not deny-with-reason)", () => {
+      // `{ action: "deny", reason: "..." }` at the surface level is parsed
+      // as a pattern→action map, where "action" is a pattern key and
+      // "deny" is its action value. This is correct — deny-with-reason is
+      // only valid at the inner pattern-value level, not at the surface level.
+      const result = normalizeFlatConfig({
+        bash: { action: "deny", reason: "Not allowed" } as never,
+      });
+      expect(result).toEqual([
+        {
+          surface: "bash",
+          pattern: "action",
+          action: "deny",
+          origin: "builtin",
+        },
+      ]);
+    });
+
+    test("non-string reason value is rejected (malformed config)", () => {
+      // A non-string reason, e.g. from a typo in JSON config, must be
+      // rejected by the type guard to prevent type pollution.
+      const result = normalizeFlatConfig({
+        bash: {
+          "npm *": { action: "deny", reason: 42 } as never,
+        },
+      });
+      expect(result).toEqual([]);
+    });
+  });
 });

--- a/packages/pi-permission-system/test/permission-manager-unified.test.ts
+++ b/packages/pi-permission-system/test/permission-manager-unified.test.ts
@@ -1245,6 +1245,75 @@ describe("cross-cutting path surface", () => {
     }
   });
 
+  // ── Deny-with-reason ────────────────────────────────────────────────────
+
+  it("deny-with-reason: reason is threaded through to PermissionCheckResult", () => {
+    const { manager, cleanup } = makeManagerWithConfig({
+      bash: { "npm *": { action: "deny", reason: "Use pnpm instead" } },
+    });
+    try {
+      const result = manager.checkPermission("bash", {
+        command: "npm install",
+      });
+      expect(result.state).toBe("deny");
+      expect(result.reason).toBe("Use pnpm instead");
+      expect(result.matchedPattern).toBe("npm *");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("deny-without-reason: reason is undefined in PermissionCheckResult", () => {
+    const { manager, cleanup } = makeManagerWithConfig({
+      bash: { "rm -rf *": "deny" },
+    });
+    try {
+      const result = manager.checkPermission("bash", {
+        command: "rm -rf /",
+      });
+      expect(result.state).toBe("deny");
+      expect(result.reason).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("deny-with-reason on non-bash surface", () => {
+    const { manager, cleanup } = makeManagerWithConfig({
+      read: {
+        "*.env": {
+          action: "deny",
+          reason: "Environment files contain secrets",
+        },
+      },
+    });
+    try {
+      const result = manager.checkPermission("read", { path: ".env" });
+      expect(result.state).toBe("deny");
+      expect(result.reason).toBe("Environment files contain secrets");
+      expect(result.matchedPattern).toBe("*.env");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("non-string reason is silently rejected (malformed config edge case)", () => {
+    const { manager, cleanup } = makeManagerWithConfig({
+      bash: { "npm *": { action: "deny", reason: 42 } },
+    });
+    try {
+      // The malformed reason value is rejected by the type guard;
+      // the pattern is treated as absent, falling through to the default.
+      const result = manager.checkPermission("bash", {
+        command: "npm install",
+      });
+      expect(result.state).toBe("ask");
+      expect(result.reason).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
   // ── Last-match-wins ordering ────────────────────────────────────────────
 
   it("last-match-wins: catch-all after deny overrides the deny", () => {

--- a/packages/pi-permission-system/test/rule.test.ts
+++ b/packages/pi-permission-system/test/rule.test.ts
@@ -211,6 +211,68 @@ describe("evaluate", () => {
     expect(result.origin).toBe("project");
   });
 
+  test("evaluate() propagates reason from the matched rule", () => {
+    const rule: Rule = {
+      surface: "bash",
+      pattern: "npm *",
+      action: "deny",
+      reason: "Use pnpm instead",
+      layer: "config",
+      origin: "global",
+    };
+    const result = evaluate("bash", "npm install", [rule]);
+    expect(result.action).toBe("deny");
+    expect(result.reason).toBe("Use pnpm instead");
+  });
+
+  test("evaluate() carries reason through last-match-wins", () => {
+    const denyNpm: Rule = {
+      surface: "bash",
+      pattern: "npm *",
+      action: "deny",
+      reason: "Use pnpm",
+      layer: "config",
+      origin: "global",
+    };
+    const allowNpmInstall: Rule = {
+      surface: "bash",
+      pattern: "npm install",
+      action: "allow",
+      layer: "config",
+      origin: "global",
+    };
+    // Last rule matches and its action is "allow" → no reason expected.
+    const result = evaluate("bash", "npm install", [denyNpm, allowNpmInstall]);
+    expect(result.action).toBe("allow");
+    expect(result.reason).toBeUndefined();
+  });
+
+  test("evaluate() preserves reason when last-match-wins picks a deny with reason", () => {
+    const allowAll: Rule = {
+      surface: "bash",
+      pattern: "*",
+      action: "allow",
+      layer: "config",
+      origin: "global",
+    };
+    const denyNpm: Rule = {
+      surface: "bash",
+      pattern: "npm *",
+      action: "deny",
+      reason: "Use pnpm",
+      layer: "config",
+      origin: "global",
+    };
+    const result = evaluate("bash", "npm install", [allowAll, denyNpm]);
+    expect(result.action).toBe("deny");
+    expect(result.reason).toBe("Use pnpm");
+  });
+
+  test("evaluate() synthetic fallback rule has no reason", () => {
+    const result = evaluate("bash", "npm install", []);
+    expect(result.reason).toBeUndefined();
+  });
+
   test("evaluate() synthetic fallback rule has origin 'builtin'", () => {
     const result = evaluate("bash", "npm install", []);
     expect(result.origin).toBe("builtin");


### PR DESCRIPTION
> slop from my agent incoming, should be clean tho

## Summary

Extend permission patterns to support an object syntax for deny actions with an optional custom reason.

### Before

```json
"bash": { "npm *": "deny" }
```

### After

```json
"bash": { "npm *": { "action": "deny", "reason": "Use pnpm instead" } }
```

The reason is shown to the agent when the command is blocked:

```
[pi-permission-system] is not permitted to run 'bash' command 'npm install' (matched 'npm *'). Reason: Use pnpm instead.
```

### Changes

- **Types:** `DenyWithReason` interface, `PatternValue` type, `reason` on `PermissionCheckResult`
- **Rule:** `reason?: string` on `Rule`
- **Normalizer:** Parse `{ action: "deny", reason }` objects in `normalizeFlatConfig`
- **Config loader:** Accept `DenyWithReason` from JSON config files (gap in the design doc, was silently stripped)
- **Denial messages:** Append reason after the sentence-ending period
- **Permission manager:** Thread `rule.reason` into result
- **Schema:** Extended `permissionState` with `{ action, reason }` object form
- **Config + docs:** Updated example config and configuration docs
- **Tests:** 17 new tests across normalize, rule, denial-messages, and permission-manager-unified suites

### Verification

- ✅ 1989 tests pass (94 files, 0 regressions)
- ✅ TypeScript `tsc --noEmit` clean
- ✅ Biome lint clean on all changed files
- ✅ rumdl clean on docs
- ✅ All existing configs continue to work unchanged (backward compatible)
