### PR TITLE
fix(pi-subagents): honor wait:true for queued agents and in-flight resumes

### DIFF
--- a/packages/pi-subagents/src/lifecycle/subagent.ts
+++ b/packages/pi-subagents/src/lifecycle/subagent.ts
@@ -343,6 +343,14 @@ export class Subagent {
 			throw new Error("Subagent not configured for resume — missing session");
 		}
 
+		// Refresh the awaitable handle: waiters (e.g. get_subagent_result wait:true)
+		// must track the live resume, not the settled promise of a prior run.
+		const run = this.runResume(subagentSession, prompt, signal);
+		this._promise = run;
+		return run;
+	}
+
+	private async runResume(subagentSession: SubagentSession, prompt: string, signal?: AbortSignal): Promise<void> {
 		this.resetForResume(Date.now());
 		this.listeners.attachObserver(subscribeSubagentObserver(subagentSession, this.state, {
 			onCompact: (info) => this.execution.observer?.onCompacted?.(this, info),

--- a/packages/pi-subagents/src/tools/get-result-tool.ts
+++ b/packages/pi-subagents/src/tools/get-result-tool.ts
@@ -32,8 +32,10 @@ export class GetResultTool {
 			return textResult(`Agent not found: "${params.agent_id}". Records are cleared at session start/switch, so it may be from a previous session.`);
 		}
 
-		// Wait for completion if requested.
-		if (params.wait && record.status === "running" && record.promise) {
+		// Wait for completion if requested. isActive() covers queued agents too:
+		// their promise is captured eagerly at spawn (scheduleVia), so waiting on a
+		// still-queued agent resolves when its slot frees and the run finishes.
+		if (params.wait && record.isActive() && record.promise) {
 			await record.promise;
 		}
 

--- a/packages/pi-subagents/test/lifecycle/subagent.test.ts
+++ b/packages/pi-subagents/test/lifecycle/subagent.test.ts
@@ -794,6 +794,31 @@ describe("Subagent.resume() — happy path", () => {
 		await agent.resume("continue");
 		expect(agent.error).toBeUndefined();
 	});
+
+	it("exposes the in-flight resume via the promise getter (wait support)", async () => {
+		const { agent, stub } = createResumableAgent();
+		let release!: (result: string) => void;
+		stub.resumeTurnLoop.mockImplementation(
+			() =>
+				new Promise<string>((resolve) => {
+					release = resolve;
+				}),
+		);
+		const resumePromise = agent.resume("continue");
+		// The awaitable promise must track the live resume, not a finished prior run.
+		expect(agent.promise).toBeDefined();
+		let settled = false;
+		void agent.promise?.then(() => {
+			settled = true;
+		});
+		await new Promise((r) => setTimeout(r, 0));
+		expect(settled).toBe(false);
+		release("resumed late");
+		await resumePromise;
+		await agent.promise;
+		expect(agent.status).toBe("completed");
+		expect(agent.result).toBe("resumed late");
+	});
 });
 
 describe("Subagent.resume() — observer lifecycle", () => {

--- a/packages/pi-subagents/test/tools/get-result-tool.test.ts
+++ b/packages/pi-subagents/test/tools/get-result-tool.test.ts
@@ -101,6 +101,32 @@ describe("GetResultTool", () => {
 		expect(record.consumed).toBe(true);
 	});
 
+	it("waits for a queued agent when wait=true (promise is captured at spawn)", async () => {
+		const sessionStub = createSubagentSessionStub();
+		sessionStub.runTurnLoop.mockResolvedValue({ responseText: "Finished after queue.", aborted: false, steered: false });
+		const record = createTestSubagent({
+			status: "queued",
+			completedAt: undefined,
+			execution: makeStubExecution({
+				createSubagentSession: async () => toSubagentSession(sessionStub),
+			}),
+		});
+		// Simulate limiter admission: the thunk starts only after the wait began.
+		let admit!: () => void;
+		record.scheduleVia(
+			(thunk) =>
+				new Promise<void>((resolve) => {
+					admit = () => void thunk().then(resolve);
+				}),
+		);
+		const records = new Map([["agent-1", record]]);
+		const resultPromise = execute(makeManager(records), { agent_id: "agent-1", wait: true });
+		admit(); // a slot frees while the parent is waiting
+		const result = await resultPromise;
+		expect(result.content[0].text).toContain("Finished after queue.");
+		expect(record.consumed).toBe(true);
+	});
+
 	it("includes conversation when verbose=true", async () => {
 		const record = createTestSubagent();
 		const stub = createSubagentSessionStub();


### PR DESCRIPTION
## Problem

`get_subagent_result`'s wait path only awaits `status === "running"`, silently returning a stale report in two cases the codebase already promises to support:

**1. Queued agents.** `scheduleVia` captures the limiter promise eagerly — its own doc comment says *"a still-queued agent is awaitable via the `promise` getter from spawn"* — but the tool never uses it. `wait: true` on a queued agent returns immediately with a useless "queued" report instead of waiting for the slot to free and the run to finish.

**2. In-flight resumes.** `Subagent.resume()` never refreshed `_promise`, so the `promise` getter kept the settled handle of the *original* run. `wait: true` during a background resume awaited an already-resolved promise and reported "running".

## Fix

- The wait guard now uses `record.isActive()` (running **or** queued) — one-line change plus a comment documenting why queued is safe.
- `resume()` stores the live resume promise in `_promise` before returning (extracted `runResume` keeps the always-resolves contract), so waiters track the current run. Synchronous-throw behavior for a missing session is unchanged.

## Tests

- `waits for a queued agent when wait=true (promise is captured at spawn)` — simulates limiter admission after the wait begins; fails on main
- `exposes the in-flight resume via the promise getter (wait support)` — asserts the promise doesn't settle before the resume does; fails on main

All 1085 tests pass; `tsc --noEmit` and `biome check` clean.