### PR TITLE
feat(pi-subagents): redact parent results

### DIFF
--- a/packages/pi-subagents/src/lifecycle/child-lifecycle.ts
+++ b/packages/pi-subagents/src/lifecycle/child-lifecycle.ts
@@ -44,7 +44,8 @@ export interface ChildSessionCreatedEvent {
 
 /** Payload for `subagents:child:completed`. */
 export interface ChildCompletedEvent {
-  sessionDir: string;
+  /** Omitted when parentResultMode redacts the child transcript. */
+  sessionDir?: string;
   agentName: string;
   /** True if the run was hard-aborted (max turns + grace exceeded). */
   aborted: boolean;

--- a/packages/pi-subagents/src/lifecycle/create-subagent-session.ts
+++ b/packages/pi-subagents/src/lifecycle/create-subagent-session.ts
@@ -23,7 +23,7 @@ import type { ParentSnapshot } from "#src/lifecycle/parent-snapshot";
 import { SubagentSession } from "#src/lifecycle/subagent-session";
 import type { EnvInfo } from "#src/session/env";
 import { type AssemblerIO, assembleSessionConfig } from "#src/session/session-config";
-import type { ParentSessionInfo, ShellExec, SubagentType, ThinkingLevel } from "#src/types";
+import type { ParentResultMode, ParentSessionInfo, ShellExec, SubagentType, ThinkingLevel } from "#src/types";
 
 /** Names of tools registered by this extension that subagents must NOT inherit. */
 const EXCLUDED_TOOL_NAMES = ["subagent", "get_subagent_result", "steer_subagent"];
@@ -135,6 +135,7 @@ export interface CreateSubagentSessionParams {
   parentSession?: ParentSessionInfo;
   model?: Model<any>;
   thinkingLevel?: ThinkingLevel;
+  parentResultMode?: ParentResultMode;
 }
 
 /**
@@ -218,6 +219,7 @@ export async function createSubagentSession(
     agentName: type,
     agentMaxTurns: cfg.agentMaxTurns,
     parentContext: snapshot.parentContext,
+    parentResultMode: params.parentResultMode,
     lifecycle: deps.lifecycle,
   });
 

--- a/packages/pi-subagents/src/lifecycle/subagent-manager.ts
+++ b/packages/pi-subagents/src/lifecycle/subagent-manager.ts
@@ -18,7 +18,7 @@ import { SubagentState, type SubagentStatus } from "#src/lifecycle/subagent-stat
 import type { WorkspaceProvider } from "#src/lifecycle/workspace";
 
 import type { RunConfig } from "#src/runtime";
-import type { AgentInvocation, CompactionInfo, ParentSessionInfo, SubagentType, ThinkingLevel } from "#src/types";
+import type { AgentInvocation, CompactionInfo, ParentResultMode, ParentSessionInfo, SubagentType, ThinkingLevel } from "#src/types";
 
 /**
  * A lightweight snapshot of a subagent evicted by the 10-minute cleanup sweep.
@@ -65,6 +65,7 @@ export interface AgentSpawnConfig {
   maxTurns?: number;
   inheritContext?: boolean;
   thinkingLevel?: ThinkingLevel;
+  parentResultMode?: ParentResultMode;
   isBackground?: boolean;
   /**
    * Skip the maxConcurrent queue check for this spawn - start immediately even
@@ -178,6 +179,7 @@ export class SubagentManager {
         model: options.model,
         maxTurns: options.maxTurns,
         thinkingLevel: options.thinkingLevel,
+        parentResultMode: options.parentResultMode,
         parentSession: options.parentSession,
         signal: options.signal,
       },
@@ -273,7 +275,8 @@ export class SubagentManager {
       if ((record.completedAt ?? 0) >= cutoff) continue;
       // Retain a navigable descriptor before freeing the heavy session. Only an
       // agent with a persisted file can be sourced from disk after eviction.
-      if (record.outputFile) this.evicted.set(id, toEvictedSubagent(record, record.outputFile));
+      const outputFile = record.parentResultPresentation.outputFile;
+      if (outputFile) this.evicted.set(id, toEvictedSubagent(record, outputFile));
       this.removeRecord(id, record);
     }
   }
@@ -354,7 +357,7 @@ function toEvictedSubagent(record: Subagent, outputFile: string): EvictedSubagen
   return {
     id: record.id,
     type: record.type,
-    description: record.description,
+    description: record.parentResultPresentation.description,
     status: record.status,
     startedAt: record.startedAt,
     completedAt: record.completedAt,

--- a/packages/pi-subagents/src/lifecycle/subagent-session.ts
+++ b/packages/pi-subagents/src/lifecycle/subagent-session.ts
@@ -20,7 +20,7 @@ import { normalizeMaxTurns } from "#src/lifecycle/turn-limits";
 import { getSessionContextPercent, type SessionStatsLike } from "#src/lifecycle/usage";
 import { extractText } from "#src/session/context";
 import { getAgentConversation } from "#src/session/conversation";
-import type { SessionMessage } from "#src/types";
+import type { ParentResultMode, SessionMessage } from "#src/types";
 
 /** Outcome of one turn loop. */
 export interface TurnLoopResult {
@@ -55,6 +55,7 @@ export interface SubagentSessionMeta {
   agentMaxTurns: number | undefined;
   /** Parent context prepended to the run prompt, captured at spawn time. */
   parentContext: string | undefined;
+  parentResultMode: ParentResultMode | undefined;
   lifecycle: ChildLifecyclePublisher;
 }
 
@@ -119,7 +120,7 @@ export class SubagentSession {
     try {
       await session.prompt(effectivePrompt);
       this.meta.lifecycle.completed({
-        sessionDir: this.meta.sessionDir,
+        ...(this.meta.parentResultMode === "redacted" ? {} : { sessionDir: this.meta.sessionDir }),
         agentName: this.meta.agentName,
         aborted,
         steered: softLimitReached,

--- a/packages/pi-subagents/src/lifecycle/subagent.ts
+++ b/packages/pi-subagents/src/lifecycle/subagent.ts
@@ -19,7 +19,7 @@ import type { WorkspaceProvider } from "#src/lifecycle/workspace";
 import { WorkspaceBracket } from "#src/lifecycle/workspace-bracket";
 import { subscribeSubagentObserver } from "#src/observation/record-observer";
 import type { RunConfig } from "#src/runtime";
-import type { AgentInvocation, CompactionInfo, ParentSessionInfo, SessionMessage, SubagentType, ThinkingLevel } from "#src/types";
+import type { AgentInvocation, CompactionInfo, ParentResultMode, ParentSessionInfo, SessionMessage, SubagentType, ThinkingLevel } from "#src/types";
 
 /** Per-subagent lifecycle observer — created by SubagentManager for each spawn. */
 export interface SubagentLifecycleObserver {
@@ -34,6 +34,14 @@ export interface SubagentLifecycleObserver {
 }
 
 export type { SubagentStatus } from "#src/lifecycle/subagent-state";
+
+/** A result projection safe to expose in the parent session. */
+export interface ParentResultPresentation {
+	description: string;
+	result: string | undefined;
+	error: string | undefined;
+	outputFile: string | undefined;
+}
 
 /**
  * The result of a steer attempt. `Subagent.steer` owns the non-running
@@ -67,6 +75,7 @@ export interface SubagentExecution {
 	model?: Model<any>;
 	maxTurns?: number;
 	thinkingLevel?: ThinkingLevel;
+	parentResultMode?: ParentResultMode;
 	parentSession?: ParentSessionInfo;
 	signal?: AbortSignal;
 }
@@ -126,6 +135,29 @@ export class Subagent {
 	/** Path to the agent's session JSONL file, or undefined if not yet available. */
 	get outputFile(): string | undefined {
 		return this.subagentSession?.outputFile;
+	}
+
+	/** Whether parent-facing transcript access is withheld for this child. */
+	get isParentResultRedacted(): boolean {
+		return this.execution.parentResultMode === "redacted";
+	}
+
+	/** Task/result fields safe to expose through parent-facing channels. */
+	get parentResultPresentation(): ParentResultPresentation {
+		if (this.isParentResultRedacted) {
+			return {
+				description: "Child task withheld.",
+				result: "Child result withheld.",
+				error: this.error === undefined ? undefined : "Child error details withheld.",
+				outputFile: undefined,
+			};
+		}
+		return {
+			description: this.description,
+			result: this.result,
+			error: this.error,
+			outputFile: this.outputFile,
+		};
 	}
 
 	/** The tool call ID that spawned this background agent, if any. */
@@ -253,6 +285,7 @@ export class Subagent {
 				parentSession: this.execution.parentSession,
 				model: this.execution.model,
 				thinkingLevel: this.execution.thinkingLevel,
+				parentResultMode: this.execution.parentResultMode,
 			});
 		} catch (err) {
 			// The factory disposed its own session on a post-creation failure.
@@ -430,7 +463,7 @@ export class Subagent {
 				: "completed";
 		const finalResult =
 			result.responseText +
-			this.workspaceBracket.dispose({ status: finalStatus, description: this.description });
+			this.workspaceBracket.dispose({ status: finalStatus, description: this.parentResultPresentation.description });
 
 		if (result.aborted) this.markAborted(finalResult);
 		else if (result.steered) this.markSteered(finalResult);
@@ -450,7 +483,7 @@ export class Subagent {
 		this.listeners.release();
 
 		try {
-			this.workspaceBracket.dispose({ status: "error", description: this.description });
+			this.workspaceBracket.dispose({ status: "error", description: this.parentResultPresentation.description });
 		} catch (cleanupErr) { debugLog("workspace dispose on agent error", cleanupErr); }
 
 		this.execution.observer?.onRunFinished?.(this);

--- a/packages/pi-subagents/src/observation/notification.ts
+++ b/packages/pi-subagents/src/observation/notification.ts
@@ -42,28 +42,29 @@ export function getStatusLabel(status: string, error?: string): string {
 
 /** Format a structured <task-notification> XML block for the parent agent to parse. */
 export function formatTaskNotification(record: Subagent, resultMaxLen: number): string {
-  const status = getStatusLabel(record.status, record.error);
+  const presentation = record.parentResultPresentation;
+  const status = getStatusLabel(record.status, presentation.error);
   const durationMs = record.completedAt ? record.completedAt - record.startedAt : 0;
   const totalTokens = getLifetimeTotal(record.lifetimeUsage);
   const contextPercent = record.getContextPercent();
   const ctxXml = contextPercent !== null ? `<context_percent>${Math.round(contextPercent)}</context_percent>` : "";
   const compactXml = record.compactionCount ? `<compactions>${record.compactionCount}</compactions>` : "";
 
-  const resultPreview = record.result
-    ? record.result.length > resultMaxLen
-      ? record.result.slice(0, resultMaxLen) + "\n...(truncated, use get_subagent_result for full output)"
-      : record.result
+  const resultPreview = presentation.result
+    ? presentation.result.length > resultMaxLen
+      ? presentation.result.slice(0, resultMaxLen) + "\n...(truncated, use get_subagent_result for full output)"
+      : presentation.result
     : "No output.";
 
   const toolCallId = record.toolCallId;
-  const outputFile = record.outputFile;
+  const outputFile = presentation.outputFile;
   return [
     "<task-notification>",
     `<task-id>${record.id}</task-id>`,
     toolCallId ? `<tool-use-id>${escapeXml(toolCallId)}</tool-use-id>` : null,
     outputFile ? `<output-file>${escapeXml(outputFile)}</output-file>` : null,
     `<status>${escapeXml(status)}</status>`,
-    `<summary>Subagent "${escapeXml(record.description)}" ${record.status}</summary>`,
+    `<summary>Subagent "${escapeXml(presentation.description)}" ${record.status}</summary>`,
     `<result>${escapeXml(resultPreview)}</result>`,
     `<usage><total_tokens>${totalTokens}</total_tokens><tool_uses>${record.toolUses}</tool_uses>${ctxXml}${compactXml}<duration_ms>${durationMs}</duration_ms></usage>`,
     "</task-notification>",
@@ -78,28 +79,30 @@ export function buildNotificationDetails(
   resultMaxLen: number,
 ): NotificationDetails {
   const totalTokens = getLifetimeTotal(record.lifetimeUsage);
+  const presentation = record.parentResultPresentation;
 
   return {
     id: record.id,
-    description: record.description,
+    description: presentation.description,
     status: record.status,
     toolUses: record.toolUses,
     turnCount: record.turnCount,
     maxTurns: record.maxTurns,
     totalTokens,
     durationMs: record.completedAt ? record.completedAt - record.startedAt : 0,
-    outputFile: record.outputFile,
-    error: record.error,
-    resultPreview: record.result
-      ? record.result.length > resultMaxLen
-        ? record.result.slice(0, resultMaxLen) + "…"
-        : record.result
+    outputFile: presentation.outputFile,
+    error: presentation.error,
+    resultPreview: presentation.result
+      ? presentation.result.length > resultMaxLen
+        ? presentation.result.slice(0, resultMaxLen) + "…"
+        : presentation.result
       : "No output.",
   };
 }
 
 /** Build event data for lifecycle events from a Subagent. */
 export function buildEventData(record: Subagent) {
+  const presentation = record.parentResultPresentation;
   const durationMs = record.completedAt ? record.completedAt - record.startedAt : Date.now() - record.startedAt;
   const u = record.lifetimeUsage;
   const total = getLifetimeTotal(u);
@@ -110,9 +113,9 @@ export function buildEventData(record: Subagent) {
   return {
     id: record.id,
     type: record.type,
-    description: record.description,
-    result: record.result,
-    error: record.error,
+    description: presentation.description,
+    result: presentation.result,
+    error: presentation.error,
     status: record.status,
     toolUses: record.toolUses,
     durationMs,
@@ -189,7 +192,7 @@ export class NotificationManager implements NotificationSystem, ResultDelivery {
     if (this.consumed.has(record.id)) return;
 
     const notification = formatTaskNotification(record, 500);
-    const outputFile = record.outputFile;
+    const outputFile = record.parentResultPresentation.outputFile;
     const footer = outputFile ? `\nFull transcript available at: ${outputFile}` : "";
 
     this.sendMessage(

--- a/packages/pi-subagents/src/observation/subagent-events-observer.ts
+++ b/packages/pi-subagents/src/observation/subagent-events-observer.ts
@@ -38,7 +38,7 @@ export class SubagentEventsObserver implements SubagentManagerObserver {
 		this.emit("subagents:started", {
 			id: record.id,
 			type: record.type,
-			description: record.description,
+			description: record.parentResultPresentation.description,
 		});
 	}
 
@@ -53,13 +53,14 @@ export class SubagentEventsObserver implements SubagentManagerObserver {
 		}
 
 		// Persist final record for cross-extension history reconstruction.
+		const presentation = record.parentResultPresentation;
 		this.appendEntry("subagents:record", {
 			id: record.id,
 			type: record.type,
-			description: record.description,
+			description: presentation.description,
 			status: record.status,
-			result: record.result,
-			error: record.error,
+			result: presentation.result,
+			error: presentation.error,
 			startedAt: record.startedAt,
 			completedAt: record.completedAt,
 		});
@@ -73,7 +74,7 @@ export class SubagentEventsObserver implements SubagentManagerObserver {
 		this.emit("subagents:compacted", {
 			id: record.id,
 			type: record.type,
-			description: record.description,
+			description: record.parentResultPresentation.description,
 			reason: info.reason,
 			tokensBefore: info.tokensBefore,
 			compactionCount: record.compactionCount,
@@ -85,7 +86,7 @@ export class SubagentEventsObserver implements SubagentManagerObserver {
 		this.emit("subagents:created", {
 			id: record.id,
 			type: record.type,
-			description: record.description,
+			description: record.parentResultPresentation.description,
 			isBackground: true,
 		});
 	}

--- a/packages/pi-subagents/src/service/service-adapter.ts
+++ b/packages/pi-subagents/src/service/service-adapter.ts
@@ -56,6 +56,7 @@ export class SubagentsServiceAdapter implements SubagentsService {
       maxTurns: options?.maxTurns,
       thinkingLevel: options?.thinkingLevel,
       inheritContext: options?.inheritContext,
+      parentResultMode: options?.parentResultMode,
       bypassQueue: options?.bypassQueue,
       isBackground,
     });
@@ -115,10 +116,11 @@ export class SubagentsServiceAdapter implements SubagentsService {
  * Uses an explicit allowlist — new fields must be opted in.
  */
 export function toSubagentRecord(record: Subagent): SubagentRecord {
+  const presentation = record.parentResultPresentation;
   const out: SubagentRecord = {
     id: record.id,
     type: record.type,
-    description: record.description,
+    description: presentation.description,
     status: record.status,
     toolUses: record.toolUses,
     startedAt: record.startedAt,
@@ -126,8 +128,8 @@ export function toSubagentRecord(record: Subagent): SubagentRecord {
     compactionCount: record.compactionCount,
   };
 
-  if (record.result !== undefined) out.result = record.result;
-  if (record.error !== undefined) out.error = record.error;
+  if (presentation.result !== undefined) out.result = presentation.result;
+  if (presentation.error !== undefined) out.error = presentation.error;
   if (record.completedAt !== undefined) out.completedAt = record.completedAt;
 
   return out;

--- a/packages/pi-subagents/src/service/service.ts
+++ b/packages/pi-subagents/src/service/service.ts
@@ -18,11 +18,13 @@ import type {
   WorkspacePrepareContext,
   WorkspaceProvider,
 } from "#src/lifecycle/workspace";
+import type { ParentResultMode } from "#src/types";
 
 
 // SubagentStatus is defined in the lifecycle layer (single home) and re-exported
 // here for the public API surface — mirrors the LifetimeUsage / workspace pattern.
 export type { SubagentStatus } from "#src/lifecycle/subagent";
+export type { ParentResultMode } from "#src/types";
 // Generative extension seam (ADR 0002, Phase 16 Step 2). The provider type
 // and all four collaborator types it references are re-exported by name so
 // consumers can import them directly rather than recovering them via
@@ -58,6 +60,8 @@ export interface SpawnOptions {
   maxTurns?: number;
   thinkingLevel?: string;
   inheritContext?: boolean;
+  /** Redact task/result text from parent-facing records, events, and notifications. */
+  parentResultMode?: ParentResultMode;
   foreground?: boolean;
   bypassQueue?: boolean;
 }

--- a/packages/pi-subagents/src/tools/agent-tool.ts
+++ b/packages/pi-subagents/src/tools/agent-tool.ts
@@ -100,9 +100,10 @@ export class AgentTool {
 			if (!record) {
 				return textResult(`Failed to resume agent "${params.resume as string}".`);
 			}
+			const presentation = record.parentResultPresentation;
 			return textResult(
-				record.result?.trim() ?? record.error?.trim() ?? "No output.",
-				buildDetails(config.presentation.detailBase, record),
+				presentation.result?.trim() ?? presentation.error?.trim() ?? "No output.",
+				buildDetails(config.presentation.detailBase, record, { error: presentation.error }),
 			);
 		}
 

--- a/packages/pi-subagents/src/tools/get-result-tool.ts
+++ b/packages/pi-subagents/src/tools/get-result-tool.ts
@@ -55,6 +55,7 @@ export class GetResultTool {
 	}
 
 	private buildReport(record: Subagent, verbose?: boolean): AgentReport {
+		const presentation = record.parentResultPresentation;
 		return {
 			id: record.id,
 			displayName: getDisplayName(record.type, this.registry),
@@ -64,10 +65,10 @@ export class GetResultTool {
 			contextPercent: record.getContextPercent(),
 			compactionCount: record.compactionCount,
 			duration: formatDuration(record.startedAt, record.completedAt),
-			description: record.description,
-			result: record.result,
-			error: record.error,
-			conversation: verbose ? record.getConversation() : undefined,
+			description: presentation.description,
+			result: presentation.result,
+			error: presentation.error,
+			conversation: verbose && !record.isParentResultRedacted ? record.getConversation() : undefined,
 		};
 	}
 

--- a/packages/pi-subagents/src/types.ts
+++ b/packages/pi-subagents/src/types.ts
@@ -9,6 +9,9 @@ import type { ModelRegistry } from "#src/session/model-resolver";
 
 export type { SteerOutcome } from "#src/lifecycle/subagent";
 export { Subagent } from "#src/lifecycle/subagent";
+
+/** Controls task/result text exposed outside a native child session. */
+export type ParentResultMode = "full" | "redacted";
 export type { AgentSessionEvent, ThinkingLevel };
 
 /**

--- a/packages/pi-subagents/src/ui/agent-widget.ts
+++ b/packages/pi-subagents/src/ui/agent-widget.ts
@@ -165,21 +165,22 @@ export class AgentWidget implements SubagentManagerObserver {
 
   /** Project a live Subagent record onto a pure-data WidgetAgent snapshot. */
   private toWidgetAgent(record: Subagent): WidgetAgent {
+    const presentation = record.parentResultPresentation;
     return {
       id: record.id,
       type: record.type,
       status: record.status,
-      description: record.description,
+      description: presentation.description,
       toolUses: record.toolUses,
       startedAt: record.startedAt,
       completedAt: record.completedAt,
-      error: record.error,
+      error: presentation.error,
       lifetimeUsage: record.lifetimeUsage,
       compactionCount: record.compactionCount,
       turnCount: record.turnCount,
       maxTurns: record.maxTurns,
       activeTools: record.activeTools,
-      responseText: record.responseText,
+      responseText: presentation.result ?? "",
       contextPercent: record.getContextPercent(),
     };
   }

--- a/packages/pi-subagents/src/ui/session-navigation.ts
+++ b/packages/pi-subagents/src/ui/session-navigation.ts
@@ -33,6 +33,7 @@ export interface NavigableSubagent {
   readonly activeTools: ReadonlyMap<string, string>;
   readonly responseText: string;
   readonly agentMessages: readonly SessionMessage[];
+  readonly isParentResultRedacted: boolean;
   isSessionReady(): boolean;
   subscribeToUpdates(fn: (event: AgentSessionEvent) => void): (() => void) | undefined;
   getToolDefinition(name: string): ToolDefinition | undefined;
@@ -86,7 +87,7 @@ export function listNavigableAgents(
   registry: AgentConfigLookup,
 ): NavigationEntry[] {
   const live = agents
-    .filter((record) => record.isSessionReady())
+    .filter((record) => record.isSessionReady() && !record.isParentResultRedacted)
     .map((record): NavigationEntry => ({ kind: "live", record, label: buildLabel(record, registry) }));
   const liveIds = new Set(agents.map((record) => record.id));
   const evictedEntries = evicted

--- a/packages/pi-subagents/test/helpers/make-navigable.ts
+++ b/packages/pi-subagents/test/helpers/make-navigable.ts
@@ -17,6 +17,7 @@ export function makeNavigable(overrides: Partial<NavigableSubagent> = {}): Navig
     activeTools: new Map(),
     responseText: "",
     agentMessages: [],
+    isParentResultRedacted: false,
     isSessionReady: () => true,
     subscribeToUpdates: vi.fn(() => () => {}),
     getToolDefinition: vi.fn(() => undefined),

--- a/packages/pi-subagents/test/helpers/make-subagent.ts
+++ b/packages/pi-subagents/test/helpers/make-subagent.ts
@@ -2,7 +2,7 @@ import type { CreateSubagentSessionParams } from "#src/lifecycle/create-subagent
 import { Subagent, type SubagentExecution } from "#src/lifecycle/subagent";
 import type { SubagentSession } from "#src/lifecycle/subagent-session";
 import { SubagentState, type SubagentStatus } from "#src/lifecycle/subagent-state";
-import type { AgentInvocation, SubagentType } from "#src/types";
+import type { AgentInvocation, ParentResultMode, SubagentType } from "#src/types";
 import { createSubagentSessionStub, toSubagentSession } from "#test/helpers/mock-session";
 import { STUB_SNAPSHOT } from "#test/helpers/stub-ctx";
 
@@ -52,10 +52,12 @@ export interface TestSubagentOptions {
 	responseText?: string;
 	/** Thread maxTurns into the stub execution. Ignored when `execution` is supplied. */
 	maxTurns?: number;
+	/** Thread parent result visibility into the stub execution. Ignored when `execution` is supplied. */
+	parentResultMode?: ParentResultMode;
 }
 
 export function createTestSubagent(overrides: TestSubagentOptions = {}): Subagent {
-	const { id, type, description, invocation, execution, toolCallId, toolUses, lifetimeUsage, compactionCount, turnCount, activeTools, responseText, maxTurns, ...stateOverrides } =
+	const { id, type, description, invocation, execution, toolCallId, toolUses, lifetimeUsage, compactionCount, turnCount, activeTools, responseText, maxTurns, parentResultMode, ...stateOverrides } =
 		overrides;
 	const state = new SubagentState({
 		status: "completed",
@@ -78,6 +80,7 @@ export function createTestSubagent(overrides: TestSubagentOptions = {}): Subagen
 		execution: execution ?? makeStubExecution({
 			...(toolCallId ? { parentSession: { toolCallId } } : {}),
 			...(maxTurns !== undefined ? { maxTurns } : {}),
+			...(parentResultMode !== undefined ? { parentResultMode } : {}),
 		}),
 		state,
 	});

--- a/packages/pi-subagents/test/lifecycle/subagent-manager.test.ts
+++ b/packages/pi-subagents/test/lifecycle/subagent-manager.test.ts
@@ -293,6 +293,29 @@ describe("SubagentManager — evicted descriptors", () => {
     expect(typeof evicted[0].startedAt).toBe("number");
   });
 
+  it("does not retain a redacted native child's task, result, or transcript path", async () => {
+    const { factory, stub } = createSessionFactory(createMockSession(), "/tasks/secret.jsonl");
+    stub.runTurnLoop.mockResolvedValue({ responseText: "SECRET CHILD RESULT", aborted: false, steered: false });
+    ({ manager } = createManager({ createSubagentSession: factory }));
+
+    const id = manager.spawn(STUB_SNAPSHOT, "general-purpose", "SECRET TASK BODY", {
+      description: "SECRET TASK BODY",
+      isBackground: true,
+      parentResultMode: "redacted",
+    });
+    await manager.getRecord(id)!.promise;
+    expect(manager.getRecord(id)!.result).toBe("SECRET CHILD RESULT");
+
+    const completedAt = manager.getRecord(id)!.completedAt!;
+    vi.spyOn(Date, "now").mockReturnValue(completedAt + 11 * 60_000);
+    (manager as any).cleanup();
+
+    expect(manager.listAgents()).toHaveLength(0);
+    expect(JSON.stringify(manager.listEvicted())).not.toContain("SECRET TASK BODY");
+    expect(JSON.stringify(manager.listEvicted())).not.toContain("SECRET CHILD RESULT");
+    expect(manager.listEvicted()).toEqual([]);
+  });
+
   it("does not retain a descriptor for an evicted agent without an outputFile", async () => {
     await spawnAndEvict(undefined);
 

--- a/packages/pi-subagents/test/lifecycle/subagent-session.test.ts
+++ b/packages/pi-subagents/test/lifecycle/subagent-session.test.ts
@@ -66,6 +66,7 @@ function makeSubagentSession(
     agentName: string;
     agentMaxTurns: number | undefined;
     parentContext: string | undefined;
+    parentResultMode: "full" | "redacted" | undefined;
     lifecycle: ReturnType<typeof createChildLifecycleMock>;
   }>,
 ) {
@@ -78,6 +79,7 @@ function makeSubagentSession(
     agentName: metaOverrides?.agentName ?? "Explore",
     agentMaxTurns: metaOverrides?.agentMaxTurns,
     parentContext: metaOverrides?.parentContext,
+    parentResultMode: metaOverrides?.parentResultMode,
     lifecycle,
   });
   return { sub, lifecycle };
@@ -219,6 +221,24 @@ describe("SubagentSession — runTurnLoop lifecycle events", () => {
     expect(lifecycle.completed).toHaveBeenCalledOnce();
     expect(lifecycle.completed).toHaveBeenCalledWith({
       sessionDir: "/d",
+      agentName: "Explore",
+      aborted: false,
+      steered: false,
+    });
+  });
+
+  it("omits sessionDir from a redacted native child's completed event", async () => {
+    const { session } = createSession("OK");
+    const { sub } = makeSubagentSession(session, {
+      sessionDir: "/sessions/SECRET-CHILD-TRANSCRIPT",
+      parentResultMode: "redacted",
+      lifecycle,
+    });
+
+    await sub.runTurnLoop("go", {});
+
+    expect(JSON.stringify(lifecycle.completed.mock.calls)).not.toContain("SECRET-CHILD-TRANSCRIPT");
+    expect(lifecycle.completed).toHaveBeenCalledWith({
       agentName: "Explore",
       aborted: false,
       steered: false,

--- a/packages/pi-subagents/test/lifecycle/subagent.test.ts
+++ b/packages/pi-subagents/test/lifecycle/subagent.test.ts
@@ -438,9 +438,11 @@ describe("Subagent — disposeSession", () => {
 /** Create a complete Agent ready for run(). */
 function createRunnableAgent(overrides?: {
 	createSubagentSession?: SessionFactory;
+	description?: string;
 	observer?: SubagentLifecycleObserver;
 	getRunConfig?: () => { defaultMaxTurns: number | undefined; graceTurns: number };
 	parentSession?: { toolCallId?: string; parentSessionFile?: string; parentSessionId?: string };
+	parentResultMode?: "full" | "redacted";
 	signal?: AbortSignal;
 	baseCwd?: string;
 	workspaceProvider?: WorkspaceProvider;
@@ -451,7 +453,7 @@ function createRunnableAgent(overrides?: {
 	return new Subagent({
 		id: "run-1",
 		type: "general-purpose",
-		description: "run test",
+		description: overrides?.description ?? "run test",
 		execution: {
 			createSubagentSession,
 			observer,
@@ -459,6 +461,7 @@ function createRunnableAgent(overrides?: {
 			prompt: "do something",
 			getRunConfig: overrides?.getRunConfig,
 			parentSession: overrides?.parentSession,
+			parentResultMode: overrides?.parentResultMode,
 			signal: overrides?.signal,
 			baseCwd: overrides?.baseCwd ?? "/base",
 			getWorkspaceProvider: provider ? () => provider : undefined,
@@ -525,6 +528,15 @@ describe("Subagent.run() — workspace provider", () => {
 		expect(params.cwd).toBe("/ws/dir");
 	});
 
+	it("threads redacted parent result mode to the child session factory", async () => {
+		const { factory } = createFactory();
+		const agent = createRunnableAgent({ createSubagentSession: factory, parentResultMode: "redacted" });
+
+		await agent.run();
+
+		expect((factory as ReturnType<typeof vi.fn>).mock.calls[0][0].parentResultMode).toBe("redacted");
+	});
+
 	it("calls prepare with the run-start context", async () => {
 		const provider = makeWorkspaceProvider(makeWorkspace("/ws/dir"));
 		const agent = createRunnableAgent({ workspaceProvider: provider, baseCwd: "/parent" });
@@ -543,6 +555,56 @@ describe("Subagent.run() — workspace provider", () => {
 		await agent.run();
 		expect(agent.result).toBe("done\n\n---\nsaved to branch foo");
 		expect(workspace.dispose).toHaveBeenCalledWith({ status: "completed", description: "run test" });
+	});
+
+	it("withholds a redacted native child's description from successful workspace disposal", async () => {
+		const { stub } = createFactory();
+		const workspace = makeWorkspace("/ws/dir");
+		const agent = createRunnableAgent({
+			createSubagentSession: async () => toSubagentSession(stub),
+			workspaceProvider: makeWorkspaceProvider(workspace),
+			parentResultMode: "redacted",
+			description: "SECRET TASK BODY",
+		});
+
+		await agent.run();
+
+		expect(JSON.stringify(vi.mocked(workspace.dispose).mock.calls)).not.toContain("SECRET TASK BODY");
+		expect(workspace.dispose).toHaveBeenCalledWith({ status: "completed", description: "Child task withheld." });
+	});
+
+	it("withholds a redacted native child's description from failed workspace disposal", async () => {
+		const { stub } = createFactory();
+		stub.runTurnLoop.mockRejectedValue(new Error("failed"));
+		const workspace = makeWorkspace("/ws/dir");
+		const agent = createRunnableAgent({
+			createSubagentSession: async () => toSubagentSession(stub),
+			workspaceProvider: makeWorkspaceProvider(workspace),
+			parentResultMode: "redacted",
+			description: "SECRET TASK BODY",
+		});
+
+		await agent.run();
+
+		expect(JSON.stringify(vi.mocked(workspace.dispose).mock.calls)).not.toContain("SECRET TASK BODY");
+		expect(workspace.dispose).toHaveBeenCalledWith({ status: "error", description: "Child task withheld." });
+	});
+
+	it("withholds a redacted native child's description from cancelled workspace disposal", async () => {
+		const { stub } = createFactory();
+		stub.runTurnLoop.mockResolvedValue({ responseText: "done", aborted: true, steered: false });
+		const workspace = makeWorkspace("/ws/dir");
+		const agent = createRunnableAgent({
+			createSubagentSession: async () => toSubagentSession(stub),
+			workspaceProvider: makeWorkspaceProvider(workspace),
+			parentResultMode: "redacted",
+			description: "SECRET TASK BODY",
+		});
+
+		await agent.run();
+
+		expect(JSON.stringify(vi.mocked(workspace.dispose).mock.calls)).not.toContain("SECRET TASK BODY");
+		expect(workspace.dispose).toHaveBeenCalledWith({ status: "aborted", description: "Child task withheld." });
 	});
 
 	it("falls back to baseCwd (cwd undefined) when prepare returns undefined", async () => {

--- a/packages/pi-subagents/test/observation/notification.test.ts
+++ b/packages/pi-subagents/test/observation/notification.test.ts
@@ -78,6 +78,21 @@ describe("formatTaskNotification", () => {
     const xml = formatTaskNotification(baseRecord, 500);
     expect(xml).not.toContain("tool-use-id");
   });
+
+  it("redacts task and result text for a redacted native child", () => {
+    const record = createTestSubagent({
+      description: "SECRET TASK BODY",
+      result: "SECRET CHILD RESULT",
+      parentResultMode: "redacted",
+    });
+    const xml = formatTaskNotification(record, 500);
+    const details = buildNotificationDetails(record, 500);
+
+    expect(xml).not.toContain("SECRET TASK BODY");
+    expect(xml).not.toContain("SECRET CHILD RESULT");
+    expect(JSON.stringify(details)).not.toContain("SECRET TASK BODY");
+    expect(JSON.stringify(details)).not.toContain("SECRET CHILD RESULT");
+  });
 });
 
 describe("buildNotificationDetails", () => {

--- a/packages/pi-subagents/test/observation/subagent-events-observer.test.ts
+++ b/packages/pi-subagents/test/observation/subagent-events-observer.test.ts
@@ -106,6 +106,25 @@ describe("SubagentEventsObserver", () => {
 			});
 		});
 
+		it("redacts task and result text from parent events and persisted records", () => {
+			const { observer, emit, appendEntry } = makeObserver();
+			const record = createTestSubagent({
+				description: "SECRET TASK BODY",
+				result: "SECRET CHILD RESULT",
+				parentResultMode: "redacted",
+			});
+
+			observer.onSubagentCreated(record);
+			observer.onSubagentStarted(record);
+			observer.onSubagentCompacted(record, { reason: "manual", tokensBefore: 1 });
+			observer.onSubagentCompleted(record);
+
+			expect(JSON.stringify(emit.mock.calls)).not.toContain("SECRET TASK BODY");
+			expect(JSON.stringify(emit.mock.calls)).not.toContain("SECRET CHILD RESULT");
+			expect(JSON.stringify(appendEntry.mock.calls)).not.toContain("SECRET TASK BODY");
+			expect(JSON.stringify(appendEntry.mock.calls)).not.toContain("SECRET CHILD RESULT");
+		});
+
 		it("calls notifications.sendCompletion unconditionally — the manager decides whether to nudge", () => {
 			const notifications = makeNotifications();
 			const { observer } = makeObserver({ notifications });

--- a/packages/pi-subagents/test/service/service-adapter.test.ts
+++ b/packages/pi-subagents/test/service/service-adapter.test.ts
@@ -40,6 +40,18 @@ describe("toSubagentRecord", () => {
     });
   });
 
+  it("redacts task and result text from a redacted native child", () => {
+    const record = createTestSubagent({
+      description: "SECRET TASK BODY",
+      result: "SECRET CHILD RESULT",
+      parentResultMode: "redacted",
+    });
+    const result = toSubagentRecord(record);
+
+    expect(JSON.stringify(result)).not.toContain("SECRET TASK BODY");
+    expect(JSON.stringify(result)).not.toContain("SECRET CHILD RESULT");
+  });
+
   it("strips the session from the serialized record", () => {
     const record = createTestSubagent();
     record.subagentSession = toSubagentSession(createSubagentSessionStub(createMockSession()));
@@ -302,6 +314,19 @@ describe("SubagentsServiceAdapter — spawn", () => {
       "Explore",
       "long prompt here",
       expect.objectContaining({ description: "short desc" }),
+    );
+  });
+
+  it("threads redacted parent result mode only through the native service", () => {
+    const mgr = createManagerStub();
+    const svc = new SubagentsServiceAdapter(mgr, vi.fn(), makeRuntimeStub());
+    svc.spawn("Explore", "SECRET TASK BODY", { parentResultMode: "redacted" });
+
+    expect(mgr.spawn).toHaveBeenCalledWith(
+      expect.anything(),
+      "Explore",
+      "SECRET TASK BODY",
+      expect.objectContaining({ parentResultMode: "redacted" }),
     );
   });
 

--- a/packages/pi-subagents/test/tools/agent-tool.test.ts
+++ b/packages/pi-subagents/test/tools/agent-tool.test.ts
@@ -126,6 +126,29 @@ describe("AgentTool — resume path", () => {
 		});
 		expect(result.content[0].text).toContain("Resumed output.");
 	});
+
+	it("withholds a redacted native child's resumed result and error", async () => {
+		const deps = createToolDeps();
+		const existing = createTestSubagent({ parentResultMode: "redacted" });
+		existing.subagentSession = toSubagentSession(createSubagentSessionStub(createMockSession()));
+		const resumed = createTestSubagent({
+			result: "SECRET CHILD RESULT",
+			error: "SECRET CHILD ERROR",
+			parentResultMode: "redacted",
+		});
+		deps.manager.getRecord = vi.fn().mockReturnValue(existing);
+		deps.manager.resume = vi.fn().mockResolvedValue(resumed);
+
+		const result = await execute(deps, {
+			prompt: "continue",
+			description: "resume",
+			subagent_type: "general-purpose",
+			resume: "agent-1",
+		});
+
+		expect(JSON.stringify(result)).not.toContain("SECRET CHILD RESULT");
+		expect(JSON.stringify(result)).not.toContain("SECRET CHILD ERROR");
+	});
 });
 
 describe("AgentTool — model resolution error", () => {

--- a/packages/pi-subagents/test/tools/get-result-tool.test.ts
+++ b/packages/pi-subagents/test/tools/get-result-tool.test.ts
@@ -109,6 +109,28 @@ describe("GetResultTool", () => {
 		expect(result.content[0].text).toContain("Finished after wait.");
 	});
 
+	it("withholds a redacted native child's task, result, and verbose conversation", async () => {
+		const record = createTestSubagent({
+			description: "SECRET TASK BODY",
+			result: "SECRET CHILD RESULT",
+			parentResultMode: "redacted",
+		});
+		const stub = createSubagentSessionStub();
+		stub.getConversation.mockReturnValue("SECRET CHILD CONVERSATION");
+		record.subagentSession = toSubagentSession(stub);
+
+		const result = await execute(
+			makeManager(new Map([["agent-1", record]])),
+			makeNotifications(),
+			{ agent_id: "agent-1", verbose: true },
+		);
+
+		expect(result.content[0].text).not.toContain("SECRET TASK BODY");
+		expect(result.content[0].text).not.toContain("SECRET CHILD RESULT");
+		expect(result.content[0].text).not.toContain("SECRET CHILD CONVERSATION");
+		expect(stub.getConversation).not.toHaveBeenCalled();
+	});
+
 	it("includes conversation when verbose=true", async () => {
 		const record = createTestSubagent();
 		const stub = createSubagentSessionStub();

--- a/packages/pi-subagents/test/ui/agent-widget.test.ts
+++ b/packages/pi-subagents/test/ui/agent-widget.test.ts
@@ -245,6 +245,44 @@ describe("AgentWidget — projection reads activity off Subagent records", () =>
 	});
 });
 
+describe("AgentWidget — parent result redaction", () => {
+	it("withholds task and streamed result text for a redacted native child", () => {
+		const record = createTestSubagent({
+			status: "running",
+			completedAt: undefined,
+			description: "SECRET TASK BODY",
+			responseText: "SECRET CHILD RESULT",
+			parentResultMode: "redacted",
+			invocation: { runInBackground: true },
+		});
+		const { widget, renderLines } = (() => {
+			const manager = { listAgents: () => [record] } as unknown as SubagentManager;
+			const registry = new AgentTypeRegistry(() => new Map());
+			const widget = new AgentWidget(manager, registry);
+			let renderFn: ((tui: unknown, theme: unknown) => { render(): string[] }) | undefined;
+			widget.setUICtx({
+				setStatus: () => {},
+				setWidget: (_key, content) => {
+					if (typeof content === "function") renderFn = content as typeof renderFn;
+				},
+			});
+			return {
+				widget,
+				renderLines: () => renderFn!(
+					{ terminal: { columns: 200 }, requestRender: () => {} },
+					{ fg: (_: string, text: string) => text, bold: (text: string) => text },
+				).render(),
+			};
+		})();
+
+		widget.update();
+
+		const text = renderLines().join("\n");
+		expect(text).not.toContain("SECRET TASK BODY");
+		expect(text).not.toContain("SECRET CHILD RESULT");
+	});
+});
+
 describe("AgentWidget.update self-seeds finished agents", () => {
 	it("seeds a completed agent so it ages out after one turn", () => {
 		const { widget, lastContent } = makeWidget([{ id: "a1", status: "completed", completedAt: 5000 }]);

--- a/packages/pi-subagents/test/ui/session-navigation.test.ts
+++ b/packages/pi-subagents/test/ui/session-navigation.test.ts
@@ -36,6 +36,16 @@ describe("listNavigableAgents", () => {
     expect(entry.kind === "live" && entry.record).toBe(ready);
   });
 
+  it("excludes a redacted native child from transcript navigation", () => {
+    const redacted = makeNavigable({
+      description: "SECRET TASK BODY",
+      agentMessages: [{ role: "assistant", content: "SECRET CHILD RESULT" }] as unknown as SessionMessage[],
+      isParentResultRedacted: true,
+    });
+
+    expect(listNavigableAgents([redacted], [], registry)).toEqual([]);
+  });
+
   it("builds a label with name, description, tool count, status, and duration", () => {
     const record = makeNavigable({
       type: "general-purpose",

--- a/packages/pi-subagents/test/ui/session-navigator.test.ts
+++ b/packages/pi-subagents/test/ui/session-navigator.test.ts
@@ -169,6 +169,21 @@ describe("SessionNavigatorHandler", () => {
     expect(ui.custom).not.toHaveBeenCalled();
   });
 
+  it("withholds a redacted native child's session from the picker", async () => {
+    const ui = makeUI();
+    const record = makeNavigable({
+      description: "SECRET TASK BODY",
+      agentMessages: [{ role: "assistant", content: "SECRET CHILD RESULT" }] as unknown as SessionMessage[],
+      isParentResultRedacted: true,
+    });
+
+    await new SessionNavigatorHandler().handle({ ui, agents: [record], evicted: [], registry, cwd: "/test/cwd", readFile: noReadFile });
+
+    expect(ui.notify).toHaveBeenCalledWith("No subagent sessions to view.", "info");
+    expect(ui.select).not.toHaveBeenCalled();
+    expect(ui.custom).not.toHaveBeenCalled();
+  });
+
   it("does not open the overlay when the operator cancels the picker", async () => {
     const ui = makeUI(undefined);
     await new SessionNavigatorHandler().handle({ ui, agents: [makeNavigable()], evicted: [], registry, cwd: "/test/cwd", readFile: noReadFile });


### PR DESCRIPTION
## Summary

- Adds opt-in native `SubagentsService.spawn` `parentResultMode: "redacted"`.
- Default `"full"` behavior and direct LLM `subagent` behavior remain unchanged.
- Redacted native children expose safe parent projections across notifications, events, records, results, UI, navigation, lifecycle, and workspace-provider paths while raw task/result data remains child-only.

## Scope

This does not include #612 active-tool inheritance, #613 background defaults, or Sentinel/router/runtime/config changes.

## Validation

- `pnpm --filter @gotgenes/pi-subagents run check`
- `pnpm --filter @gotgenes/pi-subagents run test` — 64 files / 1,011 tests
- `pnpm --filter @gotgenes/pi-subagents run lint`
- `git diff --check`
- Independent privacy review clean
