### PR TITLE
feat(pi-subagents): inherit parent active tools

### DIFF
--- a/packages/pi-subagents/src/index.ts
+++ b/packages/pi-subagents/src/index.ts
@@ -54,6 +54,7 @@ export default function (pi: ExtensionAPI) {
 
   // ---- Runtime: all mutable extension state in one place ----
   const runtime = createSubagentRuntime();
+  runtime.setActiveToolsProvider(() => pi.getActiveTools());
 
   // ---- Notification system ----
   // Owns completion nudges and live-activity cleanup. The widget detects finished

--- a/packages/pi-subagents/src/lifecycle/create-subagent-session.ts
+++ b/packages/pi-subagents/src/lifecycle/create-subagent-session.ts
@@ -206,7 +206,7 @@ export async function createSubagentSession(
     settingsManager: deps.io.createSettingsManager(cfg.effectiveCwd, agentDir),
     modelRegistry: snapshot.modelRegistry,
     model: cfg.model,
-    tools: cfg.toolNames,
+    tools: [...new Set([...cfg.toolNames, ...snapshot.activeTools])],
     resourceLoader: loader,
     thinkingLevel: cfg.thinkingLevel,
   });

--- a/packages/pi-subagents/src/lifecycle/parent-snapshot.ts
+++ b/packages/pi-subagents/src/lifecycle/parent-snapshot.ts
@@ -21,6 +21,8 @@ export interface ParentSnapshot {
     find(provider: string, modelId: string): unknown;
     getAvailable?(): Array<{ provider: string; id: string }>;
   };
+  /** Active parent tool names captured at spawn time. */
+  activeTools: string[];
   /** Pre-built parent conversation text (when inheritContext was requested). */
   parentContext?: string;
 }
