### PR TITLE
fix(pi-permission-system): cap permission prompt width to prevent TUI crash

### DIFF
--- a/packages/pi-permission-system/src/permission-prompts.ts
+++ b/packages/pi-permission-system/src/permission-prompts.ts
@@ -4,6 +4,10 @@ import type { SkillPromptEntry } from "./skill-prompt-sanitizer";
 import type { ToolPreviewFormatter } from "./tool-preview-formatter";
 import type { PermissionCheckResult } from "./types";
 import { getNonEmptyString, toRecord } from "./value-guards";
+import { truncateInlineText } from "./tool-input-preview";
+
+/** Max width for assembled prompt messages to avoid TUI rendering crashes on narrow terminals. */
+const MAX_PROMPT_WIDTH = 200;
 
 // NOTE: formatDenyReason, formatUserDeniedReason, and
 // formatPermissionHardStopHint have been moved to denial-messages.ts.
@@ -50,7 +54,10 @@ export function formatAskPrompt(
       fullCommand && fullCommand !== subCommand
         ? ` (full command: '${fullCommand}')`
         : "";
-    return `${subject} requested bash command '${subCommand}'${qualifierInfo}${fullCommandInfo}. Allow this command?`;
+    return truncateInlineText(
+      `${subject} requested bash command '${subCommand}'${qualifierInfo}${fullCommandInfo}. Allow this command?`,
+      MAX_PROMPT_WIDTH,
+    );
   }
 
   if (isMcpCheck(result) && result.target) {
@@ -61,7 +68,10 @@ export function formatAskPrompt(
       ? formatter.formatToolInputForPrompt("mcp", input)
       : "";
     const previewSuffix = mcpPreview ? ` ${mcpPreview}` : "";
-    return `${subject} requested MCP target '${result.target}'${patternInfo}${previewSuffix}. Allow this call?`;
+    return truncateInlineText(
+      `${subject} requested MCP target '${result.target}'${patternInfo}${previewSuffix}. Allow this call?`,
+      MAX_PROMPT_WIDTH,
+    );
   }
 
   const patternInfo = result.matchedPattern
@@ -71,7 +81,10 @@ export function formatAskPrompt(
     ? formatter.formatToolInputForPrompt(result.toolName, input)
     : "";
   const inputSuffix = inputPreview ? ` ${inputPreview}` : "";
-  return `${subject} requested tool '${result.toolName}'${patternInfo}${inputSuffix}. Allow this call?`;
+  return truncateInlineText(
+    `${subject} requested tool '${result.toolName}'${patternInfo}${inputSuffix}. Allow this call?`,
+    MAX_PROMPT_WIDTH,
+  );
 }
 
 export function formatSkillAskPrompt(


### PR DESCRIPTION
## Problem

Permission prompts can produce lines wider than the terminal (e.g., 279 visible width vs 213 terminal columns), triggering a TUI crash in `pi-tui` (`@earendil-works/pi-tui`). This happens because `formatAskPrompt()` assembles a message like:

```
Current agent requested tool 'ctx_batch_execute' with input {long JSON...}. Allow this call?
```

The `toolInputPreviewMaxLength` (default 200) only limits the JSON portion, but the prefix (~58 chars) and suffix (~17 chars) push the total well past terminal width.

## Fix

Import `truncateInlineText` from `./tool-input-preview` and wrap each branch of `formatAskPrompt()` with a `MAX_PROMPT_WIDTH` of **200 characters** — applied to the **final assembled message**, not just the JSON portion.

Also added the truncation to the bash command and MCP branches for defense-in-depth.

## Testing

All **2593 existing tests pass** (including the 29 `permission-prompts.test.ts` cases).

## Related

This pairs with a companion fix in `@earendil-works/pi-tui` that replaces the crash-with-throw with safe truncation:
- earendil-works/pi#7116