### PR TITLE
fix(pi-subagents): complete exclude disabled agents from the subagent…

### DIFF
--- a/packages/pi-subagents/src/tools/agent-tool.ts
+++ b/packages/pi-subagents/src/tools/agent-tool.ts
@@ -128,6 +128,12 @@ export class AgentTool {
 		const agentDir = this.agentDir;
 		const registry = this.registry;
 
+		const agentSpecificGuidelines = [
+			registry.isValidType("Explore") &&  "- Use Explore for codebase searches and code understanding.",
+			registry.isValidType("Plan") &&  "- Use Plan for architecture and implementation planning.",
+			registry.isValidType("general-purpose") && "- Use general-purpose for complex tasks that need file editing.",
+		].filter((line): line is string => typeof line === "string");
+
 		return defineTool({
 			name: "subagent" as const,
 			label: "Subagent",
@@ -140,10 +146,8 @@ Available agent types:
 ${typeListText}
 
 Guidelines:
+${agentSpecificGuidelines.join("\n")}
 - For parallel work, use run_in_background: true on each agent. Foreground calls run sequentially — only one executes at a time.
-- Use Explore for codebase searches and code understanding.
-- Use Plan for architecture and implementation planning.
-- Use general-purpose for complex tasks that need file editing.
 - Provide clear, detailed prompts so the agent can work autonomously.
 - Subagent results are returned as text — summarize them for the user.
 - Use run_in_background for work you don't need immediately. You will be notified when it completes.

--- a/packages/pi-subagents/src/tools/helpers.ts
+++ b/packages/pi-subagents/src/tools/helpers.ts
@@ -88,8 +88,7 @@ export function buildTypeListText(registry: TypeListRegistry, agentDir: string):
   });
 
   return [
-    "Default agents:",
-    ...defaultDescs,
+    ...(defaultDescs.length > 0 ? ["Default agents:", ...defaultDescs] : []),
     ...(customDescs.length > 0 ? ["", "Custom agents:", ...customDescs] : []),
     "",
     `Custom agents can be defined in .pi/agents/<name>.md (project) or ${agentDir}/agents/<name>.md (global) — they are picked up automatically. Project-level agents override global ones. Creating a .md file with the same name as a default agent overrides it.`,

--- a/packages/pi-subagents/test/helpers/make-deps.ts
+++ b/packages/pi-subagents/test/helpers/make-deps.ts
@@ -63,3 +63,21 @@ export function createToolDeps(overrides: Partial<AgentToolFixture> = {}): Agent
 		...overrides,
 	};
 }
+
+export function createToolDepsWithDisabledBuiltInAgents(...names: string[]) {
+	const registry = new AgentTypeRegistry(() => new Map(
+		names.map((name) => [
+			name,
+			{
+				name,
+				description: 'disabled built-in agent',
+				promptMode: "append",
+				systemPrompt: "",
+				isDefault: true,
+				enabled: false,
+			},
+		]),
+	));
+
+	return createToolDeps({ registry });
+}

--- a/packages/pi-subagents/test/tools/agent-tool.test.ts
+++ b/packages/pi-subagents/test/tools/agent-tool.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { AgentTool } from "#src/tools/agent-tool";
-import { createToolDeps } from "#test/helpers/make-deps";
+import { createToolDeps, createToolDepsWithDisabledBuiltInAgents } from "#test/helpers/make-deps";
 import { createTestSubagent } from "#test/helpers/make-subagent";
 import { createMockSession, createSubagentSessionStub, toSubagentSession } from "#test/helpers/mock-session";
 
@@ -48,6 +48,12 @@ describe("AgentTool", () => {
 		// testRegistry loads default agents: general-purpose, Explore, Plan
 		expect(def.description).toContain("- general-purpose: General-purpose agent");
 		expect(def.description).toContain("- Explore: Fast codebase exploration agent");
+	});
+
+	it.for(['Explore', 'Plan', 'general-purpose'])("exclude the description of default %s when it is disabled", (name) => {
+		const def = makeTool(createToolDepsWithDisabledBuiltInAgents(name)).toToolDefinition();
+		expect(def.description).not.toContain(`- ${name} :`);
+		expect(def.description).not.toContain(`- Use ${name} for `);
 	});
 
 	it("calls registry.reload() on each execute", async () => {

--- a/packages/pi-subagents/test/tools/helpers.test.ts
+++ b/packages/pi-subagents/test/tools/helpers.test.ts
@@ -125,6 +125,15 @@ describe("buildTypeListText", () => {
     expect(result).not.toContain("Plan");
   });
 
+  it('excludes Default agents section when no default agents exist', () => {
+    const registry = makeRegistry({
+      users: ["my-agent"],
+      resolve: () => ({ description: "My custom agent", model: undefined }),
+    });
+    const result = buildTypeListText(registry, "/home/.pi");
+    expect(result).not.toContain("Default agents:");
+  });
+
   it("excludes disabled agents from the custom agents list", () => {
     const registry = makeRegistry({
       defaults: ["general-purpose"],


### PR DESCRIPTION
## Summary

Fixes the pi-subagents tool description so disabled built-in agents are fully omitted from the exposed subagent tool help.

- omits the entire “Default agents” section when no default agents are available.
- removes hard-coded usage guidelines for disabled built-in agents such as Explore, Plan, and general-purpose.
- adds regression coverage for disabled built-in agents and empty default-agent lists.

## Why

Previously, disabled built-in agents could still appear in the subagent tool description through static guideline text, even after being excluded from the available agent list. The change makes the generated description reflect the actual registry state, keeping model guidance consistent with the enabled agent surface.

This problem relates to Issue #443 which has already been resolved, but the fix in commit 9a43414b3e15f0c978db9d468b737b13b801fdb2 is incomplete.

## Verification

- CI=true pnpm run --filter @gotgenes/pi-subagents exec vitest run test/helpers/make-deps.ts test/tools/agent-tool.test.ts test/tools/helpers.test.ts
- CI=true pnpm --filter @gotgenes/pi-subagents run check
- CI=true pnpm --filter @gotgenes/pi-subagents run lint