@@ -34,6 +36,7 @@ export interface ParentSnapshot {
 export function buildParentSnapshot(
   ctx: SessionContext,
   inheritContext?: boolean,
+  activeTools: string[] = [],
 ): ParentSnapshot {
   const parentContext = inheritContext ? buildParentContext(ctx) : undefined;
   return {
@@ -42,6 +45,7 @@ export function buildParentSnapshot(
     model: ctx.model,
 
     modelRegistry: ctx.modelRegistry!,
+    activeTools,
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- || intentional: converts empty string to undefined as well as null/undefined
     parentContext: parentContext || undefined,
   };

--- a/packages/pi-subagents/src/runtime.ts
+++ b/packages/pi-subagents/src/runtime.ts
@@ -30,6 +30,7 @@ export class SubagentRuntime {
   // ── Session state (was closure-scoped in index.ts) ───────────────────────
   /** Active Pi session context — set on session_start, cleared on session_shutdown. */
   currentCtx: SessionContext | undefined = undefined;
+  private getActiveTools: () => string[] = () => [];
 
   // ── Session-context methods ──────────────────────────────────────────────
 
@@ -43,13 +44,17 @@ export class SubagentRuntime {
     this.currentCtx = undefined;
   }
 
+  setActiveToolsProvider(provider: () => string[]): void {
+    this.getActiveTools = provider;
+  }
+
   /**
    * Build a parent snapshot from the current session context.
    * Only valid during an active session (currentCtx is defined).
    */
   buildSnapshot(inheritContext: boolean): ParentSnapshot {
 
-    return buildParentSnapshot(this.currentCtx!, inheritContext);
+    return buildParentSnapshot(this.currentCtx!, inheritContext, this.getActiveTools());
   }
 
   /** Extract model info from the current session context. */

--- a/packages/pi-subagents/test/helpers/stub-ctx.ts
+++ b/packages/pi-subagents/test/helpers/stub-ctx.ts
@@ -15,4 +15,5 @@ export const STUB_SNAPSHOT: ParentSnapshot = {
   systemPrompt: "test prompt",
   model: undefined,
   modelRegistry: { find: () => undefined },
+  activeTools: [],
 };

--- a/packages/pi-subagents/test/lifecycle/create-subagent-session.test.ts
+++ b/packages/pi-subagents/test/lifecycle/create-subagent-session.test.ts
@@ -70,6 +70,17 @@ describe("createSubagentSession — assembly", () => {
     expect(session.bindExtensions).toHaveBeenCalledWith({});
   });
 
+  it("includes an active parent extension tool before the child session is created", async () => {
+    await createSubagentSession(
+      { snapshot: { ...STUB_SNAPSHOT, activeTools: ["extension_tool"] }, type: "Explore" },
+      defaultDeps(),
+    );
+
+    expect(io.createSession).toHaveBeenCalledWith(expect.objectContaining({
+      tools: ["read", "extension_tool"],
+    }));
+  });
+
   it("passes the effective cwd and agentDir to the loader, settings, and session", async () => {
     await createSubagentSession(
       { snapshot: STUB_SNAPSHOT, type: "Explore", cwd: "/tmp/worktree" },

--- a/packages/pi-subagents/test/lifecycle/parent-snapshot.test.ts
+++ b/packages/pi-subagents/test/lifecycle/parent-snapshot.test.ts
@@ -33,6 +33,11 @@ describe("buildParentSnapshot", () => {
     expect(snapshot.systemPrompt).toBe("my prompt");
   });
 
+  it("captures supplied parent active tools", () => {
+    expect(buildParentSnapshot(makeCtx(), false, ["read", "extension_tool"]).activeTools)
+      .toEqual(["read", "extension_tool"]);
+  });
+
   it("captures model from ctx", () => {
     const model = { id: "claude-haiku", provider: "anthropic" };
     const snapshot = buildParentSnapshot(makeCtx({ model }));

--- a/packages/pi-subagents/test/print-mode.test.ts
+++ b/packages/pi-subagents/test/print-mode.test.ts
@@ -14,7 +14,7 @@ import subagentsExtension from "#src/index";
 import { createSubagentSession } from "#src/lifecycle/create-subagent-session";
 import { createMockSession, createSubagentSessionStub, toSubagentSession } from "./helpers/mock-session";
 
-function makePi() {
+function makePi(activeTools: string[] = []) {
   const tools = new Map<string, any>();
   const handlers = new Map<string, any>();
   const eventHandlers = new Map<string, any>();
@@ -26,6 +26,7 @@ function makePi() {
         tools.set(tool.name, tool);
       }),
       registerCommand: vi.fn(),
+      getActiveTools: vi.fn(() => activeTools),
       on: vi.fn((event: string, handler: any) => {
         handlers.set(event, handler);
       }),
@@ -65,6 +66,7 @@ function makeHeadlessCtx() {
       getBranch: vi.fn(() => []),
     },
     getSystemPrompt: vi.fn(() => "parent prompt"),
+    getActiveTools: vi.fn(() => []),
   } as any;
 }
 
@@ -79,7 +81,7 @@ describe("print mode background notifications", () => {
       toSubagentSession(createSubagentSessionStub(createMockSession(), "/sessions/child.jsonl")),
     );
 
-    const { pi, tools, handlers } = makePi();
+    const { pi, tools, handlers } = makePi(["extension_tool"]);
     subagentsExtension(pi);
     vi.useFakeTimers();
 
@@ -99,6 +101,11 @@ describe("print mode background notifications", () => {
       undefined,
       undefined,
       makeHeadlessCtx(),
+    );
+
+    expect(vi.mocked(createSubagentSession)).toHaveBeenCalledWith(
+      expect.objectContaining({ snapshot: expect.objectContaining({ activeTools: ["extension_tool"] }) }),
+      expect.anything(),
     );
 
     await vi.advanceTimersByTimeAsync(100); // smart-join batch debounce

--- a/packages/pi-subagents/test/runtime.test.ts
+++ b/packages/pi-subagents/test/runtime.test.ts
@@ -91,8 +91,20 @@ describe("SubagentRuntime context query methods", () => {
     runtime.setSessionContext(ctx);
     mockBuildParentSnapshot.mockReturnValueOnce(STUB_SNAPSHOT);
     const result = runtime.buildSnapshot(true);
-    expect(mockBuildParentSnapshot).toHaveBeenCalledWith(ctx, true);
+    expect(mockBuildParentSnapshot).toHaveBeenCalledWith(ctx, true, []);
     expect(result).toBe(STUB_SNAPSHOT);
+  });
+
+  it("captures active extension tools through its composition provider", () => {
+    const runtime = createSubagentRuntime();
+    const ctx = makeSessionCtx();
+    runtime.setSessionContext(ctx);
+    runtime.setActiveToolsProvider(() => ["read", "extension_tool"]);
+    mockBuildParentSnapshot.mockReturnValueOnce(STUB_SNAPSHOT);
+
+    runtime.buildSnapshot(true);
+
+    expect(mockBuildParentSnapshot).toHaveBeenCalledWith(ctx, true, ["read", "extension_tool"]);
   });
 
   it("buildSnapshot passes false inheritContext correctly", () => {
@@ -101,7 +113,7 @@ describe("SubagentRuntime context query methods", () => {
     runtime.setSessionContext(ctx);
     mockBuildParentSnapshot.mockReturnValueOnce(STUB_SNAPSHOT);
     runtime.buildSnapshot(false);
-    expect(mockBuildParentSnapshot).toHaveBeenCalledWith(ctx, false);
+    expect(mockBuildParentSnapshot).toHaveBeenCalledWith(ctx, false, []);
   });
 
   it("getModelInfo returns model and modelRegistry from current context", () => {


### PR DESCRIPTION
## Summary
- capture the parent active tool set at the extension runtime composition boundary
- persist it in the immutable spawn snapshot
- include active extension-provided parent tools in the native child’s initial tool set before its first model/provider request
- enable tools such as Mailbox `mecha_parent_message` to be available when the provider is loaded in that child
- preserve native child completion and the existing recursion guard after extensions bind
- add no relay, Sentinel-specific path, or policy layer

## Validation
- `mise exec pnpm@11.5.2 -- pnpm --filter @gotgenes/pi-subagents run check`
- `mise exec pnpm@11.5.2 -- pnpm --filter @gotgenes/pi-subagents test` (64 files, 999 tests)
- independent final review: clean