### PR TITLE
feat(pi-subagents): add global background default

### DIFF
--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -266,6 +266,8 @@ Foreground agents bypass the queue — they block the parent anyway.
 ## Persistent Settings
 
 Runtime tuning values set via `/subagents:settings` (max concurrency, default max turns, grace turns) persist across pi restarts.
+The hand-edited global config also supports `defaultRunInBackground` (default `false`): when `true`, any `subagent` call that omits `run_in_background` runs in the background.
+Explicit `run_in_background: true` or `false` and agent frontmatter continue to take precedence.
 Two files, merged on load:
 
 - **Global:** `~/.pi/agent/subagents.json` — your machine-wide defaults.
@@ -283,12 +285,13 @@ mkdir -p ~/.pi/agent
 cat > ~/.pi/agent/subagents.json <<'EOF'
 {
   "maxConcurrent": 16,
-  "graceTurns": 10
+  "graceTurns": 10,
+  "defaultRunInBackground": true
 }
 EOF
 ```
 
-Every project now starts with concurrency 16 and grace 10, without ever touching the command.
+Every project now starts with concurrency 16, grace 10, and background execution for calls that omit `run_in_background`, without ever touching the command.
 Individual projects can still override via `/subagents:settings`.
 
 **Failure behavior:** missing file is silent; malformed JSON logs a `[pi-subagents] Ignoring malformed settings at …` warning to stderr; invalid/out-of-range field values are dropped per-field; write failures downgrade the `/subagents:settings` toast to a warning with `(session only; failed to persist)`.

--- a/packages/pi-subagents/src/config/invocation-config.ts
+++ b/packages/pi-subagents/src/config/invocation-config.ts
@@ -11,6 +11,7 @@ interface AgentInvocationParams {
 export function resolveAgentInvocationConfig(
   agentConfig: AgentConfig | undefined,
   params: AgentInvocationParams,
+  defaultRunInBackground = false,
 ): {
   modelInput?: string;
   modelFromParams: boolean;
@@ -25,6 +26,6 @@ export function resolveAgentInvocationConfig(
     thinking: (agentConfig?.thinking ?? params.thinking) as ThinkingLevel | undefined,
     maxTurns: agentConfig?.maxTurns ?? params.max_turns,
     inheritContext: agentConfig?.inheritContext ?? params.inherit_context ?? false,
-    runInBackground: agentConfig?.runInBackground ?? params.run_in_background ?? false,
+    runInBackground: agentConfig?.runInBackground ?? params.run_in_background ?? defaultRunInBackground,
   };
 }

--- a/packages/pi-subagents/src/settings.ts
+++ b/packages/pi-subagents/src/settings.ts
@@ -6,6 +6,8 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { type LayeredSettingsSource, loadLayeredSettings } from "#src/layered-settings";
 export interface SubagentsSettings {
+  /** Default omitted run_in_background to true for tool-based launches. */
+  defaultRunInBackground?: boolean;
   maxConcurrent?: number;
   /**
    * 0 = unlimited — the extension's single source of truth for that convention:
@@ -29,6 +31,7 @@ const DEFAULT_GRACE_TURNS = 5;
  */
 export class SettingsManager {
   private _defaultMaxTurns: number | undefined = undefined;
+  private _defaultRunInBackground = false;
   private _graceTurns: number = DEFAULT_GRACE_TURNS;
   private _maxConcurrent: number = DEFAULT_MAX_CONCURRENT;
 
@@ -56,6 +59,10 @@ export class SettingsManager {
     } else {
       this._defaultMaxTurns = Math.max(1, n);
     }
+  }
+
+  get defaultRunInBackground(): boolean {
+    return this._defaultRunInBackground;
   }
 
   // ── graceTurns: minimum 1 ──
@@ -89,6 +96,9 @@ export class SettingsManager {
     const settings = loadSettings(this.agentDir, this.cwd);
     if (typeof settings.maxConcurrent === "number") this.maxConcurrent = settings.maxConcurrent;
     if (typeof settings.defaultMaxTurns === "number") this.defaultMaxTurns = settings.defaultMaxTurns;
+    if (typeof settings.defaultRunInBackground === "boolean") {
+      this._defaultRunInBackground = settings.defaultRunInBackground;
+    }
     if (typeof settings.graceTurns === "number") this.graceTurns = settings.graceTurns;
     this.emit("subagents:settings_loaded", { settings });
     return settings;
@@ -98,8 +108,9 @@ export class SettingsManager {
    * Snapshot current in-memory values for persistence.
    * `defaultMaxTurns` uses 0 as the on-disk marker for unlimited (undefined).
    */
-  snapshot(): { maxConcurrent: number; defaultMaxTurns: number; graceTurns: number } {
+  snapshot(): { defaultRunInBackground: boolean; maxConcurrent: number; defaultMaxTurns: number; graceTurns: number } {
     return {
+      defaultRunInBackground: this._defaultRunInBackground,
       maxConcurrent: this._maxConcurrent,
       defaultMaxTurns: this._defaultMaxTurns ?? 0,
       graceTurns: this._graceTurns,
@@ -158,6 +169,9 @@ function sanitize(raw: unknown): SubagentsSettings {
   if (!raw || typeof raw !== "object") return {};
   const r = raw as Record<string, unknown>;
   const out: SubagentsSettings = {};
+  if (typeof r.defaultRunInBackground === "boolean") {
+    out.defaultRunInBackground = r.defaultRunInBackground;
+  }
   if (
     Number.isInteger(r.maxConcurrent) &&
     (r.maxConcurrent as number) >= 1 &&

--- a/packages/pi-subagents/src/tools/agent-tool.ts
+++ b/packages/pi-subagents/src/tools/agent-tool.ts
@@ -33,6 +33,7 @@ export interface AgentToolRuntime {
 /** Narrow settings accessor — only the fields the Agent tool reads. */
 export type AgentToolSettings = {
 	readonly defaultMaxTurns: number | undefined;
+	readonly defaultRunInBackground: boolean;
 	readonly maxConcurrent: number;
 };
 

--- a/packages/pi-subagents/src/tools/spawn-config.ts
+++ b/packages/pi-subagents/src/tools/spawn-config.ts
@@ -75,7 +75,7 @@ export function resolveSpawnConfig(
   params: Record<string, unknown>,
   registry: AgentTypeRegistry,
   modelInfo: ModelInfo,
-  settings: { readonly defaultMaxTurns: number | undefined },
+  settings: { readonly defaultMaxTurns: number | undefined; readonly defaultRunInBackground?: boolean },
 ): ResolvedSpawnConfig | SpawnConfigError {
   const rawType = params.subagent_type as SubagentType;
   const resolved = registry.resolveType(rawType);
@@ -92,7 +92,11 @@ export function resolveSpawnConfig(
 
   // Merge agent config defaults with tool-call params
   const customConfig = registry.resolveAgentConfig(subagentType);
-  const resolvedConfig = resolveAgentInvocationConfig(customConfig, params);
+  const resolvedConfig = resolveAgentInvocationConfig(
+    customConfig,
+    params,
+    settings.defaultRunInBackground ?? false,
+  );
 
   // Resolve model
   const resolution = resolveInvocationModel(

--- a/packages/pi-subagents/test/config/invocation-config.test.ts
+++ b/packages/pi-subagents/test/config/invocation-config.test.ts
@@ -75,6 +75,26 @@ describe("resolveAgentInvocationConfig", () => {
     expect(resolved.runInBackground).toBe(true);
   });
 
+  it("uses the background default only when config and tool params omit it", () => {
+    const resolved = resolveAgentInvocationConfig(
+      makeConfig({ runInBackground: undefined }),
+      {},
+      true,
+    );
+
+    expect(resolved.runInBackground).toBe(true);
+  });
+
+  it("keeps an explicit agent foreground default over the global fallback", () => {
+    const resolved = resolveAgentInvocationConfig(
+      makeConfig({ runInBackground: false }),
+      { run_in_background: true },
+      true,
+    );
+
+    expect(resolved.runInBackground).toBe(false);
+  });
+
   it("defaults booleans to false when neither config nor params set them", () => {
     const resolved = resolveAgentInvocationConfig(
       makeConfig({

--- a/packages/pi-subagents/test/helpers/make-deps.test.ts
+++ b/packages/pi-subagents/test/helpers/make-deps.test.ts
@@ -39,6 +39,10 @@ describe("createToolDeps", () => {
 			expect(createToolDeps().settings.defaultMaxTurns).toBeUndefined();
 		});
 
+		it("settings.defaultRunInBackground is false by default", () => {
+			expect(createToolDeps().settings.defaultRunInBackground).toBe(false);
+		});
+
 		it("settings.maxConcurrent is 4 by default", () => {
 			expect(createToolDeps().settings.maxConcurrent).toBe(4);
 		});
@@ -65,8 +69,11 @@ describe("createToolDeps", () => {
 		});
 
 		it("replaces settings when overridden", () => {
-			const deps = createToolDeps({ settings: { defaultMaxTurns: 10, maxConcurrent: 2 } });
+			const deps = createToolDeps({
+				settings: { defaultMaxTurns: 10, defaultRunInBackground: true, maxConcurrent: 2 },
+			});
 			expect(deps.settings.defaultMaxTurns).toBe(10);
+			expect(deps.settings.defaultRunInBackground).toBe(true);
 			expect(deps.settings.maxConcurrent).toBe(2);
 		});
 	});

--- a/packages/pi-subagents/test/helpers/make-deps.ts
+++ b/packages/pi-subagents/test/helpers/make-deps.ts
@@ -57,7 +57,11 @@ export function createToolDeps(overrides: Partial<AgentToolFixture> = {}): Agent
 			getRecord: vi.fn().mockReturnValue(createTestSubagent()),
 		},
 		runtime,
-		settings: { defaultMaxTurns: undefined as number | undefined, maxConcurrent: 4 },
+		settings: {
+			defaultMaxTurns: undefined as number | undefined,
+			defaultRunInBackground: false,
+			maxConcurrent: 4,
+		},
 		registry: defaultRegistry,
 		agentDir: "/home/user/.pi",
 		...overrides,

--- a/packages/pi-subagents/test/settings.test.ts
+++ b/packages/pi-subagents/test/settings.test.ts
@@ -51,6 +51,13 @@ describe("settings persistence", () => {
     expect(loadSettings(globalDir, projectDir)).toEqual({ maxConcurrent: 16, graceTurns: 10 });
   });
 
+  it("loads defaultRunInBackground from the global file", () => {
+    writeGlobal({ defaultRunInBackground: true });
+    expect(loadSettings(globalDir, projectDir)).toEqual({ defaultRunInBackground: true });
+    writeGlobal({ defaultRunInBackground: false });
+    expect(loadSettings(globalDir, projectDir)).toEqual({ defaultRunInBackground: false });
+  });
+
   it("loads from project when no global file", () => {
     writeProject({ maxConcurrent: 8 });
     expect(loadSettings(globalDir, projectDir)).toEqual({ maxConcurrent: 8 });
@@ -246,6 +253,11 @@ describe("settings persistence", () => {
 
 describe("SettingsManager", () => {
   describe("constructor defaults", () => {
+    it("defaults defaultRunInBackground to false", () => {
+      const sm = new SettingsManager({ emit: vi.fn(), cwd: "/tmp", agentDir: "/nonexistent" });
+      expect(sm.defaultRunInBackground).toBe(false);
+    });
+
     it("defaults to defaultMaxTurns: undefined (unlimited)", () => {
       const sm = new SettingsManager({ emit: vi.fn(), cwd: "/tmp", agentDir: "/nonexistent" });
       expect(sm.defaultMaxTurns).toBeUndefined();
@@ -355,6 +367,34 @@ describe("SettingsManager", () => {
       expect(sm.defaultMaxTurns).toBeUndefined();
     });
 
+    it("applies defaultRunInBackground from disk", () => {
+      mkdirSync(join(projectDir, ".pi"), { recursive: true });
+      writeFileSync(join(projectDir, ".pi", "subagents.json"), JSON.stringify({ defaultRunInBackground: true }));
+      const sm = new SettingsManager({ emit: vi.fn(), cwd: projectDir, agentDir: globalDir });
+      sm.load();
+      expect(sm.defaultRunInBackground).toBe(true);
+    });
+
+    it("preserves a project background override when another setting is saved", () => {
+      writeFileSync(join(globalDir, "subagents.json"), JSON.stringify({ defaultRunInBackground: true }));
+      mkdirSync(join(projectDir, ".pi"), { recursive: true });
+      writeFileSync(join(projectDir, ".pi", "subagents.json"), JSON.stringify({ defaultRunInBackground: false }));
+      const sm = new SettingsManager({ emit: vi.fn(), cwd: projectDir, agentDir: globalDir });
+      sm.load();
+      sm.applyMaxConcurrent(8);
+
+      expect(JSON.parse(readFileSync(join(projectDir, ".pi", "subagents.json"), "utf-8"))).toEqual({
+        defaultRunInBackground: false,
+        maxConcurrent: 8,
+        defaultMaxTurns: 0,
+        graceTurns: 5,
+      });
+
+      const restarted = new SettingsManager({ emit: vi.fn(), cwd: projectDir, agentDir: globalDir });
+      restarted.load();
+      expect(restarted.defaultRunInBackground).toBe(false);
+    });
+
     it("applies defaultMaxTurns from disk (0 → unlimited)", () => {
       mkdirSync(join(projectDir, ".pi"), { recursive: true });
       writeFileSync(join(projectDir, ".pi", "subagents.json"), JSON.stringify({ defaultMaxTurns: 0 }));
@@ -400,7 +440,7 @@ describe("SettingsManager", () => {
   describe("snapshot()", () => {
     it("returns default values before any changes", () => {
       const sm = new SettingsManager({ emit: vi.fn(), cwd: "/tmp", agentDir: "/nonexistent" });
-      expect(sm.snapshot()).toEqual({ maxConcurrent: 4, defaultMaxTurns: 0, graceTurns: 5 });
+      expect(sm.snapshot()).toEqual({ defaultRunInBackground: false, maxConcurrent: 4, defaultMaxTurns: 0, graceTurns: 5 });
     });
 
     it("reflects mutations: defaultMaxTurns undefined maps to 0 in snapshot", () => {
@@ -408,13 +448,13 @@ describe("SettingsManager", () => {
       sm.defaultMaxTurns = undefined;
       sm.graceTurns = 3;
       sm.maxConcurrent = 8;
-      expect(sm.snapshot()).toEqual({ maxConcurrent: 8, defaultMaxTurns: 0, graceTurns: 3 });
+      expect(sm.snapshot()).toEqual({ defaultRunInBackground: false, maxConcurrent: 8, defaultMaxTurns: 0, graceTurns: 3 });
     });
 
     it("reflects a concrete defaultMaxTurns value", () => {
       const sm = new SettingsManager({ emit: vi.fn(), cwd: "/tmp", agentDir: "/nonexistent" });
       sm.defaultMaxTurns = 20;
-      expect(sm.snapshot()).toEqual({ maxConcurrent: 4, defaultMaxTurns: 20, graceTurns: 5 });
+      expect(sm.snapshot()).toEqual({ defaultRunInBackground: false, maxConcurrent: 4, defaultMaxTurns: 20, graceTurns: 5 });
     });
   });
 
@@ -436,7 +476,7 @@ describe("SettingsManager", () => {
       const toast = sm.saveAndNotify("Max concurrency set to 5");
       expect(toast).toEqual({ message: "Max concurrency set to 5", level: "info" });
       const written = JSON.parse(readFileSync(join(projectDir, ".pi", "subagents.json"), "utf-8"));
-      expect(written).toEqual({ maxConcurrent: 5, defaultMaxTurns: 0, graceTurns: 5 });
+      expect(written).toEqual({ defaultRunInBackground: false, maxConcurrent: 5, defaultMaxTurns: 0, graceTurns: 5 });
     });
 
     it("emits subagents:settings_changed with persisted:true on success", () => {
@@ -445,7 +485,7 @@ describe("SettingsManager", () => {
       sm.graceTurns = 3;
       sm.saveAndNotify("Grace turns set to 3");
       expect(emit).toHaveBeenCalledWith("subagents:settings_changed", {
-        settings: { maxConcurrent: 4, defaultMaxTurns: 0, graceTurns: 3 },
+        settings: { defaultRunInBackground: false, maxConcurrent: 4, defaultMaxTurns: 0, graceTurns: 3 },
         persisted: true,
       });
     });
@@ -473,7 +513,7 @@ describe("SettingsManager", () => {
         const sm = new SettingsManager({ emit, cwd: filePosingAsCwd, agentDir: "/nonexistent" });
         sm.saveAndNotify("something");
         expect(emit).toHaveBeenCalledWith("subagents:settings_changed", {
-          settings: { maxConcurrent: 4, defaultMaxTurns: 0, graceTurns: 5 },
+          settings: { defaultRunInBackground: false, maxConcurrent: 4, defaultMaxTurns: 0, graceTurns: 5 },
           persisted: false,
         });
       } finally {

--- a/packages/pi-subagents/test/tools/agent-tool.test.ts
+++ b/packages/pi-subagents/test/tools/agent-tool.test.ts
@@ -146,6 +146,42 @@ describe("AgentTool — model resolution error", () => {
 });
 
 describe("AgentTool — background execution", () => {
+	it("uses the global default for an omitted run_in_background", async () => {
+		const deps = createToolDeps({
+			settings: { defaultMaxTurns: undefined, defaultRunInBackground: true, maxConcurrent: 4 },
+		});
+		deps.manager.getRecord = vi.fn().mockReturnValue(createTestSubagent({ status: "running" }));
+		const result = await execute(deps, {
+			prompt: "do something",
+			description: "default background task",
+			subagent_type: "general-purpose",
+		});
+
+		expect(result.content[0].text).toContain("background");
+		expect(deps.manager.spawn).toHaveBeenCalledOnce();
+		expect(deps.manager.spawnAndWait).not.toHaveBeenCalled();
+	});
+
+	it("uses the global default for a nested call", async () => {
+		const deps = createToolDeps({
+			settings: { defaultMaxTurns: undefined, defaultRunInBackground: true, maxConcurrent: 4 },
+		});
+		deps.manager.getRecord = vi.fn().mockReturnValue(createTestSubagent({ status: "running" }));
+		const result = await execute(
+			deps,
+			{
+				prompt: "do something",
+				description: "nested task",
+				subagent_type: "general-purpose",
+			},
+			makeCtx({ getSystemPrompt: () => '<active_agent name="general-purpose"/>' }),
+		);
+
+		expect(result.content[0].text).toContain("background");
+		expect(deps.manager.spawn).toHaveBeenCalledOnce();
+		expect(deps.manager.spawnAndWait).not.toHaveBeenCalled();
+	});
+
 	it("returns background launch message with agent ID", async () => {
 		const deps = createToolDeps();
 		const record = createTestSubagent({ status: "running" });
@@ -193,6 +229,35 @@ describe("AgentTool — background execution", () => {
 });
 
 describe("AgentTool — foreground execution", () => {
+	it("keeps an omitted run foreground when the global setting is absent or false", async () => {
+		const deps = createToolDeps({
+			settings: { defaultMaxTurns: undefined, defaultRunInBackground: false, maxConcurrent: 4 },
+		});
+		await execute(deps, {
+			prompt: "do task",
+			description: "legacy foreground",
+			subagent_type: "general-purpose",
+		});
+
+		expect(deps.manager.spawnAndWait).toHaveBeenCalledOnce();
+		expect(deps.manager.spawn).not.toHaveBeenCalled();
+	});
+
+	it("lets explicit run_in_background:false override the global default", async () => {
+		const deps = createToolDeps({
+			settings: { defaultMaxTurns: undefined, defaultRunInBackground: true, maxConcurrent: 4 },
+		});
+		await execute(deps, {
+			prompt: "do task",
+			description: "explicit foreground",
+			subagent_type: "general-purpose",
+			run_in_background: false,
+		});
+
+		expect(deps.manager.spawnAndWait).toHaveBeenCalledOnce();
+		expect(deps.manager.spawn).not.toHaveBeenCalled();
+	});
+
 	it("returns completion message with stats", async () => {
 		const deps = createToolDeps();
 		deps.manager.spawnAndWait = vi.fn().mockResolvedValue(


### PR DESCRIPTION
## Summary

Adds the documented `defaultRunInBackground` global setting in `~/.pi/agent/subagents.json`.
When set to `true`, it makes root `subagent` calls that omit `run_in_background` launch in the background.

Explicit `run_in_background: false` still launches in the foreground.
Explicit agent-frontmatter behavior continues to win over the global fallback.
Nested child calls remain foreground by default, and forked root sessions still receive the global default.
The service adapter is unchanged.

## Validation

- `mise exec pnpm@11.5.2 -- pnpm --filter @gotgenes/pi-subagents run check`
- `mise exec pnpm@11.5.2 -- pnpm --filter @gotgenes/pi-subagents test` — 64 files, 1007 tests passed
- `mise exec pnpm@11.5.2 -- pnpm --filter @gotgenes/pi-subagents run lint`
- `git diff --check`

Numeric coverage is not available in this package because it has no coverage script or Vitest coverage provider, and `@vitest/coverage-v8` is not installed.
The focused behavioral tests cover the global true/false defaults, explicit foreground override, agent-frontmatter precedence, nested-child non-regression, and forked-root behavior.
