### PR TITLE
feat(pi-permission-system): add overlay config option

### DIFF
--- a/packages/pi-permission-system/src/authority/local-user-authorizer.ts
+++ b/packages/pi-permission-system/src/authority/local-user-authorizer.ts
@@ -55,6 +55,7 @@ export class LocalUserAuthorizer implements TerminalAuthorizer {
         ui: this.deps.ui,
         doublePressToConfirm:
           this.deps.getPromptPreferences().doublePressToConfirm,
+        overlay: this.deps.getPromptPreferences().overlay,
       },
       details.forwarding
         ? "Permission Required (Subagent)"

--- a/packages/pi-permission-system/src/authority/permission-prompt-component.ts
+++ b/packages/pi-permission-system/src/authority/permission-prompt-component.ts
@@ -43,11 +43,13 @@ export interface PermissionPromptView {
   mode: ExtensionContext["mode"];
   ui: PermissionPromptUi;
   doublePressToConfirm: boolean;
+  overlay: boolean;
 }
 
-/** Live prompt-behavior preferences read at prompt time (see `doublePressToConfirm`). */
+/** Live prompt-behavior preferences read at prompt time. */
 export interface PromptPreferences {
   doublePressToConfirm: boolean;
+  overlay: boolean;
 }
 
 /**
@@ -108,7 +110,7 @@ export function presentInlinePermissionPrompt(
         },
         done,
       ),
-    { overlay: false },
+    { overlay: view.overlay },
   );
 }
 

--- a/packages/pi-permission-system/src/config-loader.ts
+++ b/packages/pi-permission-system/src/config-loader.ts
@@ -199,7 +199,7 @@ function formatConfigIssues(error: ZodError): string[] {
  */
 // Scalar knobs merged by override-replaces-base; keep in sync with
 // PermissionSystemExtensionConfig booleans (debugLog, permissionReviewLog,
-// yoloMode, doublePressToConfirm).
+// yoloMode, doublePressToConfirm, overlay).
 export function mergeUnifiedConfigs(
   base: UnifiedPermissionConfig,
   override: UnifiedPermissionConfig,
@@ -212,6 +212,7 @@ export function mergeUnifiedConfigs(
     "permissionReviewLog",
     "yoloMode",
     "doublePressToConfirm",
+    "overlay",
   ] as const) {
     const value = override[key] ?? base[key];
     if (value !== undefined) {

--- a/packages/pi-permission-system/src/config-modal.ts
+++ b/packages/pi-permission-system/src/config-modal.ts
@@ -52,6 +52,7 @@ function cloneDefaultConfig(): PermissionSystemExtensionConfig {
     permissionReviewLog: DEFAULT_EXTENSION_CONFIG.permissionReviewLog,
     yoloMode: DEFAULT_EXTENSION_CONFIG.yoloMode,
     doublePressToConfirm: DEFAULT_EXTENSION_CONFIG.doublePressToConfirm,
+    overlay: DEFAULT_EXTENSION_CONFIG.overlay,
   };
 }
 

--- a/packages/pi-permission-system/src/config-schema.ts
+++ b/packages/pi-permission-system/src/config-schema.ts
@@ -187,6 +187,13 @@ export const unifiedConfigSchema = z
         "Require a confirming second press of a decision hotkey (`y`/`s`/`n`/`r`) in the inline permission dialog before it commits — the first press arms the action and shows a `Press y again to approve.` hint.\n\nApplies to interactive **TUI** sessions only; the non-TUI (RPC/frontend) prompt keeps its single-select flow. Set to `false` to commit decisions on the first hotkey press.",
       default: true,
     }),
+    overlay: z.boolean().optional().meta({
+      description:
+        "Render the permission dialog as an overlay instead of inline.",
+      markdownDescription:
+        "Render the permission dialog as an overlay instead of replacing the full TUI content. Default: `false`.",
+      default: false,
+    }),
     toolInputPreviewMaxLength: z.number().int().min(1).optional().meta({
       description:
         "Maximum character length of the inline-JSON tool-input preview shown in permission prompts. Omit to use the default (200). Set to a large value to disable truncation.",

--- a/packages/pi-permission-system/src/extension-config.ts
+++ b/packages/pi-permission-system/src/extension-config.ts
@@ -15,6 +15,7 @@ export interface PermissionSystemExtensionConfig {
   yoloMode: boolean;
   /** Require a confirming second press of a decision hotkey in the inline TUI dialog. Defaults to true. */
   doublePressToConfirm: boolean;
+  overlay: boolean;
   /** Additional directories to auto-allow for reads as Pi infrastructure. */
   piInfrastructureReadPaths?: string[];
   /** Max length of the inline-JSON input preview shown in permission prompts. Defaults to 200. */
@@ -32,6 +33,7 @@ export const DEFAULT_EXTENSION_CONFIG: PermissionSystemExtensionConfig = {
   permissionReviewLog: true,
   yoloMode: false,
   doublePressToConfirm: true,
+  overlay: false,
 };
 
 function resolveExtensionRoot(moduleUrl = import.meta.url): string {
@@ -64,6 +66,7 @@ export function normalizePermissionSystemConfig(
     permissionReviewLog: raw.permissionReviewLog !== false,
     yoloMode: raw.yoloMode === true,
     doublePressToConfirm: raw.doublePressToConfirm !== false,
+    overlay: raw.overlay === true,
   };
   if (raw.piInfrastructureReadPaths !== undefined) {
     result.piInfrastructureReadPaths = raw.piInfrastructureReadPaths;

--- a/packages/pi-permission-system/src/index.ts
+++ b/packages/pi-permission-system/src/index.ts
@@ -107,6 +107,7 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
     events: pi.events,
     getPromptPreferences: () => ({
       doublePressToConfirm: configStore.current().doublePressToConfirm,
+      overlay: configStore.current().overlay,
     }),
     requestPermissionDecision,
     forwardingDir: paths.forwardingDir,


### PR DESCRIPTION
## Problem

The inline permission dialog (`{ overlay: false }`) replaces the full TUI content on every prompt. In tmux, this causes visible flicker on scroll.

## Fix

Add `overlay` config option. When `true`, the dialog renders on top of existing content - only the overlay portion redraws. Default `false` (existing behavior).
