### PR TITLE
fix(pi-subagents): emit completion lifecycle for stopped-while-queued agents

### DIFF
--- a/packages/pi-subagents/src/lifecycle/subagent-manager.ts
+++ b/packages/pi-subagents/src/lifecycle/subagent-manager.ts
@@ -256,10 +256,26 @@ export class SubagentManager {
     // becomes a no-op (status guard) when its slot finally opens.
     if (record.status === "queued") {
       record.markStopped();
+      this.notifyQueuedStopped(record);
       return true;
     }
 
     return record.abort();
+  }
+
+  /**
+   * Deliver the terminal lifecycle notification for a stopped-while-queued
+   * agent. A queued agent never runs, so onRunFinished cannot fire for it —
+   * without this, queued stops emitted no completion event or notification,
+   * leaving event subscribers waiting forever (asymmetric with running agents,
+   * whose aborts flow through the run path).
+   */
+  private notifyQueuedStopped(record: Subagent): void {
+    try {
+      this.observer?.onSubagentCompleted(record);
+    } catch (err) {
+      debugLog("onSubagentCompleted observer", err);
+    }
   }
 
   /** Dispose a record's session and remove it from the map. */
@@ -315,6 +331,7 @@ export class SubagentManager {
     for (const record of this.agents.values()) {
       if (record.status === "queued") {
         record.markStopped();
+        this.notifyQueuedStopped(record);
         count++;
       } else if (record.abort()) {
         count++;

--- a/packages/pi-subagents/test/lifecycle/subagent-manager.test.ts
+++ b/packages/pi-subagents/test/lifecycle/subagent-manager.test.ts
@@ -815,6 +815,68 @@ describe("SubagentManager — lifecycle observer forwarding", () => {
   });
 });
 
+describe("SubagentManager — queued-stop lifecycle contract", () => {
+  it("abort() on a queued agent notifies onSubagentCompleted with status stopped", () => {
+    const onSubagentCompleted = vi.fn();
+    const { manager: mgr } = createManager({
+      createSubagentSession: createBlockingFactory(),
+      getMaxConcurrent: () => 1,
+      observer: { onSubagentCompleted },
+    });
+    const running = spawnBg(mgr, "a");
+    const queued = spawnBg(mgr, "b");
+
+    expect(mgr.abort(queued)).toBe(true);
+
+    expect(onSubagentCompleted).toHaveBeenCalledTimes(1);
+    const record = onSubagentCompleted.mock.calls[0][0] as Subagent;
+    expect(record.id).toBe(queued);
+    expect(record.status).toBe("stopped");
+    mgr.abort(running);
+  });
+
+  it("a stopped-while-queued agent notifies exactly once even after its slot frees", async () => {
+    const onSubagentCompleted = vi.fn();
+    let limit = 0; // everything queues until raised
+    const { manager: mgr, limiter } = createManager({
+      getMaxConcurrent: () => limit,
+      observer: { onSubagentCompleted },
+    });
+    const queued = spawnBg(mgr, "a");
+    const queuedPromise = mgr.getRecord(queued)!.promise;
+
+    mgr.abort(queued); // stopped while queued → terminal notification
+    limit = 4;
+    limiter.recheck(); // slot opens; the dropped thunk must stay a no-op
+    await queuedPromise;
+
+    const queuedCalls = onSubagentCompleted.mock.calls.filter(
+      (c) => (c[0] as Subagent).id === queued,
+    );
+    expect(queuedCalls).toHaveLength(1);
+    expect((queuedCalls[0][0] as Subagent).status).toBe("stopped");
+  });
+
+  it("abortAll() notifies onSubagentCompleted for queued agents", () => {
+    const onSubagentCompleted = vi.fn();
+    const { manager: mgr } = createManager({
+      createSubagentSession: createBlockingFactory(),
+      getMaxConcurrent: () => 1,
+      observer: { onSubagentCompleted },
+    });
+    spawnBg(mgr, "a");
+    const queued = spawnBg(mgr, "b");
+
+    mgr.abortAll();
+
+    const queuedCalls = onSubagentCompleted.mock.calls.filter(
+      (c) => (c[0] as Subagent).id === queued,
+    );
+    expect(queuedCalls).toHaveLength(1);
+    expect((queuedCalls[0][0] as Subagent).status).toBe("stopped");
+  });
+});
+
 describe("SubagentManager — toolCallId notification wiring", () => {
   let manager: SubagentManager;
 


### PR DESCRIPTION
## Problem

Aborting a **queued** agent — `abort(id)` or `abortAll()` — only marks it stopped (`subagent-manager.ts`, queued branch). Unlike running agents, whose aborts flow through the run path (`completeRun`/`failRun` → `onRunFinished` → `onSubagentCompleted`), a queued stop emits **no** `subagents:completed`/`failed` event, no `subagents:record` session entry, and no completion notification.

Consequences:
- Cross-extension subscribers of the lifecycle events wait forever for an agent that has already terminated.
- The persisted history (`subagents:record`) silently omits queued-stopped agents.
- The event contract is asymmetric: whether a user's abort produces a terminal event depends on whether the limiter had admitted the agent yet — a scheduling accident, not a semantic difference.

## Fix

`SubagentManager` now delivers `onSubagentCompleted` for the queued-stop branch in both `abort()` and `abortAll()` (extracted `notifyQueuedStopped`, same try/debugLog guard as the run-path dispatch).

No double-fire: the limiter's dropped/no-op thunk cannot re-notify — `guardedRun()` resolves without running for non-active records, so the run path never fires for a record stopped while queued. Covered by a dedicated test that frees the slot after the stop and asserts exactly one notification.

Shutdown stays quiet: `handleSessionShutdown` aborts before disposing notifications, so nudges scheduled by shutdown-time stops are cancelled by the existing cleanup order.

## Tests

- `abort() on a queued agent notifies onSubagentCompleted with status stopped`
- `a stopped-while-queued agent notifies exactly once even after its slot frees`
- `abortAll() notifies onSubagentCompleted for queued agents`

All red on main, green with the fix (1086/1086 total); `tsc --noEmit` and `biome check` clean. Independent of #661/#662/#663 (branched from main).