### PR TITLE
feat(pi-subagents): add ordered lifecycle interception

### DIFF
--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -368,6 +368,22 @@ svc?.spawn("Explore", "Check for stale TODOs");
 Declare this package as an optional peer dependency.
 See `src/service/service.ts` for the full `SubagentsService` interface and the `WorkspaceProvider` seam.
 
+#### Ordered lifecycle interception
+
+`registerLifecycleInterceptor()` is a generative provider seam for extensions that must replace or deny the exact child prompt, or accept, replace, abort, or continue a proposed child result before finalization.
+Callbacks receive immutable agent, session, run, and parent identity plus execution-path facts, never a manager or live session.
+Registrations are awaited in registration order, prompt and result replacements flow to later registrations, and continuations remain in the same session for at most three rounds.
+Existing lifecycle events remain observational and cannot substitute for this registration API.
+
+```typescript
+const registration = svc?.registerLifecycleInterceptor({
+  beforeStart: async ({ prompt }) => ({ action: "continue", prompt: `Context:\n${prompt}` }),
+  beforeComplete: async ({ proposedResult }) => ({ action: "complete", result: proposedResult }),
+});
+
+await registration?.dispose();
+```
+
 ### `@gotgenes/pi-subagents/settings` — layered config loader
 
 Extensions that store configuration in JSON files can use the shared layered loader, which reads a global file (`<agentDir>/<filename>`) and a project file (`<cwd>/.pi/<filename>`) and merges them — project wins on conflicts, missing files are silent, malformed files warn and fall back:

--- a/packages/pi-subagents/docs/decisions/0005-ordered-lifecycle-interceptors.md
+++ b/packages/pi-subagents/docs/decisions/0005-ordered-lifecycle-interceptors.md
@@ -1,0 +1,40 @@
+---
+status: accepted
+date: 2026-07-16
+---
+
+# 0005 — Ordered lifecycle interceptors are a narrow provider seam
+
+## Context
+
+Child lifecycle events are observational.
+Event listeners cannot replace the exact prompt, prevent a turn, inspect a candidate result before finalization, or request a same-session continuation.
+Some Pi extensions need those generative decisions.
+
+## Decision
+
+The package exposes `SubagentsService.registerLifecycleInterceptor()`.
+A registration receives immutable execution identity and path facts, an exact prompt immediately before `AgentSession.prompt()`, and a proposed result before workspace teardown, state changes, completion events, history, notifications, or disposal.
+
+Registrations run sequentially in registration order.
+Prompt and result replacements flow to the next registration.
+A registration may abort a turn or request another turn on the same child session.
+The package owns a fixed bound of three continuation rounds to prevent unbounded loops.
+
+The callback surface intentionally exposes neither `SubagentManager` nor `AgentSession`.
+It has no host-specific hook names, policy, process execution, configuration, or model/tool behavior.
+Existing child lifecycle events remain observational and unchanged.
+
+## Lifetime and failure rules
+
+- A registration handle unregisters idempotently.
+  It excludes future boundary snapshots immediately; a snapshot that already captured it finishes in order.
+- A provider's optional `dispose()` runs once after its captured callbacks finish.
+- Parent cancellation and manager shutdown abort an in-flight callback wait.
+  A callback rejection or malformed decision fails the execution before any completion finalization occurs.
+- With no active registration, the released prompt, result, event, workspace, queue, session, and resume paths retain their existing behavior and ordering.
+
+## Consequences
+
+The core now has one additional, concrete generative seam.
+Extensions compose by registering a provider, while the core continues to own configuration, models, sessions, tools, queueing, concurrency, steering, persistence, workspaces, turn limits, notifications, and disposal.

--- a/packages/pi-subagents/scripts/verify-public-types.sh
+++ b/packages/pi-subagents/scripts/verify-public-types.sh
@@ -24,7 +24,7 @@ if grep -q '#src' "$DTS"; then
   grep -n '#src' "$DTS" >&2
   exit 1
 fi
-for sym in getSubagentsService WorkspaceProvider SubagentsService LifetimeUsage Workspace WorkspacePrepareContext WorkspaceDisposeOutcome WorkspaceDisposeResult; do
+for sym in getSubagentsService WorkspaceProvider SubagentsService LifetimeUsage Workspace WorkspacePrepareContext WorkspaceDisposeOutcome WorkspaceDisposeResult MAX_LIFECYCLE_CONTINUATION_ROUNDS SubagentExecutionAdmission SubagentExecutionMode SubagentExecutionOrigin SubagentExecutionPhase SubagentLifecycleCompletionContext SubagentLifecycleCompletionDecision SubagentLifecycleExecutionPath SubagentLifecycleIdentity SubagentLifecycleInterceptor SubagentLifecycleOutcome SubagentLifecycleRegistration SubagentLifecycleStartContext SubagentLifecycleStartDecision; do
   grep -q "$sym" "$DTS" || { echo "FAIL: '$sym' missing from dist/public.d.ts" >&2; exit 1; }
 done
 echo "OK: dist/public.d.ts is self-contained and exports the public surface"
@@ -70,6 +70,9 @@ import {
   type WorkspaceDisposeResult,
   type WorkspacePrepareContext,
   type WorkspaceProvider,
+  type SubagentLifecycleInterceptor,
+  type SubagentLifecycleRegistration,
+  MAX_LIFECYCLE_CONTINUATION_ROUNDS,
 } from "@gotgenes/pi-subagents";
 
 // Exercise the value export and all workspace collaborator type exports.
@@ -85,8 +88,17 @@ const provider: WorkspaceProvider = {
   },
 };
 
+const interceptor: SubagentLifecycleInterceptor = {
+  beforeStart: (context) => ({ action: "continue", prompt: context.prompt }),
+  beforeComplete: (context) => ({ action: "complete", result: context.proposedResult }),
+};
+
+declare const registration: SubagentLifecycleRegistration;
 void provider;
 void getSubagentsService;
+void interceptor;
+void registration;
+void MAX_LIFECYCLE_CONTINUATION_ROUNDS;
 TS
 
 cat > "$CONSUMER/probe-settings.ts" <<'TS'

