### PR TITLE
fix(pi-permission-system): strip shell comment lines from bash commands before matching

### DIFF
--- a/packages/pi-permission-system/src/bash-arity.ts
+++ b/packages/pi-permission-system/src/bash-arity.ts
@@ -184,3 +184,27 @@ export function prefix(tokens: string[]): string[] {
   // Unknown command — default arity 1.
   return [tokens[0]];
 }
+
+/**
+ * Remove shell comment lines from a bash command string.
+ *
+ * A comment line is one whose first non-whitespace character is `#`. Agents
+ * frequently prepend descriptive comments before the real command
+ * (e.g. `"# Check debug logs\nfind ..."`); such prefixes defeat wildcard
+ * pattern matching and session-approval suggestions, which tokenize the
+ * leading text. Stripping comment lines lets matching operate on the actual
+ * command.
+ *
+ * The original command is never returned: when every line is a comment (or
+ * the input is blank) an empty string is returned, and each caller applies
+ * its own fallback.
+ *
+ * @param command - Raw bash command, possibly multi-line.
+ * @returns The command with comment lines removed and surrounding whitespace
+ *   trimmed, or an empty string when nothing meaningful remains.
+ */
+export function stripBashCommentLines(command: string): string {
+  const lines = command.split("\n");
+  const meaningful = lines.filter((line) => !/^\s*#/.test(line));
+  return meaningful.join("\n").trim();
+}

--- a/packages/pi-permission-system/src/input-normalizer.ts
+++ b/packages/pi-permission-system/src/input-normalizer.ts
@@ -1,3 +1,4 @@
+import { stripBashCommentLines } from "./bash-arity";
 import { getNonEmptyString, toRecord } from "./common";
 import { createMcpPermissionTargets } from "./mcp-targets";
 import { getPathPolicyValues, PATH_BEARING_TOOLS } from "./path-utils";
@@ -92,9 +93,14 @@ export function normalizeInput(
   if (toolName === "bash") {
     const record = toRecord(input);
     const command = typeof record.command === "string" ? record.command : "";
+    // Strip leading shell comment lines so pattern matching operates on the
+    // actual command, not a `# description` prefix agents often prepend.
+    // Fall back to the raw command when stripping leaves nothing, so an
+    // all-comment command still evaluates against its literal text.
+    const matchValue = stripBashCommentLines(command) || command;
     return {
       surface: "bash",
-      values: [command],
+      values: [matchValue],
       resultExtras: { command },
     };
   }

--- a/packages/pi-permission-system/src/pattern-suggest.ts
+++ b/packages/pi-permission-system/src/pattern-suggest.ts
@@ -1,4 +1,4 @@
-import { prefix } from "./bash-arity";
+import { prefix, stripBashCommentLines } from "./bash-arity";
 import { PATH_BEARING_TOOLS } from "./path-utils";
 import { deriveApprovalPattern } from "./session-rules";
 
@@ -26,11 +26,15 @@ export interface SessionApprovalSuggestion {
 export function suggestBashPattern(command: string): string {
   const trimmed = command.trim();
   if (!trimmed) return "";
-  const tokens = trimmed.split(/\s+/);
-  if (tokens.length === 1) return trimmed;
+  // Strip leading shell comment lines so the suggestion is based on the
+  // actual command, not a `# description` prefix agents often prepend.
+  const stripped = stripBashCommentLines(trimmed);
+  if (!stripped) return "";
+  const tokens = stripped.split(/\s+/);
+  if (tokens.length === 1) return stripped;
   const meaningful = prefix(tokens);
   if (meaningful.length >= tokens.length) {
-    return `${trimmed}*`;
+    return `${stripped}*`;
   }
   return `${meaningful.join(" ")} *`;
 }

--- a/packages/pi-permission-system/test/bash-arity.test.ts
+++ b/packages/pi-permission-system/test/bash-arity.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ARITY, prefix } from "#src/bash-arity";
+import { ARITY, prefix, stripBashCommentLines } from "#src/bash-arity";
 
 describe("ARITY dictionary", () => {
   it("is exported as a plain object", () => {
@@ -102,5 +102,43 @@ describe("prefix", () => {
 
   it("returns arity-1 for bare 'ls' (args are paths)", () => {
     expect(prefix(["ls", "-la", "/tmp"])).toEqual(["ls"]);
+  });
+});
+
+describe("stripBashCommentLines", () => {
+  it("removes a single leading comment line", () => {
+    expect(
+      stripBashCommentLines("# Check debug logs\nfind /home -type f"),
+    ).toBe("find /home -type f");
+  });
+
+  it("removes multiple leading comment lines", () => {
+    expect(
+      stripBashCommentLines("# Step 1\n# Step 2\ngit status --short"),
+    ).toBe("git status --short");
+  });
+
+  it("returns empty string when all lines are comments", () => {
+    expect(stripBashCommentLines("# just a comment")).toBe("");
+  });
+
+  it("returns empty string for blank input", () => {
+    expect(stripBashCommentLines("")).toBe("");
+  });
+
+  it("returns the command unchanged when no comment lines are present", () => {
+    expect(stripBashCommentLines("grep -rn foo src/")).toBe(
+      "grep -rn foo src/",
+    );
+  });
+
+  it("trims surrounding whitespace from the result", () => {
+    expect(stripBashCommentLines("\n\n  ls -la  \n")).toBe("ls -la");
+  });
+
+  it("treats indented comment lines as comments", () => {
+    expect(stripBashCommentLines("    # indented comment\necho hi")).toBe(
+      "echo hi",
+    );
   });
 });

--- a/packages/pi-permission-system/test/input-normalizer.test.ts
+++ b/packages/pi-permission-system/test/input-normalizer.test.ts
@@ -198,6 +198,34 @@ describe("normalizeInput — non-MCP surfaces", () => {
       expect(result.values).toEqual([""]);
       expect(result.resultExtras).toEqual({ command: "" });
     });
+
+    it("strips leading comment lines from values but keeps original in resultExtras", () => {
+      const cmd = "# Check debug logs\nfind /home -path '*debug*' -type f";
+      const result = normalizeInput("bash", { command: cmd }, []);
+      expect(result.values).toEqual(["find /home -path '*debug*' -type f"]);
+      expect(result.resultExtras).toEqual({ command: cmd });
+    });
+
+    it("strips multiple comment lines", () => {
+      const cmd = "# Step 1\n# Step 2\ngit status --short";
+      const result = normalizeInput("bash", { command: cmd }, []);
+      expect(result.values).toEqual(["git status --short"]);
+    });
+
+    it("preserves command when no comment lines present", () => {
+      const result = normalizeInput(
+        "bash",
+        { command: "grep -rn foo src/" },
+        [],
+      );
+      expect(result.values).toEqual(["grep -rn foo src/"]);
+    });
+
+    it("falls back to original when all lines are comments", () => {
+      const cmd = "# just a comment";
+      const result = normalizeInput("bash", { command: cmd }, []);
+      expect(result.values).toEqual(["# just a comment"]);
+    });
   });
 
   describe("path-bearing tools (read, write, edit, grep, find, ls)", () => {

--- a/packages/pi-permission-system/test/pattern-suggest.test.ts
+++ b/packages/pi-permission-system/test/pattern-suggest.test.ts
@@ -42,6 +42,30 @@ describe("suggestBashPattern", () => {
       "docker compose up *",
     );
   });
+
+  it("strips leading comment lines and suggests based on the actual command", () => {
+    expect(
+      suggestBashPattern(
+        "# Check debug logs\nfind /home -path '*debug*' -type f",
+      ),
+    ).toBe("find *");
+  });
+
+  it("strips multiple leading comment lines", () => {
+    expect(suggestBashPattern("# Step 1\n# Step 2\ngit status --short")).toBe(
+      "git status *",
+    );
+  });
+
+  it("returns empty for comment-only input", () => {
+    expect(suggestBashPattern("# just a comment")).toBe("");
+  });
+
+  it("handles mixed comment and command lines", () => {
+    expect(suggestBashPattern("# description\nrm -rf ./build; echo done")).toBe(
+      "rm *",
+    );
+  });
 });
 
 describe("suggestMcpPattern", () => {


### PR DESCRIPTION
## Symptom

I use wildcard "always allow" patterns and session-approval suggestions for bash commands. When an agent prepends a descriptive comment line before the actual command (a common pattern, e.g. `# list node versions` then `nvm ls`), the pattern match and the suggestion both fired against the comment text instead of the command, so an approved `nvm ls` pattern did not match and the suggestion proposed a pattern built from the `# list...` tokens.

## What I observed

Both `normalizeInput` (bash surface lookup value) and `suggestBashPattern` tokenize the leading text of the command. A leading `#`-comment line shifts the "leading text" onto the comment, so the lookup and the suggestion operate on comment tokens rather than the command.

## Change

Add `stripBashCommentLines()` to `bash-arity.ts` (the shared module already responsible for bash command structure analysis) and apply it in both consumers:

- `normalizeInput` (bash surface): strip comments for the lookup value, falling back to the raw command when nothing meaningful remains, so an all-comment command still evaluates against its literal text.
- `suggestBashPattern`: strip comments before tokenizing so suggestions are based on the real command.

The original command is preserved in `resultExtras` for display and logging.

## Tests

`test/bash-arity.test.ts`, `test/input-normalizer.test.ts`, and `test/pattern-suggest.test.ts` cover the stripping, the fallback for all-comment commands, and that suggestions are computed against the command rather than the comment.
