### PR TITLE
fix(pi-subagents): hold completion nudges while the parent agent streams

### DIFF
--- a/packages/pi-subagents/src/index.ts
+++ b/packages/pi-subagents/src/index.ts
@@ -63,6 +63,13 @@ export default function (pi: ExtensionAPI) {
     (msg, opts) => pi.sendMessage(msg, opts),
   );
 
+  // Track the parent agent loop so completion nudges are held while it streams
+  // and flushed (with a fresh consumed re-check) when it ends — a nudge handed
+  // to Pi's followUp queue mid-turn could not be recalled if the parent pulled
+  // the result later in the same turn, duplicating the delivery.
+  pi.on("agent_start", () => notifications.onParentAgentStart());
+  pi.on("agent_end", () => notifications.onParentAgentEnd());
+
   // Settings: owns all three in-memory values and handles load/save/emit.
   // onMaxConcurrentChanged is wired to the limiter directly (closure captures by reference).
   const settings = new SettingsManager({

--- a/packages/pi-subagents/src/observation/notification.ts
+++ b/packages/pi-subagents/src/observation/notification.ts
@@ -132,6 +132,14 @@ const NUDGE_HOLD_MS = 200;
 
 export class NotificationManager implements NotificationSystem {
   private pendingNudges = new Map<string, ReturnType<typeof setTimeout>>();
+  // pi.sendMessage is fire-and-forget: once a followUp is handed to Pi's queue
+  // it cannot be recalled, yet it is only delivered when the parent's agent
+  // loop ends. A parent that pulls the result (get_subagent_result) between
+  // handoff and delivery would then receive the same result twice. So while
+  // the parent is streaming, fired nudges are held here — where
+  // record.consumed can still be consulted — and flushed on agent end.
+  private heldNudges = new Map<string, Subagent>();
+  private parentStreaming = false;
 
   constructor(
     private sendMessage: (
@@ -152,6 +160,30 @@ export class NotificationManager implements NotificationSystem {
   dispose(): void {
     for (const timer of this.pendingNudges.values()) clearTimeout(timer);
     this.pendingNudges.clear();
+    this.heldNudges.clear();
+  }
+
+  /** Mark the parent agent loop as streaming; fired nudges are held until agent end. */
+  onParentAgentStart(): void {
+    this.parentStreaming = true;
+  }
+
+  /**
+   * Flush nudges held during the parent's agent loop. Each held record
+   * re-checks consumption via emitIndividualNudge, so results the parent
+   * already pulled mid-turn are suppressed instead of delivered twice.
+   */
+  onParentAgentEnd(): void {
+    this.parentStreaming = false;
+    const held = [...this.heldNudges.values()];
+    this.heldNudges.clear();
+    for (const record of held) {
+      try {
+        this.emitIndividualNudge(record);
+      } catch (err) {
+        debugLog("notification render", err);
+      }
+    }
   }
 
   private cancelNudge(key: string): void {
@@ -179,6 +211,10 @@ export class NotificationManager implements NotificationSystem {
 
   private emitIndividualNudge(record: Subagent): void {
     if (record.consumed) return;
+    if (this.parentStreaming) {
+      this.heldNudges.set(record.id, record);
+      return;
+    }
 
     const notification = formatTaskNotification(record, 500);
     const outputFile = record.outputFile;

--- a/packages/pi-subagents/test/observation/notification.test.ts
+++ b/packages/pi-subagents/test/observation/notification.test.ts
@@ -231,4 +231,67 @@ describe("NotificationManager", () => {
     vi.advanceTimersByTime(300);
     expect(args.sendMessage).not.toHaveBeenCalled();
   });
+
+  describe("parent-turn awareness", () => {
+    it("holds a nudge that fires while the parent agent is streaming and delivers it on agent end", () => {
+      const args = makeArgs();
+      const system = makeManager(args);
+      const record = createTestSubagent({ id: "held-1" });
+      system.onParentAgentStart();
+      system.sendCompletion(record);
+      vi.advanceTimersByTime(300);
+      // Not handed to pi's followUp queue mid-turn — held where consumed is still consultable.
+      expect(args.sendMessage).not.toHaveBeenCalled();
+      system.onParentAgentEnd();
+      expect(args.sendMessage).toHaveBeenCalledOnce();
+    });
+
+    it("suppresses a held nudge when the record is consumed before agent end (fire→pull→turn-end race)", () => {
+      const args = makeArgs();
+      const system = makeManager(args);
+      const record = createTestSubagent({ id: "race-2" });
+      system.onParentAgentStart();
+      system.sendCompletion(record);
+      vi.advanceTimersByTime(300); // nudge fires mid-turn
+      record.markConsumed(); // parent pulls via get_subagent_result later in the same turn
+      system.onParentAgentEnd();
+      expect(args.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it("delivers at fire time when the parent went idle before the hold elapsed", () => {
+      const args = makeArgs();
+      const system = makeManager(args);
+      const record = createTestSubagent({ id: "idle-1" });
+      system.onParentAgentStart();
+      system.onParentAgentEnd();
+      system.sendCompletion(record);
+      vi.advanceTimersByTime(300);
+      expect(args.sendMessage).toHaveBeenCalledOnce();
+    });
+
+    it("does not duplicate a held nudge when the agent re-completes before agent end", () => {
+      const args = makeArgs();
+      const system = makeManager(args);
+      const record = createTestSubagent({ id: "recomplete-1" });
+      system.onParentAgentStart();
+      system.sendCompletion(record);
+      vi.advanceTimersByTime(300);
+      system.sendCompletion(record); // e.g. a resumed run reaching terminal state again
+      vi.advanceTimersByTime(300);
+      system.onParentAgentEnd();
+      expect(args.sendMessage).toHaveBeenCalledOnce();
+    });
+
+    it("dispose clears held nudges", () => {
+      const args = makeArgs();
+      const system = makeManager(args);
+      const record = createTestSubagent({ id: "disposed-1" });
+      system.onParentAgentStart();
+      system.sendCompletion(record);
+      vi.advanceTimersByTime(300);
+      system.dispose();
+      system.onParentAgentEnd();
+      expect(args.sendMessage).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Problem

A background agent's completion nudge can be delivered **twice** — once as the pulled result mid-turn, and again verbatim at turn end.

`pi.sendMessage()` is fire-and-forget: once the nudge is handed to Pi's `followUp` queue it cannot be recalled, yet it is only *delivered* when the parent's agent loop ends. The existing guards check `record.consumed` at schedule time and at fire time — but "fire" means *handoff to Pi's queue*, not *delivery to the LLM*. Between handoff and delivery lies the entire remainder of the parent's current turn.

Reproduction timeline (100% deterministic):

| Time | Event |
|---|---|
| T | Background agent completes while the parent turn is streaming |
| T+200ms | Nudge fires → handed to Pi's followUp queue (`consumed` correctly false at that instant) |
| T+n (same turn) | Parent calls `get_subagent_result(id)` → full result returned, `markConsumed()` — too late, the message is already queued |
| Turn end | Pi delivers the queued `<task-notification>` with the same result preview; `triggerTurn` forces a redundant LLM turn re-reporting the same result |

The 200ms hold (CHANGELOG: *"pi.sendMessage() is fire-and-forget, so completion notifications … could not be retracted"*) only covers pulls within 200ms of completion — it shrinks the completion→pull window, but the dangerous window is fire→turn-end.

## Fix

`NotificationManager` now tracks the parent agent loop via `agent_start`/`agent_end`. While the parent streams, fired nudges are **held inside the extension** — where `record.consumed` can still be consulted — and flushed on agent end with a fresh consumed re-check.

Delivery timing is unchanged: `followUp` semantics already deliver at agent-loop end; the queue simply lives where it can still be cancelled. When the parent is idle, nudges send immediately at fire time exactly as before.

## Tests

- `holds a nudge that fires while the parent agent is streaming and delivers it on agent end`
- `suppresses a held nudge when the record is consumed before agent end (fire→pull→turn-end race)` ← the bug repro; fails on main
- `delivers at fire time when the parent went idle before the hold elapsed`
- `does not duplicate a held nudge when the agent re-completes before agent end`
- `dispose clears held nudges`

All 1088 tests pass; `tsc --noEmit` and `biome check` clean.