--- a/packages/pi-subagents/src/lifecycle/concurrency-limiter.ts
+++ b/packages/pi-subagents/src/lifecycle/concurrency-limiter.ts
@@ -15,6 +15,11 @@ export class ConcurrencyLimiter {
 
 	constructor(private readonly getLimit: () => number) {}
 
+	/** Whether a newly scheduled task will wait behind work already admitted. */
+	isSaturated(): boolean {
+		return this.active >= this.getLimit();
+	}
+
 	/**
 	 * Schedule a task to run FIFO once a slot is free.
 	 * Returns a promise that settles with the task, or resolves early if the

--- a/packages/pi-subagents/src/lifecycle/lifecycle-interceptor.ts
+++ b/packages/pi-subagents/src/lifecycle/lifecycle-interceptor.ts
@@ -1,0 +1,401 @@
+/**
+ * lifecycle-interceptor.ts — Ordered, generative lifecycle interception.
+ *
+ * Unlike the child lifecycle events, this registry is intentionally small: it
+ * exists only because callers need the core to consume prompt/result decisions.
+ * It owns ordering, cancellation, registration lifetime, and the finite
+ * continuation bound; it does not expose sessions, records, models, or queues.
+ */
+
+/** The fixed bound prevents a provider from turning completion into an unbounded loop. */
+export const MAX_LIFECYCLE_CONTINUATION_ROUNDS = 3;
+
+export type SubagentExecutionPhase = "initial" | "resume";
+export type SubagentExecutionOrigin = "tool" | "service";
+export type SubagentExecutionMode = "foreground" | "background";
+export type SubagentExecutionAdmission = "immediate" | "queued";
+export type SubagentLifecycleOutcome = "completed" | "steered" | "aborted";
+
+/** Immutable identifiers for one initial or resumed execution attempt. */
+export interface SubagentLifecycleIdentity {
+  readonly agentId: string;
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly agentType: string;
+  readonly parentSessionId?: string;
+}
+
+/** How this execution entered the core; queue admission is captured before it starts. */
+export interface SubagentLifecycleExecutionPath {
+  readonly phase: SubagentExecutionPhase;
+  readonly origin: SubagentExecutionOrigin;
+  readonly mode: SubagentExecutionMode;
+  readonly admission: SubagentExecutionAdmission;
+}
+
+export interface SubagentLifecycleStartContext {
+  readonly identity: SubagentLifecycleIdentity;
+  readonly execution: SubagentLifecycleExecutionPath;
+  /** The exact next value that will be passed to AgentSession.prompt(). */
+  readonly prompt: string;
+  readonly signal: AbortSignal;
+}
+
+export type SubagentLifecycleStartDecision =
+  | { readonly action: "continue"; readonly prompt?: string }
+  | { readonly action: "abort"; readonly reason: string };
+
+export interface SubagentLifecycleCompletionContext {
+  readonly identity: SubagentLifecycleIdentity;
+  readonly execution: SubagentLifecycleExecutionPath;
+  /** Candidate text before workspace teardown, state mutation, and events. */
+  readonly proposedResult: string;
+  readonly outcome: SubagentLifecycleOutcome;
+  readonly continuationRound: number;
+  readonly maxContinuationRounds: number;
+  readonly signal: AbortSignal;
+}
+
+export type SubagentLifecycleCompletionDecision =
+  | { readonly action: "complete"; readonly result?: string }
+  | { readonly action: "continue"; readonly prompt: string }
+  | { readonly action: "abort"; readonly reason: string };
+
+/**
+ * A provider can observe and transform boundaries but never receives the live
+ * AgentSession. Omitted callbacks are no-ops, making one provider useful for a
+ * single boundary without creating a second registration kind.
+ */
+export interface SubagentLifecycleInterceptor {
+  beforeStart?(
+    context: SubagentLifecycleStartContext,
+  ): SubagentLifecycleStartDecision | undefined | Promise<SubagentLifecycleStartDecision | undefined>;
+  beforeComplete?(
+    context: SubagentLifecycleCompletionContext,
+  ): SubagentLifecycleCompletionDecision | undefined | Promise<SubagentLifecycleCompletionDecision | undefined>;
+  /** Called exactly once after unregistration or registry shutdown. */
+  dispose?(): void | Promise<void>;
+}
+
+/** Idempotent registration handle returned by the public service. */
+export interface SubagentLifecycleRegistration {
+  dispose(): Promise<void>;
+}
+
+/** Internal bridge from the registry to the object that owns AgentSession.prompt(). */
+export interface SubagentTurnLifecycle {
+  readonly signal: AbortSignal;
+  readonly maxContinuationRounds: number;
+  beforeStart(prompt: string): Promise<SubagentLifecycleStartDecision | undefined>;
+  beforeComplete(
+    proposedResult: string,
+    outcome: SubagentLifecycleOutcome,
+    continuationRound: number,
+  ): Promise<SubagentLifecycleCompletionDecision | undefined>;
+}
+
+export class LifecycleInterceptorError extends Error {
+  constructor(phase: "beforeStart" | "beforeComplete", cause: unknown) {
+    // Keep callback details out of a record's public error text. The original
+    // cause remains available to a local debugger without becoming API data.
+    super(`Lifecycle interceptor failed during ${phase}`, { cause });
+    this.name = "LifecycleInterceptorError";
+  }
+}
+
+type RegistrationRecord = {
+  readonly interceptor: SubagentLifecycleInterceptor;
+  active: boolean;
+  inFlight: number;
+  finalizer?: Promise<void>;
+  readonly idleWaiters: Array<() => void>;
+};
+
+/**
+ * Package-private ordered provider registry. The service exposes only its
+ * registration method; executions receive a narrow callback bridge, never this
+ * object or a manager/session reference.
+ */
+export class LifecycleInterceptorRegistry {
+  private readonly registrations: RegistrationRecord[] = [];
+  private readonly shutdownController = new AbortController();
+  private shutdownPromise?: Promise<void>;
+
+  // fallow-ignore-next-line unused-class-member -- lifecycle execution checks this through its narrow internal registry type
+  hasInterceptors(): boolean {
+    return !this.shutdownController.signal.aborted &&
+      this.registrations.some((record) => record.active);
+  }
+
+  register(interceptor: SubagentLifecycleInterceptor): SubagentLifecycleRegistration {
+    if (this.shutdownController.signal.aborted) {
+      throw new Error("Subagent lifecycle registry is disposed");
+    }
+    if (typeof interceptor !== "object") {
+      throw new TypeError("A lifecycle interceptor object is required");
+    }
+
+    const record: RegistrationRecord = {
+      interceptor,
+      active: true,
+      inFlight: 0,
+      idleWaiters: [],
+    };
+    this.registrations.push(record);
+    return Object.freeze({ dispose: () => this.disposeRegistration(record) });
+  }
+
+  /**
+   * Create callback-local control for one run. Identity and path are frozen
+   * once so every start/completion/continuation callback observes identical
+   * metadata. The execution signal also ends when the service is disposed.
+   */
+  createTurnLifecycle(input: Readonly<{
+    identity: SubagentLifecycleIdentity;
+    execution: SubagentLifecycleExecutionPath;
+    signal: AbortSignal;
+  }>): SubagentTurnLifecycle {
+    const identity = Object.freeze({ ...input.identity });
+    const execution = Object.freeze({ ...input.execution });
+    const signal = AbortSignal.any([input.signal, this.shutdownController.signal]);
+    return Object.freeze({
+      signal,
+      maxContinuationRounds: MAX_LIFECYCLE_CONTINUATION_ROUNDS,
+      beforeStart: (prompt: string) => this.applyStart(identity, execution, prompt, signal),
+      beforeComplete: (
+        proposedResult: string,
+        outcome: SubagentLifecycleOutcome,
+        continuationRound: number,
+      ) =>
+        this.applyCompletion(
+          identity,
+          execution,
+          proposedResult,
+          outcome,
+          continuationRound,
+          signal,
+        ),
+    });
+  }
+
+  /** Abort callback waits, unregister every provider, and dispose each once. */
+  dispose(): Promise<void> {
+    this.shutdownPromise ??= this.shutdown();
+    return this.shutdownPromise;
+  }
+
+  private async shutdown(): Promise<void> {
+    this.shutdownController.abort(new DOMException("Subagent lifecycle registry disposed", "AbortError"));
+    for (const record of this.registrations) this.unregister(record);
+    const finalizers = this.registrations.flatMap((record) =>
+      record.finalizer === undefined ? [] : [record.finalizer],
+    );
+    await Promise.all(finalizers);
+  }
+
+  /**
+   * Unregistration is immediate for future snapshots. Provider disposal waits
+   * until callbacks already captured by a boundary finish, but the returned
+   * handle deliberately does not wait for that finalizer: an interceptor may
+   * unregister another interceptor while the same ordered snapshot is running.
+   */
+  private disposeRegistration(record: RegistrationRecord): Promise<void> {
+    this.unregister(record);
+    return Promise.resolve();
+  }
+
+  private unregister(record: RegistrationRecord): void {
+    record.active = false;
+    record.finalizer ??= (async () => {
+      await this.waitForIdle(record);
+      await record.interceptor.dispose?.();
+    })();
+  }
+
+  private async waitForIdle(record: RegistrationRecord): Promise<void> {
+    if (record.inFlight === 0) return;
+    await new Promise<void>((resolve) => record.idleWaiters.push(resolve));
+  }
+
+  private releaseInvocation(record: RegistrationRecord): void {
+    record.inFlight--;
+    if (record.inFlight !== 0) return;
+    for (const resolve of record.idleWaiters.splice(0)) resolve();
+  }
+
+  private snapshot(): readonly RegistrationRecord[] {
+    const snapshot = this.registrations.filter((record) => record.active);
+    // Pin the current boundary before invoking the first callback. A disposer
+    // therefore cannot tear down a later provider that this stable snapshot
+    // still has to call; it only excludes future boundaries.
+    for (const record of snapshot) record.inFlight++;
+    return snapshot;
+  }
+
+  private async applyStart(
+    identity: SubagentLifecycleIdentity,
+    execution: SubagentLifecycleExecutionPath,
+    initialPrompt: string,
+    signal: AbortSignal,
+  ): Promise<SubagentLifecycleStartDecision | undefined> {
+    let prompt = initialPrompt;
+    let transformed = false;
+    const snapshot = this.snapshot();
+    try {
+      for (const record of snapshot) {
+        if (!record.interceptor.beforeStart) continue;
+        const decision = await this.invoke(
+          "beforeStart",
+          () => record.interceptor.beforeStart!(Object.freeze({ identity, execution, prompt, signal })),
+          signal,
+        );
+        const normalized = normalizeStartDecision(decision);
+        if (normalized === undefined) continue;
+        if (normalized.action === "abort") return normalized;
+        if (normalized.prompt !== undefined) {
+          prompt = normalized.prompt;
+          transformed = true;
+        }
+      }
+      return transformed ? { action: "continue", prompt } : undefined;
+    } finally {
+      for (const record of snapshot) this.releaseInvocation(record);
+    }
+  }
+
+  private async applyCompletion(
+    identity: SubagentLifecycleIdentity,
+    execution: SubagentLifecycleExecutionPath,
+    initialResult: string,
+    outcome: SubagentLifecycleOutcome,
+    continuationRound: number,
+    signal: AbortSignal,
+  ): Promise<SubagentLifecycleCompletionDecision | undefined> {
+    let result = initialResult;
+    let transformed = false;
+    const snapshot = this.snapshot();
+    try {
+      for (const record of snapshot) {
+        if (!record.interceptor.beforeComplete) continue;
+        const decision = await this.invoke(
+          "beforeComplete",
+          () => record.interceptor.beforeComplete!(Object.freeze({
+            identity,
+            execution,
+            proposedResult: result,
+            outcome,
+            continuationRound,
+            maxContinuationRounds: MAX_LIFECYCLE_CONTINUATION_ROUNDS,
+            signal,
+          })),
+          signal,
+        );
+        const normalized = normalizeCompletionDecision(decision);
+        if (normalized === undefined) continue;
+        if (normalized.action !== "complete") return normalized;
+        if (normalized.result !== undefined) {
+          result = normalized.result;
+          transformed = true;
+        }
+      }
+      return transformed ? { action: "complete", result } : undefined;
+    } finally {
+      for (const record of snapshot) this.releaseInvocation(record);
+    }
+  }
+
+  private async invoke<T>(
+    phase: "beforeStart" | "beforeComplete",
+    callback: () => T | Promise<T>,
+    signal: AbortSignal,
+  ): Promise<T> {
+    if (signal.aborted) throw abortError(signal);
+    try {
+      return await awaitWithSignal(Promise.resolve().then(callback), signal);
+    } catch (error) {
+      const cancellation = currentAbortError(signal);
+      if (cancellation) throw cancellation;
+      throw new LifecycleInterceptorError(phase, error);
+    }
+  }
+}
+
+function awaitWithSignal<T>(value: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(abortError(signal));
+  return new Promise<T>((resolve, reject) => {
+    const abort = () => reject(abortError(signal));
+    signal.addEventListener("abort", abort, { once: true });
+    void value.then(
+      (result) => {
+        signal.removeEventListener("abort", abort);
+        if (signal.aborted) reject(abortError(signal));
+        else resolve(result);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", abort);
+        reject(signal.aborted ? abortError(signal) : toError(error));
+      },
+    );
+  });
+}
+
+function currentAbortError(signal: AbortSignal): Error | undefined {
+  return signal.aborted ? abortError(signal) : undefined;
+}
+
+function abortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new Error("The lifecycle execution was aborted");
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error("Lifecycle interceptor rejected");
+}
+
+function normalizeStartDecision(
+  decision: unknown,
+): SubagentLifecycleStartDecision | undefined {
+  if (decision === undefined) return undefined;
+  if (decision === null || typeof decision !== "object") {
+    throw new TypeError("Lifecycle beforeStart must return a decision object or undefined");
+  }
+  const value = decision as { action?: unknown; prompt?: unknown; reason?: unknown };
+  if (value.action === "continue") {
+    if (value.prompt !== undefined && typeof value.prompt !== "string") {
+      throw new TypeError("Lifecycle beforeStart continuation prompt must be a string");
+    }
+    return value.prompt === undefined
+      ? { action: "continue" }
+      : { action: "continue", prompt: value.prompt };
+  }
+  if (value.action === "abort" && typeof value.reason === "string" && value.reason.length > 0) {
+    return { action: "abort", reason: value.reason };
+  }
+  throw new TypeError("Lifecycle beforeStart returned an invalid decision");
+}
+
+function normalizeCompletionDecision(
+  decision: unknown,
+): SubagentLifecycleCompletionDecision | undefined {
+  if (decision === undefined) return undefined;
+  if (decision === null || typeof decision !== "object") {
+    throw new TypeError("Lifecycle beforeComplete must return a decision object or undefined");
+  }
+  const value = decision as { action?: unknown; result?: unknown; prompt?: unknown; reason?: unknown };
+  if (value.action === "complete") {
+    if (value.result !== undefined && typeof value.result !== "string") {
+      throw new TypeError("Lifecycle completion result must be a string");
+    }
+    return value.result === undefined
+      ? { action: "complete" }
+      : { action: "complete", result: value.result };
+  }
+  if (value.action === "continue" && typeof value.prompt === "string" && value.prompt.length > 0) {
+    return { action: "continue", prompt: value.prompt };
+  }
+  if (value.action === "abort" && typeof value.reason === "string" && value.reason.length > 0) {
+    return { action: "abort", reason: value.reason };
+  }
+  throw new TypeError("Lifecycle beforeComplete returned an invalid decision");
+}

