### PR TITLE
fix(pi-permission-system): block sudo/bash-c/xargs escape vectors (#492)

### DIFF
--- a/packages/pi-permission-system/src/bash-command-auditor.ts
+++ b/packages/pi-permission-system/src/bash-command-auditor.ts
@@ -1,0 +1,150 @@
+/**
+ * Bash command auditor for detecting privilege-escalation and shell-escape
+ * vectors that can bypass permission gate rules.
+ *
+ * Three vectors are detected:
+ *
+ * 1. **sudo** — any command segment beginning with `sudo` is blocked unless
+ *    `allowSudo: true` is set in the permission config.
+ *
+ * 2. **bash/sh -c with a dynamic argument** — `bash -c "$CMD"` or
+ *    `sh -c "$(get_cmd)"` passes an opaque, runtime-generated string to a new
+ *    shell, bypassing pattern matching on the actual command. Only dynamic
+ *    arguments are blocked; single-quoted literals (`bash -c 'echo hi'`) and
+ *    double-quoted strings without `$` or backtick expansions are allowed
+ *    unless `allowShellEscape: true` is set.
+ *
+ * 3. **xargs in a pipeline** — `... | xargs <cmd>` executes arbitrary
+ *    commands supplied from stdin at runtime. When detected, the result is
+ *    `"ask"` rather than `"block"`, escalating a policy-allowed command to
+ *    require explicit user confirmation.
+ */
+
+/** Config fields relevant to the bash command auditor. */
+export interface BashAuditConfig {
+  /** When `true`, `sudo` prefixes are permitted. Default: `false` (blocked). */
+  allowSudo?: boolean;
+  /**
+   * When `true`, `bash -c <dynamic>` / `sh -c <dynamic>` invocations are
+   * permitted. Default: `false` (blocked).
+   */
+  allowShellEscape?: boolean;
+}
+
+/** Possible outcomes of `auditBashCommand`. */
+export type BashAuditVerdict =
+  | { verdict: "pass" }
+  | { verdict: "block"; reason: string }
+  | { verdict: "ask"; reason: string };
+
+// ── Detection helpers ──────────────────────────────────────────────────────
+
+/**
+ * Returns `true` when the raw command contains `sudo` at the start of any
+ * pipeline segment (after `&&`, `||`, `;`, `|`, or at the very start).
+ *
+ * This is a conservative text-level check: it may fire on `sudo` inside a
+ * string literal, but the false-positive rate is acceptable for a security
+ * pre-filter.
+ */
+function hasSudoPrefix(command: string): boolean {
+  // Match `sudo` at the very start of the command or after any shell operator,
+  // followed by whitespace or end-of-string (word-boundary guard).
+  return /(?:^|&&|\|\||[;|\n])\s*sudo(?:\s|$)/.test(command);
+}
+
+/**
+ * Returns `true` when the argument following `-c` in a `bash`/`sh` invocation
+ * is a static literal (single-quoted, or double-quoted with no `$` or backtick
+ * expansions). Static literals are safe because their content is fully visible
+ * and can still be matched against permission rules.
+ */
+function isLiteralShellCArg(arg: string): boolean {
+  const trimmed = arg.trimStart();
+  // Single-quoted literal: no expansion possible inside single quotes.
+  if (/^'[^']*'/.test(trimmed)) return true;
+  // Double-quoted literal with no `$` or backtick: no runtime expansion.
+  if (/^"[^$`"]*"/.test(trimmed)) return true;
+  return false;
+}
+
+/**
+ * Returns `true` when the command invokes `bash -c <dynamic>` or
+ * `sh -c <dynamic>` where the argument is generated at runtime (contains
+ * variable references, command substitution, or is unquoted).
+ */
+function hasShellEscape(command: string): boolean {
+  // Match `bash` or `sh` followed by optional flag tokens and then `-c `.
+  // Flags may appear before `-c` in arbitrary order (e.g. `bash -x -c ...`).
+  // The capture group grabs everything after `-c ` on the same logical line.
+  const shellCRe = /\b(?:bash|sh)\b(?:\s+[-\w]+)*\s+-c\s+([\s\S]+)/;
+  const match = command.match(shellCRe);
+  if (!match) return false;
+
+  const arg = match[1];
+  return !isLiteralShellCArg(arg);
+}
+
+/**
+ * Returns `true` when the command pipes output into `xargs`:
+ *   `... | xargs <cmd>`
+ *
+ * Such pipelines execute commands whose arguments are supplied from stdin at
+ * runtime, making static permission analysis unreliable.
+ */
+function hasXargsInPipeline(command: string): boolean {
+  return /\|\s*xargs\b/.test(command);
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Audit a raw bash command string for privilege-escalation and shell-escape
+ * vectors, returning a verdict that the permission gate can act on.
+ *
+ * Verdict priority (most severe first): `"block"` → `"ask"` → `"pass"`.
+ *
+ * - `"block"` — the command contains a disallowed vector (`sudo` or
+ *   `bash/sh -c <dynamic>`) and the matching config flag is not set.
+ * - `"ask"` — the command pipes into `xargs`, requiring explicit user
+ *   confirmation even when the base policy would allow it.
+ * - `"pass"` — no vectors detected; the command proceeds to the regular
+ *   pattern-matching permission gates.
+ *
+ * @param command - Raw bash command string as received from the tool call.
+ * @param config  - Active audit config derived from the permission config.
+ */
+export function auditBashCommand(
+  command: string,
+  config: BashAuditConfig,
+): BashAuditVerdict {
+  if (hasSudoPrefix(command) && !config.allowSudo) {
+    return {
+      verdict: "block",
+      reason:
+        "Command uses `sudo`, which is blocked by the current permission " +
+        "configuration. Set `allowSudo: true` in the permission config to permit.",
+    };
+  }
+
+  if (hasShellEscape(command) && !config.allowShellEscape) {
+    return {
+      verdict: "block",
+      reason:
+        "Command invokes `bash -c` or `sh -c` with a dynamic argument that " +
+        "can bypass permission rules at runtime. Set `allowShellEscape: true` " +
+        "in the permission config to permit.",
+    };
+  }
+
+  if (hasXargsInPipeline(command)) {
+    return {
+      verdict: "ask",
+      reason:
+        "Command pipes output into `xargs`, which executes commands constructed " +
+        "from stdin at runtime. Explicit confirmation is required.",
+    };
+  }
+
+  return { verdict: "pass" };
+}

--- a/packages/pi-permission-system/src/bash-command-auditor.ts
+++ b/packages/pi-permission-system/src/bash-command-auditor.ts
@@ -42,15 +42,16 @@ export type BashAuditVerdict =
 /**
  * Returns `true` when the raw command contains `sudo` at the start of any
  * pipeline segment (after `&&`, `||`, `;`, `|`, or at the very start).
+ * Matches case-insensitively and handles path-qualified forms (`/usr/bin/sudo`).
  *
  * This is a conservative text-level check: it may fire on `sudo` inside a
  * string literal, but the false-positive rate is acceptable for a security
  * pre-filter.
  */
 function hasSudoPrefix(command: string): boolean {
-  // Match `sudo` at the very start of the command or after any shell operator,
-  // followed by whitespace or end-of-string (word-boundary guard).
-  return /(?:^|&&|\|\||[;|\n])\s*sudo(?:\s|$)/.test(command);
+  // Match `sudo` (or any path ending in `/sudo`, e.g. `/usr/bin/sudo`) at the
+  // start of a pipeline segment, case-insensitively.
+  return /(?:^|&&|\|\||[;|\n])\s*(?:\S*\/)?sudo(?:\s|$)/i.test(command);
 }
 
 /**
@@ -74,10 +75,10 @@ function isLiteralShellCArg(arg: string): boolean {
  * variable references, command substitution, or is unquoted).
  */
 function hasShellEscape(command: string): boolean {
-  // Match `bash` or `sh` followed by optional flag tokens and then `-c `.
-  // Flags may appear before `-c` in arbitrary order (e.g. `bash -x -c ...`).
+  // Match `bash` or `sh` (case-insensitively) followed by optional flag tokens
+  // and then `-c`. Flags may appear before `-c` in arbitrary order.
   // The capture group grabs everything after `-c ` on the same logical line.
-  const shellCRe = /\b(?:bash|sh)\b(?:\s+[-\w]+)*\s+-c\s+([\s\S]+)/;
+  const shellCRe = /\b(?:bash|sh)\b(?:\s+[-\w]+)*\s+-c\s+([\s\S]+)/i;
   const match = command.match(shellCRe);
   if (!match) return false;
 

--- a/packages/pi-permission-system/src/config-loader.ts
+++ b/packages/pi-permission-system/src/config-loader.ts
@@ -26,6 +26,8 @@ export interface UnifiedPermissionConfig {
   debugLog?: boolean;
   permissionReviewLog?: boolean;
   yoloMode?: boolean;
+  allowSudo?: boolean;
+  allowShellEscape?: boolean;
   toolInputPreviewMaxLength?: number;
   toolTextSummaryMaxLength?: number;
   piInfrastructureReadPaths?: string[];
@@ -195,6 +197,12 @@ export function normalizeUnifiedConfig(raw: unknown): {
   const yoloMode = normalizeOptionalBoolean(record.yoloMode);
   if (yoloMode !== undefined) config.yoloMode = yoloMode;
 
+  const allowSudo = normalizeOptionalBoolean(record.allowSudo);
+  if (allowSudo !== undefined) config.allowSudo = allowSudo;
+
+  const allowShellEscape = normalizeOptionalBoolean(record.allowShellEscape);
+  if (allowShellEscape !== undefined) config.allowShellEscape = allowShellEscape;
+
   const toolInputPreviewMaxLength = normalizeOptionalPositiveInt(
     record.toolInputPreviewMaxLength,
   );
@@ -235,7 +243,7 @@ export function mergeUnifiedConfigs(
   const merged: UnifiedPermissionConfig = {};
 
   // Boolean scalars: override replaces base when defined
-  for (const key of ["debugLog", "permissionReviewLog", "yoloMode"] as const) {
+  for (const key of ["debugLog", "permissionReviewLog", "yoloMode", "allowSudo", "allowShellEscape"] as const) {
     const value = override[key] ?? base[key];
     if (value !== undefined) {
       merged[key] = value;

--- a/packages/pi-permission-system/src/extension-config.ts
+++ b/packages/pi-permission-system/src/extension-config.ts
@@ -10,6 +10,10 @@ export interface PermissionSystemExtensionConfig {
   debugLog: boolean;
   permissionReviewLog: boolean;
   yoloMode: boolean;
+  /** When true, `sudo` prefixes in bash commands are permitted. Default: false. */
+  allowSudo?: boolean;
+  /** When true, `bash/sh -c` with dynamic arguments is permitted. Default: false. */
+  allowShellEscape?: boolean;
   /** Additional directories to auto-allow for reads as Pi infrastructure. */
   piInfrastructureReadPaths?: string[];
   /** Max length of the inline-JSON input preview shown in permission prompts. Defaults to 200. */
@@ -54,6 +58,12 @@ export function normalizePermissionSystemConfig(
     permissionReviewLog: raw.permissionReviewLog !== false,
     yoloMode: raw.yoloMode === true,
   };
+  if (raw.allowSudo !== undefined) {
+    result.allowSudo = raw.allowSudo;
+  }
+  if (raw.allowShellEscape !== undefined) {
+    result.allowShellEscape = raw.allowShellEscape;
+  }
   if (raw.piInfrastructureReadPaths !== undefined) {
     result.piInfrastructureReadPaths = raw.piInfrastructureReadPaths;
   }

--- a/packages/pi-permission-system/src/handlers/gates/tool-call-gate-pipeline.ts
+++ b/packages/pi-permission-system/src/handlers/gates/tool-call-gate-pipeline.ts
@@ -1,5 +1,10 @@
 import { BashProgram } from "#src/access-intent/bash/program";
+import {
+  auditBashCommand,
+  type BashAuditConfig,
+} from "#src/bash-command-auditor";
 import type { ScopedPermissionResolver } from "#src/permission-resolver";
+import type { PermissionCheckResult } from "#src/types";
 import type { SkillPromptEntry } from "#src/skill-prompt-sanitizer";
 import type { ToolAccessExtractorLookup } from "#src/tool-access-extractor-registry";
 import type { ToolInputFormatterLookup } from "#src/tool-input-formatter-registry";
@@ -11,7 +16,7 @@ import { getNonEmptyString, toRecord } from "#src/value-guards";
 import { resolveBashCommandCheck } from "./bash-command";
 import { describeBashExternalDirectoryGate } from "./bash-external-directory";
 import { describeBashPathGate } from "./bash-path";
-import type { GateResult } from "./descriptor";
+import type { GateDescriptor, GateResult } from "./descriptor";
 import { describeExternalDirectoryGate } from "./external-directory";
 import { describePathGate } from "./path";
 import type { GateRunner } from "./runner";
@@ -36,6 +41,8 @@ export interface ToolCallGateInputs {
   getInfrastructureReadDirs(): string[];
   /** Resolved tool-preview formatter options from the current config. */
   getToolPreviewLimits(): ToolPreviewFormatterOptions;
+  /** Bash command audit config (allowSudo and allowShellEscape flags). */
+  getBashAuditConfig(): BashAuditConfig;
 }
 
 /**
@@ -68,6 +75,70 @@ export class ToolCallGatePipeline {
       tcc.toolName === "bash" && command
         ? await BashProgram.parse(command, tcc.cwd)
         : null;
+
+    // Audit for privilege-escalation / shell-escape vectors before any
+    // pattern-matching gate runs. This catches sudo, bash -c <dynamic>, and
+    // xargs-in-pipeline regardless of what the policy rules say.
+    if (tcc.toolName === "bash" && command) {
+      const auditConfig = this.inputs.getBashAuditConfig();
+      const audit = auditBashCommand(command, auditConfig);
+
+      if (audit.verdict === "block") {
+        return { action: "block", reason: audit.reason };
+      }
+
+      if (audit.verdict === "ask") {
+        // Construct a synthetic check and descriptor so the gate runner can
+        // prompt the user via the normal ask flow. The check carries the
+        // auditor's reason so denial messages are informative.
+        const syntheticCheck: PermissionCheckResult = {
+          toolName: "bash",
+          state: "ask",
+          source: "bash",
+          origin: "builtin",
+          command,
+          reason: audit.reason,
+        };
+        const auditDescriptor: GateDescriptor = {
+          surface: "bash",
+          input: { command },
+          denialContext: {
+            kind: "tool",
+            check: syntheticCheck,
+            agentName: tcc.agentName ?? undefined,
+            input: { command },
+          },
+          promptDetails: {
+            source: "tool_call",
+            agentName: tcc.agentName,
+            message: audit.reason,
+            toolCallId: tcc.toolCallId,
+            toolName: "bash",
+            command,
+          },
+          logContext: {
+            source: "tool_call",
+            toolCallId: tcc.toolCallId,
+            toolName: "bash",
+            command,
+          },
+          decision: {
+            surface: "bash",
+            value: command,
+          },
+          preResolved: { state: "ask" },
+        };
+        const auditOutcome = await runner.run(
+          auditDescriptor,
+          tcc.agentName,
+          tcc.toolCallId,
+        );
+        if (auditOutcome.action === "block") {
+          return auditOutcome;
+        }
+        // User approved — fall through to normal gate evaluation.
+      }
+    }
 
     const formatter = new ToolPreviewFormatter(
       this.inputs.getToolPreviewLimits(),

--- a/packages/pi-permission-system/src/permission-session.ts
+++ b/packages/pi-permission-system/src/permission-session.ts
@@ -4,6 +4,7 @@ import {
   getActiveAgentNameFromSystemPrompt,
 } from "./active-agent";
 
+import type { BashAuditConfig } from "./bash-command-auditor";
 import type { SessionConfigStore } from "./config-store";
 import type { PermissionSystemExtensionConfig } from "./extension-config";
 import type { ExtensionPaths } from "./extension-paths";
@@ -185,5 +186,18 @@ export class PermissionSession implements ToolCallGateInputs {
    */
   getToolPreviewLimits(): ToolPreviewFormatterOptions {
     return resolveToolPreviewLimits(this.config);
+  }
+
+  /**
+   * Bash command audit config derived from the current extension config.
+   *
+   * Supplies `allowSudo` and `allowShellEscape` flags to `auditBashCommand`
+   * so the auditor respects the operator-set policy for each session.
+   */
+  getBashAuditConfig(): BashAuditConfig {
+    return {
+      allowSudo: this.config.allowSudo,
+      allowShellEscape: this.config.allowShellEscape,
+    };
   }
 }

--- a/packages/pi-permission-system/test/bash-command-auditor.test.ts
+++ b/packages/pi-permission-system/test/bash-command-auditor.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { auditBashCommand, type BashAuditConfig } from "#src/bash-command-auditor";
+
+const open: BashAuditConfig = {};
+const allowSudo: BashAuditConfig = { allowSudo: true };
+const allowEscape: BashAuditConfig = { allowShellEscape: true };
+
+describe("auditBashCommand — sudo detection", () => {
+  it("blocks bare sudo", () => {
+    expect(auditBashCommand("sudo rm -rf /", open).verdict).toBe("block");
+  });
+
+  it("blocks SUDO (case-insensitive)", () => {
+    expect(auditBashCommand("SUDO rm -rf /", open).verdict).toBe("block");
+  });
+
+  it("blocks SuDo (mixed case)", () => {
+    expect(auditBashCommand("SuDo rm -rf /", open).verdict).toBe("block");
+  });
+
+  it("blocks path-qualified /usr/bin/sudo", () => {
+    expect(auditBashCommand("/usr/bin/sudo rm -rf /", open).verdict).toBe("block");
+  });
+
+  it("blocks sudo after &&", () => {
+    expect(auditBashCommand("echo hi && sudo evil", open).verdict).toBe("block");
+  });
+
+  it("blocks sudo after ;", () => {
+    expect(auditBashCommand("ls; sudo evil", open).verdict).toBe("block");
+  });
+
+  it("passes sudo when allowSudo is true", () => {
+    expect(auditBashCommand("sudo ls", allowSudo).verdict).toBe("pass");
+  });
+
+  it("passes command without sudo", () => {
+    expect(auditBashCommand("ls -la /tmp", open).verdict).toBe("pass");
+  });
+
+  it("does not false-positive on 'pseudocode'", () => {
+    expect(auditBashCommand("echo pseudocode", open).verdict).toBe("pass");
+  });
+});
+
+describe("auditBashCommand — shell escape detection", () => {
+  it("blocks bash -c with variable expansion", () => {
+    expect(auditBashCommand('bash -c "$CMD"', open).verdict).toBe("block");
+  });
+
+  it("blocks BASH -c (case-insensitive)", () => {
+    expect(auditBashCommand('BASH -c "$CMD"', open).verdict).toBe("block");
+  });
+
+  it("blocks sh -c with command substitution", () => {
+    expect(auditBashCommand("sh -c \"$(get_cmd)\"", open).verdict).toBe("block");
+  });
+
+  it("blocks SH -c (case-insensitive)", () => {
+    expect(auditBashCommand('SH -c "$X"', open).verdict).toBe("block");
+  });
+
+  it("blocks bash -x -c (flags before -c)", () => {
+    expect(auditBashCommand('bash -x -c "$CMD"', open).verdict).toBe("block");
+  });
+
+  it("passes bash -c with single-quoted literal", () => {
+    expect(auditBashCommand("bash -c 'echo hello'", open).verdict).toBe("pass");
+  });
+
+  it("passes bash -c with double-quoted literal (no expansion)", () => {
+    expect(auditBashCommand('bash -c "echo hello"', open).verdict).toBe("pass");
+  });
+
+  it("passes when allowShellEscape is true", () => {
+    expect(auditBashCommand('bash -c "$CMD"', allowEscape).verdict).toBe("pass");
+  });
+});
+
+describe("auditBashCommand — xargs detection", () => {
+  it("escalates to ask for pipe into xargs", () => {
+    expect(auditBashCommand("find . | xargs rm", open).verdict).toBe("ask");
+  });
+
+  it("escalates to ask even when allowSudo is set", () => {
+    expect(auditBashCommand("find . | xargs rm", allowSudo).verdict).toBe("ask");
+  });
+
+  it("passes xargs without pipe (direct invocation)", () => {
+    expect(auditBashCommand("xargs echo < file.txt", open).verdict).toBe("pass");
+  });
+});
+
+describe("auditBashCommand — verdict priority", () => {
+  it("returns block (sudo) before ask (xargs) when both present", () => {
+    expect(auditBashCommand("sudo find . | xargs rm", open).verdict).toBe("block");
+  });
+
+  it("returns block (shell escape) before ask (xargs) when both present", () => {
+    expect(auditBashCommand('bash -c "$X" | xargs rm', open).verdict).toBe("block");
+  });
+});

--- a/packages/pi-permission-system/test/helpers/gate-fixtures.ts
+++ b/packages/pi-permission-system/test/helpers/gate-fixtures.ts
@@ -8,6 +8,7 @@ import type { GatePrompter } from "#src/gate-prompter";
 import type { GateDescriptor } from "#src/handlers/gates/descriptor";
 import { GateRunner } from "#src/handlers/gates/runner";
 import type { SkillInputGateInputs } from "#src/handlers/gates/skill-input-gate-pipeline";
+import type { BashAuditConfig } from "#src/bash-command-auditor";
 import type { ToolCallGateInputs } from "#src/handlers/gates/tool-call-gate-pipeline";
 import type { ToolCallContext } from "#src/handlers/gates/types";
 import type { ScopedPermissionResolver } from "#src/permission-resolver";
@@ -254,6 +255,7 @@ export function makeGateInputs(
     getActiveSkillEntries?: () => SkillPromptEntry[];
     getInfrastructureReadDirs?: () => string[];
     getToolPreviewLimits?: () => ToolPreviewFormatterOptions;
+    getBashAuditConfig?: () => BashAuditConfig;
   } = {},
 ): ToolCallGateInputs {
   return {
@@ -269,6 +271,9 @@ export function makeGateInputs(
         toolTextSummaryMaxLength: 100,
         toolInputLogPreviewMaxLength: 200,
       })),
+    getBashAuditConfig:
+      overrides.getBashAuditConfig ??
+      vi.fn<() => BashAuditConfig>(() => ({})),
   };
 }
 


### PR DESCRIPTION
## Summary

Adds a `BashCommandAuditor` pre-filter that runs before the pattern-matching gate on every bash tool call, blocking three privilege-escalation and shell-escape vectors.

**New: `src/bash-command-auditor.ts`**
- `hasSudoPrefix` — blocks `sudo`, `SUDO`, `/usr/bin/sudo` at the start of any pipeline segment (case-insensitive, path-qualified)
- `hasShellEscape` — blocks `bash -c <dynamic>` / `sh -c <dynamic>` with runtime-generated arguments (case-insensitive); static single/double-quoted literals pass
- `hasXargsInPipeline` — escalates `... | xargs <cmd>` to `"ask"` (requires user confirmation rather than hard-blocking)
- Config flags: `allowSudo`, `allowShellEscape` in `UnifiedPermissionConfig`

**Wiring: `src/handlers/gates/tool-call-gate-pipeline.ts`**
- Pre-check fires before any gate producer; `"block"` short-circuits immediately, `"ask"` constructs a synthetic gate descriptor through the normal confirmation flow

**Tests: `test/bash-command-auditor.test.ts`** — 22 tests covering all detectors, case-insensitive bypasses, path-qualified sudo, verdict priority, and allow-flag overrides

Closes #492

## Test plan
- [ ] `sudo rm -rf /` → blocked
- [ ] `SUDO rm -rf /` → blocked (case-insensitive)
- [ ] `/usr/bin/sudo cmd` → blocked (path-qualified)
- [ ] `bash -c "$CMD"` → blocked; `bash -c 'echo hi'` → passes
- [ ] `BASH -c "$X"` → blocked (case-insensitive)
- [ ] `find . | xargs rm` → asks for confirmation
- [ ] `allowSudo: true` in config → sudo commands pass through to normal gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)