### PR TITLE
fix(pi-subagents): make escapeXml attribute-safe by escaping quotes

### DIFF
--- a/packages/pi-subagents/src/observation/notification.ts
+++ b/packages/pi-subagents/src/observation/notification.ts
@@ -20,9 +20,18 @@ export interface NotificationDetails {
 
 // ---- Pure helpers (exported for unit testing) ----
 
-/** Escape XML special characters to prevent injection in structured notifications. */
+/**
+ * Escape XML special characters to prevent injection in structured
+ * notifications. Quotes are escaped too, so values stay safe if they are ever
+ * placed in attribute position, not only element content.
+ */
 export function escapeXml(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
 }
 
 /** Human-readable status label for agent completion. */

--- a/packages/pi-subagents/test/observation/notification.test.ts
+++ b/packages/pi-subagents/test/observation/notification.test.ts
@@ -19,6 +19,10 @@ describe("escapeXml", () => {
   it("returns unchanged string with no special chars", () => {
     expect(escapeXml("hello world")).toBe("hello world");
   });
+
+  it("escapes double and single quotes (attribute-safe)", () => {
+    expect(escapeXml('say "hi" it\'s fine')).toBe("say &quot;hi&quot; it&apos;s fine");
+  });
 });
 
 describe("getStatusLabel", () => {


### PR DESCRIPTION
## Problem

`escapeXml` (`src/observation/notification.ts`) only handles `&`, `<`, `>`. That is safe while every escaped value lands in element content — which is true today — but it is a latent injection hazard the moment any caller places a value in attribute position: a `description` or `error` containing `"` would break out of the attribute.

## Fix

Escape `"` → `&quot;` and `'` → `&apos;` as well, and document the attribute-safety guarantee on the helper. Element-content output is unaffected in meaning; the notification XML remains parseable by the parent model.

## Tests

- `escapes double and single quotes (attribute-safe)` — new
- All existing tests pass (1084/1084); `tsc --noEmit` and `biome check` clean.

Independent of #661/#662 (branched from main).