--- a/packages/pi-subagents/src/lifecycle/subagent-manager.ts
+++ b/packages/pi-subagents/src/lifecycle/subagent-manager.ts
@@ -11,6 +11,13 @@ import type { Model } from "@earendil-works/pi-ai";
 import { debugLog } from "#src/debug";
 import type { ConcurrencyLimiter } from "#src/lifecycle/concurrency-limiter";
 import type { CreateSubagentSessionParams } from "#src/lifecycle/create-subagent-session";
+import {
+  LifecycleInterceptorRegistry,
+  type SubagentExecutionAdmission,
+  type SubagentExecutionOrigin,
+  type SubagentLifecycleInterceptor,
+  type SubagentLifecycleRegistration,
+} from "#src/lifecycle/lifecycle-interceptor";
 import type { ParentSnapshot } from "#src/lifecycle/parent-snapshot";
 import { Subagent, type SubagentLifecycleObserver } from "#src/lifecycle/subagent";
 import type { SubagentSession } from "#src/lifecycle/subagent-session";
@@ -80,6 +87,10 @@ export interface AgentSpawnConfig {
   observer?: SubagentLifecycleObserver;
   /** Parent session identity - grouped fields that travel together from the tool boundary. */
   parentSession?: ParentSessionInfo;
+  /** Identity known to a service caller without changing its existing session setup. */
+  lifecycleParentSession?: ParentSessionInfo;
+  /** Which supported public entry path created this execution. */
+  origin?: SubagentExecutionOrigin;
 }
 
 export class SubagentManager {
@@ -93,6 +104,7 @@ export class SubagentManager {
   private readonly baseCwd: string;
   private getRunConfig?: () => RunConfig;
   private _workspaceProvider?: WorkspaceProvider;
+  private readonly lifecycleInterceptors = new LifecycleInterceptorRegistry();
 
   /** The registered workspace provider, or undefined when none is registered. */
   get workspaceProvider(): WorkspaceProvider | undefined {
@@ -127,6 +139,13 @@ export class SubagentManager {
     };
   }
 
+  /** Register a generative lifecycle provider without exposing manager internals. */
+  registerLifecycleInterceptor(
+    interceptor: SubagentLifecycleInterceptor,
+  ): SubagentLifecycleRegistration {
+    return this.lifecycleInterceptors.register(interceptor);
+  }
+
   /** Compose a per-agent lifecycle observer from manager and spawn-config concerns. */
   private buildObserver(options: AgentSpawnConfig): SubagentLifecycleObserver {
     return {
@@ -158,6 +177,9 @@ export class SubagentManager {
     options: AgentSpawnConfig,
   ): string {
     const id = randomUUID().slice(0, 17);
+    const admission: SubagentExecutionAdmission = options.isBackground && !options.bypassQueue && this.limiter.isSaturated()
+      ? "queued"
+      : "immediate";
     const record = new Subagent({
       id,
       type,
@@ -179,7 +201,15 @@ export class SubagentManager {
         maxTurns: options.maxTurns,
         thinkingLevel: options.thinkingLevel,
         parentSession: options.parentSession,
+        lifecycleParentSession: options.lifecycleParentSession,
         signal: options.signal,
+        lifecycleInterceptors: this.lifecycleInterceptors,
+        executionPath: {
+          phase: "initial",
+          origin: options.origin ?? "service",
+          mode: options.isBackground ? "background" : "foreground",
+          admission,
+        },
       },
     });
     this.agents.set(id, record);
@@ -339,6 +369,9 @@ export class SubagentManager {
 
   dispose() {
     clearInterval(this.cleanupInterval);
+    // Lifecycle callbacks observe the shutdown signal before their registration
+    // disposer runs. Existing no-provider teardown stays synchronous.
+    void this.lifecycleInterceptors.dispose();
     // Drop pending thunks
     this.limiter.clear();
     for (const record of this.agents.values()) {

--- a/packages/pi-subagents/src/lifecycle/subagent-session.ts
+++ b/packages/pi-subagents/src/lifecycle/subagent-session.ts
@@ -16,6 +16,10 @@ import {
   type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import type { ChildLifecyclePublisher } from "#src/lifecycle/child-lifecycle";
+import {
+  type SubagentLifecycleOutcome,
+  type SubagentTurnLifecycle,
+} from "#src/lifecycle/lifecycle-interceptor";
 import { normalizeMaxTurns } from "#src/lifecycle/turn-limits";
 import { getSessionContextPercent, type SessionStatsLike } from "#src/lifecycle/usage";
 import { extractText } from "#src/session/context";
@@ -29,6 +33,8 @@ export interface TurnLoopResult {
   aborted: boolean;
   /** True if the agent was steered to wrap up (soft turn limit) but finished in time. */
   steered: boolean;
+  /** A lifecycle provider denied finalization; no child completion is emitted. */
+  lifecycleAborted?: boolean;
 }
 
 /** Per-call options for the initial run's turn loop. */
@@ -40,6 +46,8 @@ export interface TurnLoopOptions {
   /** Grace turns after the soft-limit steer message before a hard abort. */
   graceTurns?: number;
   signal?: AbortSignal;
+  /** Present only for an execution that captured active lifecycle providers. */
+  lifecycle?: SubagentTurnLifecycle;
 }
 
 /** Session-level facts known at creation, supplied by the factory. */
@@ -79,7 +87,13 @@ export class SubagentSession {
     return this.meta.outputFile;
   }
 
-  /** Drive the initial run's turn loop; emits `completed` on success. */
+  /** Stable child session identity for lifecycle provider metadata. */
+  // fallow-ignore-next-line unused-class-member -- Subagent reads this through the lifecycle-only session boundary
+  get sessionId(): string {
+    return this.meta.sessionId;
+  }
+
+  /** Drive the initial run's turn loop; emits `completed` on accepted success. */
   async runTurnLoop(prompt: string, opts: TurnLoopOptions): Promise<TurnLoopResult> {
     const session = this._session;
 
@@ -111,30 +125,34 @@ export class SubagentSession {
     const collector = collectResponseText(session);
     const cleanupAbort = forwardAbortSignal(session, opts.signal);
 
-    // Prepend parent context if it was captured at spawn time.
+    // Prepend parent context before lifecycle providers see the exact prompt.
     const effectivePrompt = this.meta.parentContext
       ? this.meta.parentContext + prompt
       : prompt;
 
     try {
-      await session.prompt(effectivePrompt);
-      this.meta.lifecycle.completed({
-        sessionDir: this.meta.sessionDir,
-        agentName: this.meta.agentName,
-        aborted,
-        steered: softLimitReached,
-      });
+      if (!opts.lifecycle) {
+        // Preserve the released no-provider order byte-for-byte: completion is
+        // published immediately after prompt resolution and before extraction.
+        await session.prompt(effectivePrompt);
+        this.publishCompleted(aborted, softLimitReached);
+        const responseText = collector.getText().trim() || getLastAssistantText(session);
+        return { responseText, aborted, steered: softLimitReached };
+      }
+      return await this.driveLifecycleTurns(
+        effectivePrompt,
+        opts.lifecycle,
+        () => collector.getText().trim() || getLastAssistantText(session),
+        () => ({ aborted, steered: softLimitReached }),
+      );
     } finally {
       unsubTurns();
       collector.unsubscribe();
       cleanupAbort();
     }
-
-    const responseText = collector.getText().trim() || getLastAssistantText(session);
-    return { responseText, aborted, steered: softLimitReached };
   }
 
-  /** Re-prompt the same session (resume); does not emit `completed`. */
+  /** Re-prompt the same session (resume); preserves the released no-provider path. */
   async resumeTurnLoop(prompt: string, signal?: AbortSignal): Promise<string> {
     const session = this._session;
     const collector = collectResponseText(session);
@@ -142,12 +160,108 @@ export class SubagentSession {
 
     try {
       await session.prompt(prompt);
+      return collector.getText().trim() || getLastAssistantText(session);
     } finally {
       collector.unsubscribe();
       cleanupAbort();
     }
+  }
 
-    return collector.getText().trim() || getLastAssistantText(session);
+  /**
+   * Resume with active providers. This is separate from resumeTurnLoop so the
+   * historical no-provider method signature and event behavior remain intact.
+   */
+  // fallow-ignore-next-line unused-class-member -- Subagent selects this only when a provider is registered
+  async resumeLifecycleTurnLoop(
+    prompt: string,
+    signal: AbortSignal | undefined,
+    lifecycle: SubagentTurnLifecycle,
+  ): Promise<TurnLoopResult> {
+    const collector = collectResponseText(this._session);
+    const cleanupAbort = forwardAbortSignal(this._session, signal);
+    try {
+      return await this.driveLifecycleTurns(
+        prompt,
+        lifecycle,
+        () => collector.getText().trim() || getLastAssistantText(this._session),
+        () => ({ aborted: false, steered: false }),
+      );
+    } finally {
+      collector.unsubscribe();
+      cleanupAbort();
+    }
+  }
+
+  private async driveLifecycleTurns(
+    initialPrompt: string,
+    lifecycle: SubagentTurnLifecycle,
+    responseText: () => string,
+    outcome: () => Readonly<{ aborted: boolean; steered: boolean }>,
+  ): Promise<TurnLoopResult> {
+    const start = await lifecycle.beforeStart(initialPrompt);
+    if (start?.action === "abort") {
+      return this.lifecycleAbort(start.reason, outcome());
+    }
+
+    let prompt = start?.prompt ?? initialPrompt;
+    let continuationRound = 0;
+    for (;;) {
+      lifecycle.signal.throwIfAborted();
+      await this._session.prompt(prompt);
+      const turnOutcome = outcome();
+      const proposedResult = responseText();
+      const completion = await lifecycle.beforeComplete(
+        proposedResult,
+        toLifecycleOutcome(turnOutcome),
+        continuationRound,
+      );
+      if (completion?.action === "abort") {
+        return this.lifecycleAbort(completion.reason, turnOutcome);
+      }
+      if (completion?.action === "continue") {
+        if (continuationRound >= lifecycle.maxContinuationRounds) {
+          return this.lifecycleAbort(
+            `Lifecycle continuation limit of ${lifecycle.maxContinuationRounds} reached`,
+            turnOutcome,
+          );
+        }
+        continuationRound++;
+        prompt = completion.prompt;
+        continue;
+      }
+
+      const finalResult = completion?.action === "complete"
+        ? completion.result ?? proposedResult
+        : proposedResult;
+      this.publishCompleted(turnOutcome.aborted, turnOutcome.steered);
+      return {
+        responseText: finalResult,
+        aborted: turnOutcome.aborted,
+        steered: turnOutcome.steered,
+      };
+    }
+  }
+
+  private lifecycleAbort(
+    reason: string,
+    outcome: Readonly<{ aborted: boolean; steered: boolean }>,
+  ): TurnLoopResult {
+    // No child completion is emitted: the provider declined to accept a turn.
+    return {
+      responseText: reason,
+      aborted: true,
+      steered: outcome.steered,
+      lifecycleAborted: true,
+    };
+  }
+
+  private publishCompleted(aborted: boolean, steered: boolean): void {
+    this.meta.lifecycle.completed({
+      sessionDir: this.meta.sessionDir,
+      agentName: this.meta.agentName,
+      aborted,
+      steered,
+    });
   }
 
   /** Deliver a steer to the live session. */
@@ -199,6 +313,14 @@ export class SubagentSession {
 }
 
 // ── Private turn-loop helpers ───────────────────────────────────────────────────
+
+function toLifecycleOutcome(
+  outcome: Readonly<{ aborted: boolean; steered: boolean }>,
+): SubagentLifecycleOutcome {
+  if (outcome.aborted) return "aborted";
+  if (outcome.steered) return "steered";
+  return "completed";
+}
 
 /**
  * Subscribe to a session and collect the last assistant message text.

--- a/packages/pi-subagents/src/lifecycle/subagent.ts
+++ b/packages/pi-subagents/src/lifecycle/subagent.ts
@@ -6,10 +6,16 @@
  * Behavior (abort, steer buffering) lives here rather than on SubagentManager.
  */
 
+import { randomUUID } from "node:crypto";
 import type { Model } from "@earendil-works/pi-ai";
 import type { AgentSessionEvent, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { debugLog } from "#src/debug";
 import type { CreateSubagentSessionParams } from "#src/lifecycle/create-subagent-session";
+import {
+  type LifecycleInterceptorRegistry,
+  type SubagentLifecycleExecutionPath,
+  type SubagentTurnLifecycle,
+} from "#src/lifecycle/lifecycle-interceptor";
 import type { ParentSnapshot } from "#src/lifecycle/parent-snapshot";
 import { RunListeners } from "#src/lifecycle/run-listeners";
 import type { SubagentSession, TurnLoopResult } from "#src/lifecycle/subagent-session";
@@ -68,7 +74,13 @@ export interface SubagentExecution {
 	maxTurns?: number;
 	thinkingLevel?: ThinkingLevel;
 	parentSession?: ParentSessionInfo;
+	/** Service-origin identity for lifecycle callbacks; never changes child setup. */
+	lifecycleParentSession?: ParentSessionInfo;
 	signal?: AbortSignal;
+	/** Owned by the manager; only a callback bridge reaches the child session. */
+	lifecycleInterceptors?: LifecycleInterceptorRegistry;
+	/** Spawn-path facts remain stable when the same child session resumes. */
+	executionPath?: SubagentLifecycleExecutionPath;
 }
 
 export interface SubagentInit {
@@ -267,12 +279,14 @@ export class Subagent {
 		this.execution.observer?.onSessionCreated?.(this);
 
 		const runConfig = this.execution.getRunConfig?.();
+		const lifecycle = this.createTurnLifecycle("initial");
 		try {
 			const result = await this.subagentSession.runTurnLoop(this.execution.prompt, {
 				maxTurns: this.execution.maxTurns,
 				defaultMaxTurns: runConfig?.defaultMaxTurns,
 				graceTurns: runConfig?.graceTurns,
-				signal: this.abortController.signal,
+				signal: lifecycle?.signal ?? this.abortController.signal,
+				...(lifecycle ? { lifecycle } : {}),
 			});
 			this.completeRun(result);
 		} catch (err) {
@@ -329,14 +343,58 @@ export class Subagent {
 			onCompact: (info) => this.execution.observer?.onCompacted?.(this, info),
 		}));
 
+		const lifecycle = this.createTurnLifecycle("resume", signal);
 		try {
-			const responseText = await subagentSession.resumeTurnLoop(prompt, signal);
-			this.markCompleted(responseText);
+			if (lifecycle) {
+				const result = await subagentSession.resumeLifecycleTurnLoop(
+					prompt,
+					lifecycle.signal,
+					lifecycle,
+				);
+				if (result.aborted) this.markAborted(result.responseText);
+				else if (result.steered) this.markSteered(result.responseText);
+				else this.markCompleted(result.responseText);
+			} else {
+				const responseText = await subagentSession.resumeTurnLoop(prompt, signal);
+				this.markCompleted(responseText);
+			}
 		} catch (err) {
 			this.markError(err);
 		} finally {
 			this.listeners.release();
 		}
+	}
+
+	/** Build a callback-only lifecycle bridge after the immutable child session exists. */
+	private createTurnLifecycle(
+		phase: "initial" | "resume",
+		executionSignal: AbortSignal | undefined = this.abortController.signal,
+	): SubagentTurnLifecycle | undefined {
+		const registry = this.execution.lifecycleInterceptors;
+		const session = this.subagentSession;
+		if (!registry?.hasInterceptors() || !session) return undefined;
+		const initialPath = this.execution.executionPath ?? {
+			phase: "initial" as const,
+			origin: "service" as const,
+			mode: "foreground" as const,
+			admission: "immediate" as const,
+		};
+		const lifecycleParent = this.execution.lifecycleParentSession ?? this.execution.parentSession;
+		return registry.createTurnLifecycle({
+			identity: {
+				agentId: this.id,
+				sessionId: session.sessionId,
+				runId: randomUUID(),
+				agentType: this.type,
+				...(lifecycleParent?.parentSessionId
+					? { parentSessionId: lifecycleParent.parentSessionId }
+					: {}),
+			},
+			execution: { ...initialPath, phase },
+			signal: executionSignal === this.abortController.signal
+				? executionSignal
+				: AbortSignal.any([this.abortController.signal, executionSignal]),
+		});
 	}
 
 	/** Transition to running state. Sets status and startedAt. */

--- a/packages/pi-subagents/src/service/service-adapter.ts
+++ b/packages/pi-subagents/src/service/service-adapter.ts
@@ -6,6 +6,10 @@
  */
 
 import type { Model } from "@earendil-works/pi-ai";
+import type {
+  SubagentLifecycleInterceptor,
+  SubagentLifecycleRegistration,
+} from "#src/lifecycle/lifecycle-interceptor";
 import type { ParentSnapshot } from "#src/lifecycle/parent-snapshot";
 import type { WorkspaceProvider } from "#src/lifecycle/workspace";
 import type { SpawnOptions, SubagentRecord, SubagentsService } from "#src/service/service";
@@ -21,6 +25,9 @@ export interface SubagentManagerLike {
   waitForAll(): Promise<void>;
   hasRunning(): boolean;
   registerWorkspaceProvider(provider: WorkspaceProvider): () => void;
+  registerLifecycleInterceptor(
+    interceptor: SubagentLifecycleInterceptor,
+  ): SubagentLifecycleRegistration;
 }
 
 /**
@@ -30,6 +37,7 @@ export interface SubagentManagerLike {
 export interface ServiceRuntimeLike {
   readonly currentCtx: SessionContext | undefined;
   buildSnapshot(inheritContext: boolean): ParentSnapshot;
+  getSessionInfo(): { parentSessionFile: string; parentSessionId: string };
 }
 
 /** Adapter that wraps SubagentManager to satisfy SubagentsService. */
@@ -50,6 +58,7 @@ export class SubagentsServiceAdapter implements SubagentsService {
     const isBackground = !(options?.foreground ?? false);
 
     const snapshot = this.runtime.buildSnapshot(options?.inheritContext ?? false);
+    const parent = this.runtime.getSessionInfo();
     return this.manager.spawn(snapshot, type, prompt, {
       description,
       model,
@@ -58,6 +67,13 @@ export class SubagentsServiceAdapter implements SubagentsService {
       inheritContext: options?.inheritContext,
       bypassQueue: options?.bypassQueue,
       isBackground,
+      origin: "service",
+      lifecycleParentSession: parent.parentSessionId
+        ? {
+            parentSessionFile: parent.parentSessionFile || undefined,
+            parentSessionId: parent.parentSessionId,
+          }
+        : undefined,
     });
   }
 
@@ -93,6 +109,12 @@ export class SubagentsServiceAdapter implements SubagentsService {
 
   registerWorkspaceProvider(provider: WorkspaceProvider): () => void {
     return this.manager.registerWorkspaceProvider(provider);
+  }
+
+  registerLifecycleInterceptor(
+    interceptor: SubagentLifecycleInterceptor,
+  ): SubagentLifecycleRegistration {
+    return this.manager.registerLifecycleInterceptor(interceptor);
   }
 
   /** Resolve an optional model-string override against the current session's registry. */

--- a/packages/pi-subagents/src/service/service.ts
+++ b/packages/pi-subagents/src/service/service.ts
@@ -9,6 +9,10 @@
  *   svc?.spawn("Explore", "Check for stale TODOs");
  */
 
+import type {
+  SubagentLifecycleInterceptor,
+  SubagentLifecycleRegistration,
+} from "#src/lifecycle/lifecycle-interceptor";
 import type { SubagentStatus } from "#src/lifecycle/subagent";
 import type { LifetimeUsage } from "#src/lifecycle/usage";
 import type {
@@ -20,6 +24,22 @@ import type {
 } from "#src/lifecycle/workspace";
 
 
+export {
+  MAX_LIFECYCLE_CONTINUATION_ROUNDS,
+  type SubagentExecutionAdmission,
+  type SubagentExecutionMode,
+  type SubagentExecutionOrigin,
+  type SubagentExecutionPhase,
+  type SubagentLifecycleCompletionContext,
+  type SubagentLifecycleCompletionDecision,
+  type SubagentLifecycleExecutionPath,
+  type SubagentLifecycleIdentity,
+  type SubagentLifecycleInterceptor,
+  type SubagentLifecycleOutcome,
+  type SubagentLifecycleRegistration,
+  type SubagentLifecycleStartContext,
+  type SubagentLifecycleStartDecision,
+} from "#src/lifecycle/lifecycle-interceptor";
 // SubagentStatus is defined in the lifecycle layer (single home) and re-exported
 // here for the public API surface — mirrors the LifetimeUsage / workspace pattern.
 export type { SubagentStatus } from "#src/lifecycle/subagent";
@@ -91,6 +111,14 @@ export interface SubagentsService {
    * registered. Returns a disposer that unregisters the provider.
    */
   registerWorkspaceProvider(provider: WorkspaceProvider): () => void;
+
+  /**
+   * Register an ordered async lifecycle provider. It receives only immutable
+   * execution facts and prompt/result decisions, never a manager or session.
+   */
+  registerLifecycleInterceptor(
+    interceptor: SubagentLifecycleInterceptor,
+  ): SubagentLifecycleRegistration;
 }
 
 /** Event channel constants for pi.events subscriptions. */

--- a/packages/pi-subagents/src/tools/background-spawner.ts
+++ b/packages/pi-subagents/src/tools/background-spawner.ts
@@ -38,6 +38,7 @@ export function spawnBackground(
       inheritContext: execution.inheritContext,
       thinkingLevel: execution.thinking,
       isBackground: true,
+      origin: "tool",
       invocation: execution.agentInvocation,
     });
   } catch (err) {

--- a/packages/pi-subagents/src/tools/foreground-runner.ts
+++ b/packages/pi-subagents/src/tools/foreground-runner.ts
@@ -92,6 +92,7 @@ export async function runForeground(
         maxTurns: execution.effectiveMaxTurns,
         inheritContext: execution.inheritContext,
         thinkingLevel: execution.thinking,
+        origin: "tool",
         invocation: execution.agentInvocation,
         signal,
         parentSession: params.parentSession,

--- a/packages/pi-subagents/test/lifecycle/lifecycle-interceptor.test.ts
+++ b/packages/pi-subagents/test/lifecycle/lifecycle-interceptor.test.ts
@@ -1,0 +1,380 @@
+import { EventEmitter } from "node:events";
+import type { AgentSession } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import { createChildLifecyclePublisher, SUBAGENT_CHILD_COMPLETED } from "#src/lifecycle/child-lifecycle";
+import { ConcurrencyLimiter } from "#src/lifecycle/concurrency-limiter";
+import {
+  LifecycleInterceptorRegistry,
+  type SubagentLifecycleExecutionPath,
+  type SubagentLifecycleIdentity,
+} from "#src/lifecycle/lifecycle-interceptor";
+import { SubagentManager } from "#src/lifecycle/subagent-manager";
+import { SubagentSession } from "#src/lifecycle/subagent-session";
+import { STUB_SNAPSHOT } from "#test/helpers/stub-ctx";
+
+function createSession(results = ["result"]) {
+  const listeners: Array<(event: any) => void> = [];
+  let nextResult = 0;
+  const session = {
+    messages: [] as unknown[],
+    subscribe: vi.fn((listener: (event: any) => void) => {
+      listeners.push(listener);
+      return () => {};
+    }),
+    prompt: vi.fn(async () => {
+      session.messages.push({
+        role: "assistant",
+        content: [{ type: "text", text: results[nextResult++] ?? results.at(-1)! }],
+      });
+    }),
+    abort: vi.fn(),
+    steer: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn(),
+    getSessionStats: vi.fn(() => ({ tokens: { input: 0, output: 0, cacheWrite: 0 } })),
+    getToolDefinition: vi.fn(),
+  };
+  return { session, listeners };
+}
+
+function makeSubagentSession(
+  session: ReturnType<typeof createSession>["session"],
+  completed = vi.fn(),
+) {
+  return new SubagentSession(session as unknown as AgentSession, {
+    outputFile: undefined,
+    sessionId: "child-1",
+    sessionDir: "/session-dir",
+    agentName: "Explore",
+    agentMaxTurns: undefined,
+    parentContext: "PARENT:\n",
+    lifecycle: {
+      spawning: vi.fn(),
+      sessionCreated: vi.fn(),
+      completed,
+      disposed: vi.fn(),
+    },
+  });
+}
+
+function control(registry: LifecycleInterceptorRegistry, signal = new AbortController().signal) {
+  const identity: SubagentLifecycleIdentity = {
+    agentId: "agent-1",
+    sessionId: "child-1",
+    runId: "run-1",
+    agentType: "Explore",
+    parentSessionId: "parent-1",
+  };
+  const execution: SubagentLifecycleExecutionPath = {
+    phase: "initial",
+    origin: "tool",
+    mode: "background",
+    admission: "queued",
+  };
+  return registry.createTurnLifecycle({ identity, execution, signal });
+}
+
+describe("LifecycleInterceptorRegistry", () => {
+  it("runs sequentially, pipes exact prompt/result replacements, and preserves immutable identity", async () => {
+    const registry = new LifecycleInterceptorRegistry();
+    const calls: string[] = [];
+    const seen: unknown[] = [];
+    registry.register({
+      beforeStart: async (context) => {
+        calls.push(`start-1:${context.prompt}`);
+        seen.push(context.identity, context.execution);
+        return { action: "continue", prompt: `${context.prompt}:first` };
+      },
+      beforeComplete: async (context) => {
+        calls.push(`complete-1:${context.proposedResult}`);
+        seen.push(context.identity, context.execution);
+        return { action: "complete", result: `${context.proposedResult}:first` };
+      },
+    });
+    registry.register({
+      beforeStart: (context) => {
+        calls.push(`start-2:${context.prompt}`);
+        return { action: "continue", prompt: `${context.prompt}:second` };
+      },
+      beforeComplete: (context) => {
+        calls.push(`complete-2:${context.proposedResult}`);
+        return { action: "complete", result: `${context.proposedResult}:second` };
+      },
+    });
+
+    const turn = control(registry);
+    const start = await turn.beforeStart("exact");
+    const completion = await turn.beforeComplete("candidate", "completed", 0);
+
+    expect(start).toEqual({ action: "continue", prompt: "exact:first:second" });
+    expect(completion).toEqual({ action: "complete", result: "candidate:first:second" });
+    expect(calls).toEqual([
+      "start-1:exact",
+      "start-2:exact:first",
+      "complete-1:candidate",
+      "complete-2:candidate:first",
+    ]);
+    expect(seen).toHaveLength(4);
+    expect(Object.isFrozen((seen[0] as { agentId: string }))).toBe(true);
+    expect(Object.isFrozen((seen[1] as { phase: string }))).toBe(true);
+    await registry.dispose();
+  });
+
+  it("unregisters future snapshots while allowing the captured ordered snapshot to finish", async () => {
+    const registry = new LifecycleInterceptorRegistry();
+    const calls: string[] = [];
+    registry.register({
+      beforeStart: async (context) => {
+        calls.push("first");
+        await second.dispose();
+        return { action: "continue", prompt: context.prompt };
+      },
+    });
+    const second = registry.register({
+      beforeStart: (context) => {
+        calls.push("second");
+        return { action: "continue", prompt: context.prompt };
+      },
+      dispose: () => { calls.push("second-disposed"); },
+    });
+
+    await control(registry).beforeStart("prompt");
+    await Promise.resolve();
+    expect(calls).toEqual(["first", "second", "second-disposed"]);
+
+    await control(registry).beforeStart("prompt");
+    expect(calls).toEqual(["first", "second", "second-disposed", "first"]);
+    await registry.dispose();
+  });
+
+  it("propagates cancellation during a callback without starting a prompt", async () => {
+    const registry = new LifecycleInterceptorRegistry();
+    let entered!: () => void;
+    const enteredPromise = new Promise<void>((resolve) => { entered = resolve; });
+    registry.register({
+      beforeStart: async () => {
+        entered();
+        return new Promise(() => undefined);
+      },
+    });
+    const controller = new AbortController();
+    const turn = control(registry, controller.signal);
+    const pending = turn.beforeStart("prompt");
+    await enteredPromise;
+    const reason = new Error("caller cancelled");
+    controller.abort(reason);
+    await expect(pending).rejects.toBe(reason);
+    await registry.dispose();
+  });
+});
+
+describe("SubagentSession lifecycle interception", () => {
+  it("runs start before the exact prompt and completion before child completion", async () => {
+    const registry = new LifecycleInterceptorRegistry();
+    const order: string[] = [];
+    registry.register({
+      beforeStart: (context) => {
+        order.push(`start:${context.prompt}`);
+        return { action: "continue", prompt: `${context.prompt}:provider` };
+      },
+      beforeComplete: (context) => {
+        order.push(`completion:${context.proposedResult}`);
+        return { action: "complete", result: `${context.proposedResult}:accepted` };
+      },
+    });
+    const { session } = createSession(["candidate"]);
+    const completed = vi.fn(() => { order.push("child-completed"); });
+    const subagentSession = makeSubagentSession(session, completed);
+
+    const result = await subagentSession.runTurnLoop("work", { lifecycle: control(registry) });
+
+    expect(session.prompt).toHaveBeenCalledWith("PARENT:\nwork:provider");
+    expect(result).toMatchObject({ responseText: "candidate:accepted", aborted: false });
+    expect(order).toEqual([
+      "start:PARENT:\nwork",
+      "completion:candidate",
+      "child-completed",
+    ]);
+    await registry.dispose();
+  });
+
+  it("publishes the Pi EventEmitter completion only after provider acceptance", async () => {
+    const registry = new LifecycleInterceptorRegistry();
+    const order: string[] = [];
+    registry.register({
+      beforeComplete: (context) => {
+        order.push(`provider:${context.proposedResult}`);
+        return { action: "complete", result: context.proposedResult };
+      },
+    });
+    const events = new EventEmitter();
+    events.on(SUBAGENT_CHILD_COMPLETED, () => { order.push("event"); });
+    const { session } = createSession(["candidate"]);
+    const subagentSession = new SubagentSession(session as unknown as AgentSession, {
+      outputFile: undefined,
+      sessionId: "child-1",
+      sessionDir: "/session-dir",
+      agentName: "Explore",
+      agentMaxTurns: undefined,
+      parentContext: undefined,
+      lifecycle: createChildLifecyclePublisher((channel, data) => events.emit(channel, data)),
+    });
+
+    await subagentSession.runTurnLoop("work", { lifecycle: control(registry) });
+
+    expect(order).toEqual(["provider:candidate", "event"]);
+    await registry.dispose();
+  });
+
+  it("prevents the first prompt on start abort and does not emit child completion", async () => {
+    const registry = new LifecycleInterceptorRegistry();
+    registry.register({ beforeStart: () => ({ action: "abort", reason: "blocked" }) });
+    const { session } = createSession();
+    const completed = vi.fn();
+    const subagentSession = makeSubagentSession(session, completed);
+
+    const result = await subagentSession.runTurnLoop("work", { lifecycle: control(registry) });
+
+    expect(result).toMatchObject({ responseText: "blocked", aborted: true, lifecycleAborted: true });
+    expect(session.prompt).not.toHaveBeenCalled();
+    expect(completed).not.toHaveBeenCalled();
+    await registry.dispose();
+  });
+
+  it("cancels a pending completion callback before any completion side effect", async () => {
+    const registry = new LifecycleInterceptorRegistry();
+    let entered!: () => void;
+    const enteredPromise = new Promise<void>((resolve) => { entered = resolve; });
+    registry.register({
+      beforeComplete: async () => {
+        entered();
+        return new Promise(() => undefined);
+      },
+    });
+    const controller = new AbortController();
+    const reason = new Error("completion cancelled");
+    const { session } = createSession(["candidate"]);
+    const completed = vi.fn();
+    const subagentSession = makeSubagentSession(session, completed);
+    const pending = subagentSession.runTurnLoop("work", {
+      lifecycle: control(registry, controller.signal),
+    });
+    await enteredPromise;
+    controller.abort(reason);
+
+    await expect(pending).rejects.toBe(reason);
+    expect(session.prompt).toHaveBeenCalledOnce();
+    expect(completed).not.toHaveBeenCalled();
+    await registry.dispose();
+  });
+
+  it("continues on the same session and aborts exactly at the finite bound", async () => {
+    const registry = new LifecycleInterceptorRegistry();
+    registry.register({
+      beforeComplete: (context) => ({
+        action: "continue",
+        prompt: `continue-${context.continuationRound}`,
+      }),
+    });
+    const { session } = createSession(["first", "second", "third", "fourth"]);
+    const completed = vi.fn();
+    const subagentSession = makeSubagentSession(session, completed);
+
+    const result = await subagentSession.runTurnLoop("work", { lifecycle: control(registry) });
+
+    expect(result).toMatchObject({ aborted: true, lifecycleAborted: true });
+    expect(session.prompt).toHaveBeenCalledTimes(4);
+    expect(session.prompt).toHaveBeenNthCalledWith(1, "PARENT:\nwork");
+    expect(session.prompt).toHaveBeenNthCalledWith(2, "continue-0");
+    expect(session.prompt).toHaveBeenNthCalledWith(3, "continue-1");
+    expect(session.prompt).toHaveBeenNthCalledWith(4, "continue-2");
+    expect(completed).not.toHaveBeenCalled();
+    await registry.dispose();
+  });
+
+  it("covers tool/service, foreground/background/queued, initial, and resume through the manager", async () => {
+    let limit = 1;
+    let sessionNumber = 0;
+    const manager = new SubagentManager({
+      baseCwd: "/repo",
+      limiter: new ConcurrencyLimiter(() => limit),
+      createSubagentSession: async () => {
+        const { session } = createSession([`result-${++sessionNumber}`]);
+        return makeSubagentSession(session);
+      },
+    });
+    const starts: SubagentLifecycleExecutionPath[] = [];
+    const completions: SubagentLifecycleExecutionPath[] = [];
+    manager.registerLifecycleInterceptor({
+      beforeStart: (context) => {
+        starts.push(context.execution);
+        return { action: "continue" };
+      },
+      beforeComplete: (context) => {
+        completions.push(context.execution);
+        return { action: "complete" };
+      },
+    });
+
+    await manager.spawnAndWait(STUB_SNAPSHOT, "Explore", "tool foreground", {
+      description: "tool foreground",
+      origin: "tool",
+    });
+    const serviceImmediate = manager.spawn(STUB_SNAPSHOT, "Explore", "service background", {
+      description: "service background",
+      isBackground: true,
+      origin: "service",
+      parentSession: { parentSessionId: "service-parent" },
+    });
+    await manager.getRecord(serviceImmediate)!.promise;
+
+    limit = 0;
+    const queued = manager.spawn(STUB_SNAPSHOT, "Explore", "tool queued", {
+      description: "tool queued",
+      isBackground: true,
+      origin: "tool",
+    });
+    expect(manager.getRecord(queued)!.status).toBe("queued");
+    limit = 1;
+    // The limiter intentionally owns queue admission; reopening it starts the
+    // already-registered lifecycle at dequeue rather than record creation.
+    (manager as unknown as { limiter: ConcurrencyLimiter }).limiter.recheck();
+    await manager.getRecord(queued)!.promise;
+    await manager.resume(serviceImmediate, "resume");
+
+    expect(starts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ phase: "initial", origin: "tool", mode: "foreground", admission: "immediate" }),
+      expect.objectContaining({ phase: "initial", origin: "service", mode: "background", admission: "immediate" }),
+      expect.objectContaining({ phase: "initial", origin: "tool", mode: "background", admission: "queued" }),
+      expect.objectContaining({ phase: "resume", origin: "service", mode: "background", admission: "immediate" }),
+    ]));
+    expect(completions).toHaveLength(4);
+    manager.dispose();
+  });
+
+  it("fails before finalization when a completion interceptor rejects", async () => {
+    const registry = new LifecycleInterceptorRegistry();
+    registry.register({ beforeComplete: () => { throw new Error("provider failed"); } });
+    const { session } = createSession(["candidate"]);
+    const completed = vi.fn();
+    const subagentSession = makeSubagentSession(session, completed);
+
+    await expect(subagentSession.runTurnLoop("work", { lifecycle: control(registry) }))
+      .rejects.toThrow("Lifecycle interceptor failed during beforeComplete");
+    expect(completed).not.toHaveBeenCalled();
+    await registry.dispose();
+  });
+
+  it("keeps no-provider event ordering unchanged", async () => {
+    const { session } = createSession(["result"]);
+    const order: string[] = [];
+    const subagentSession = makeSubagentSession(session, vi.fn(() => { order.push("child-completed"); }));
+    session.prompt.mockImplementation(async () => {
+      session.messages.push({ role: "assistant", content: [{ type: "text", text: "result" }] });
+      order.push("prompt-resolved");
+    });
+
+    await subagentSession.runTurnLoop("work", {});
+
+    expect(order).toEqual(["prompt-resolved", "child-completed"]);
+  });
+});

--- a/packages/pi-subagents/test/service/service-adapter.test.ts
+++ b/packages/pi-subagents/test/service/service-adapter.test.ts
@@ -124,10 +124,15 @@ function makeStubCtx(): SessionContext {
  * Override `currentCtx` to simulate no active session.
  */
 function makeRuntimeStub(override: Partial<ServiceRuntimeLike> = {}): ServiceRuntimeLike {
+  const { getSessionInfo, ...rest } = override;
   return {
     currentCtx: makeStubCtx(),
     buildSnapshot: vi.fn((_: boolean): ParentSnapshot => STUB_SNAPSHOT),
-    ...override,
+    getSessionInfo: getSessionInfo ?? (() => ({
+      parentSessionFile: "/sessions/parent.jsonl",
+      parentSessionId: "stub-session",
+    })),
+    ...rest,
   };
 }
 
@@ -147,6 +152,9 @@ function createManagerStub() {
     waitForAll: vi.fn<SubagentManagerLike["waitForAll"]>(async () => {}),
     hasRunning: vi.fn<SubagentManagerLike["hasRunning"]>(() => false),
     registerWorkspaceProvider: vi.fn<SubagentManagerLike["registerWorkspaceProvider"]>(() => () => {}),
+    registerLifecycleInterceptor: vi.fn<SubagentManagerLike["registerLifecycleInterceptor"]>(() => ({
+      dispose: async () => {},
+    })),
   };
 }
 
@@ -260,6 +268,11 @@ describe("SubagentsServiceAdapter — spawn", () => {
         model: resolvedModel,
         maxTurns: 5,
         isBackground: true,
+        origin: "service",
+        lifecycleParentSession: {
+          parentSessionFile: "/sessions/parent.jsonl",
+          parentSessionId: "stub-session",
+        },
       }),
     );
   });
@@ -388,6 +401,19 @@ describe("SubagentsServiceAdapter — steer, abort, waitForAll, hasRunning", () 
       expect(await svc.steer("a-1", "focus on tests")).toBe(true);
       expect(mockSteer).toHaveBeenCalledWith("focus on tests");
     });
+  });
+});
+
+describe("SubagentsServiceAdapter — registerLifecycleInterceptor", () => {
+  it("delegates the generic provider without exposing manager internals", () => {
+    const registration = { dispose: vi.fn(async () => {}) };
+    const mgr = createManagerStub();
+    mgr.registerLifecycleInterceptor.mockReturnValue(registration);
+    const svc = new SubagentsServiceAdapter(mgr, vi.fn(), makeRuntimeStub());
+    const interceptor = { beforeStart: () => ({ action: "continue" as const }) };
+
+    expect(svc.registerLifecycleInterceptor(interceptor)).toBe(registration);
+    expect(mgr.registerLifecycleInterceptor).toHaveBeenCalledWith(interceptor);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds an ordered, asynchronous lifecycle-interceptor registration to `@gotgenes/pi-subagents`.
The API is a narrow generative provider seam: it lets an extension transform or abort the exact next prompt and inspect, transform, abort, or continue a proposed result before finalization.
It preserves the existing execution path when no interceptor is registered.

## Design

- Extends ADR 0002's provider-seam model rather than treating observational events as a decision API.
- Exposes immutable agent, session, run, type, optional parent-session, and execution-path facts without exposing a manager or live session.
- Applies to tool and service calls; foreground, background, immediate, and queued execution; and initial and resumed turns.
- Awaits registrations in order and pipes prompt/result replacements to later registrations.
- Supports cancellation, typed callback failure, idempotent unregister, one-time provider cleanup, and a bounded three-round same-session continuation.
- Keeps configuration, models, tools, queues, sessions, steering, persistence, workspaces, notifications, and disposal in the existing core.

`packages/pi-subagents/docs/decisions/0005-ordered-lifecycle-interceptors.md` records the contract, and the README includes a minimal extension-author example.

Related to #466: resumed turns now pass through the same interception boundary without reinterpreting the existing public events as an interceptor mechanism.

## Verification

- `mise exec pnpm@11.5.2 -- pnpm --filter @gotgenes/pi-subagents run check`
- `mise exec pnpm@11.5.2 -- pnpm --filter @gotgenes/pi-subagents run lint`
- `mise exec pnpm@11.5.2 -- pnpm --filter @gotgenes/pi-subagents test` — 65 files, 1,008 tests
- `mise exec pnpm@11.5.2 -- pnpm --filter @gotgenes/pi-subagents run verify:public-types`
- `mise exec pnpm@11.5.2 -- pnpm run check`
- `mise exec pnpm@11.5.2 -- pnpm run lint`
- `mise exec pnpm@11.5.2 -- pnpm run test`
- `mise exec pnpm@11.5.2 -- pnpm exec fallow dead-code`
- Lifecycle order matrix: `test/lifecycle/lifecycle-interceptor.test.ts` — 11 tests
- Unchanged portable lifecycle conformance: 2 files, 11 tests, with target-project typecheck

## Release request

This is an additive public service API and should be released as a minor `pi-subagents` version through the normal release-please flow.

## Immutable comparison

- Base: `gotgenes/pi-packages` `main` at `0456e17098de1c9f9da8d3ddb90545140b021881`
- Head: `nklisch:upstream/subagent-lifecycle-interception` at `e74f70ae095b6f6f4d17b458015ed4a716ddf505`
