### PR TITLE
fix(pi-permission-system): preserve tool expansion in prompts

### DIFF
--- a/packages/pi-permission-system/src/authority/permission-prompt-component.ts
+++ b/packages/pi-permission-system/src/authority/permission-prompt-component.ts
@@ -1,6 +1,7 @@
 import type {
   ExtensionContext,
   ExtensionUIContext,
+  KeybindingsManager,
 } from "@earendil-works/pi-coding-agent";
 import {
   type Component,
@@ -35,7 +36,7 @@ import {
 /** The subset of the session UI surface the inline dialog needs. */
 export type PermissionPromptUi = Pick<
   ExtensionUIContext,
-  "select" | "input" | "custom"
+  "select" | "input" | "custom" | "getToolsExpanded" | "setToolsExpanded"
 >;
 
 /** The resolved presentation context selected once per activation. */
@@ -97,12 +98,16 @@ export function presentInlinePermissionPrompt(
     sessionScope: options?.sessionScope,
   };
   return view.ui.custom<PermissionPromptDecision>(
-    (tui, theme, _keybindings, done) =>
+    (tui, theme, keybindings, done) =>
       new PermissionPromptComponent(
         theme,
+        keybindings,
         config,
         title,
         message,
+        () => {
+          view.ui.setToolsExpanded(!view.ui.getToolsExpanded());
+        },
         () => {
           tui.requestRender();
         },
@@ -118,9 +123,11 @@ class PermissionPromptComponent implements Component {
 
   constructor(
     private readonly theme: PromptTheme,
+    private readonly keybindings: KeybindingsManager,
     private readonly config: PromptModelConfig,
     private readonly title: string,
     private readonly message: string,
+    private readonly toggleToolsExpanded: () => void,
     private readonly requestRender: () => void,
     private readonly done: (decision: PermissionPromptDecision) => void,
   ) {
@@ -147,6 +154,10 @@ class PermissionPromptComponent implements Component {
   }
 
   handleInput(data: string): void {
+    if (this.keybindings.matches(data, "app.tools.expand")) {
+      this.toggleToolsExpanded();
+      return;
+    }
     if (this.state.step === "reason") {
       this.handleReasonInput(data);
       return;

--- a/packages/pi-permission-system/test/authority/local-user-authorizer.test.ts
+++ b/packages/pi-permission-system/test/authority/local-user-authorizer.test.ts
@@ -19,6 +19,16 @@ function makeDetails(
   };
 }
 
+function makePromptUi() {
+  return {
+    select: vi.fn(),
+    input: vi.fn(),
+    custom: vi.fn(),
+    getToolsExpanded: vi.fn(() => false),
+    setToolsExpanded: vi.fn(),
+  };
+}
+
 function makeDeps(
   overrides: {
     requestPermissionDecision?: typeof requestPermissionDecision;
@@ -28,7 +38,7 @@ function makeDeps(
     emit: vi.fn(),
     on: vi.fn().mockReturnValue(() => undefined),
   };
-  const ui = { select: vi.fn(), input: vi.fn(), custom: vi.fn() };
+  const ui = makePromptUi();
   const decisionFn =
     overrides.requestPermissionDecision ??
     vi
@@ -135,7 +145,7 @@ describe("LocalUserAuthorizer", () => {
       }),
       on: vi.fn().mockReturnValue(() => undefined),
     };
-    const ui = { select: vi.fn(), input: vi.fn(), custom: vi.fn() };
+    const ui = makePromptUi();
     const decisionFn = vi.fn<typeof requestPermissionDecision>(() => {
       calls.push("dialog");
       return Promise.resolve({ approved: true, state: "approved" });

--- a/packages/pi-permission-system/test/authority/permission-prompt-component.test.ts
+++ b/packages/pi-permission-system/test/authority/permission-prompt-component.test.ts
@@ -31,15 +31,18 @@ interface CapturedComponent {
 type PromptFactory = (
   tui: { requestRender: () => void },
   theme: ReturnType<typeof plainTheme>,
-  keybindings: undefined,
+  keybindings: { matches(data: string, action: string): boolean },
   done: (decision: PermissionPromptDecision) => void,
 ) => CapturedComponent;
+
+const CONFIGURED_TOOLS_EXPAND_KEY = "\u0010";
 
 function makeFakeView(doublePressToConfirm: boolean) {
   const captured: {
     component?: CapturedComponent;
     options?: unknown;
   } = {};
+  let toolsExpanded = false;
   const custom = (
     factory: PromptFactory,
     options: unknown,
@@ -49,17 +52,31 @@ function makeFakeView(doublePressToConfirm: boolean) {
       captured.component = factory(
         { requestRender: vi.fn() },
         plainTheme(),
-        undefined,
+        {
+          matches: (data, action) =>
+            action === "app.tools.expand" &&
+            data === CONFIGURED_TOOLS_EXPAND_KEY,
+        },
         resolve,
       );
     });
   };
+  const getToolsExpanded = vi.fn(() => toolsExpanded);
+  const setToolsExpanded = vi.fn((expanded: boolean) => {
+    toolsExpanded = expanded;
+  });
   const view = {
     mode: "tui",
     doublePressToConfirm,
-    ui: { select: vi.fn(), input: vi.fn(), custom },
+    ui: {
+      select: vi.fn(),
+      input: vi.fn(),
+      custom,
+      getToolsExpanded,
+      setToolsExpanded,
+    },
   } as unknown as PermissionPromptView;
-  return { view, captured };
+  return { view, captured, getToolsExpanded, setToolsExpanded };
 }
 
 const ARROW_DOWN = "\u001b[B";
@@ -117,6 +134,39 @@ describe("presentInlinePermissionPrompt", () => {
     for (const line of lines) {
       expect(visibleWidth(line)).toBeLessThanOrEqual(width);
     }
+  });
+
+  describe("tool expansion", () => {
+    it("toggles tools with the configured app.tools.expand key without resolving", async () => {
+      const { view, captured, getToolsExpanded, setToolsExpanded } =
+        makeFakeView(true);
+      const promise = presentInlinePermissionPrompt(view, "Title", "Message");
+      let settled = false;
+      void promise.then(() => {
+        settled = true;
+      });
+
+      captured.component?.handleInput(CONFIGURED_TOOLS_EXPAND_KEY);
+      await Promise.resolve();
+
+      expect(getToolsExpanded).toHaveBeenCalledTimes(1);
+      expect(setToolsExpanded).toHaveBeenNthCalledWith(1, true);
+      expect(settled).toBe(false);
+
+      captured.component?.handleInput(CONFIGURED_TOOLS_EXPAND_KEY);
+      await Promise.resolve();
+
+      expect(getToolsExpanded).toHaveBeenCalledTimes(2);
+      expect(setToolsExpanded).toHaveBeenNthCalledWith(2, false);
+      expect(settled).toBe(false);
+
+      captured.component?.handleInput("y");
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      captured.component?.handleInput("y");
+      expect(await promise).toEqual({ approved: true, state: "approved" });
+    });
   });
 
   describe("double-press to confirm (enabled)", () => {


### PR DESCRIPTION
## Summary

- preserve Pi's configured `app.tools.expand` action while the inline permission prompt has focus
- toggle native tool expansion without changing or resolving the pending permission decision
- add regression coverage for expansion, collapse, and continued prompt interaction

## Verification

- `pnpm --filter @gotgenes/pi-permission-system test`
- `pnpm --filter @gotgenes/pi-permission-system run check`
- `pnpm --filter @gotgenes/pi-permission-system lint`

Refs #642
