### PR TITLE
fix(pi-subagents): align content width with overlay 90% width in session navigator

### DIFF
--- a/packages/pi-subagents/src/ui/session-navigator.ts
+++ b/packages/pi-subagents/src/ui/session-navigator.ts
@@ -171,7 +171,8 @@ export class TranscriptOverlay implements Component {
       return;
     }
 
-    const totalLines = this.buildContentLines(this.innerWidth()).length;
+    const hInnerW = this.contentWidth();
+    const totalLines = this.buildContentLines(hInnerW).length;
     const viewportHeight = this.viewportHeight();
     const maxScroll = Math.max(0, totalLines - viewportHeight);
 
@@ -199,7 +200,7 @@ export class TranscriptOverlay implements Component {
   render(width: number): string[] {
     if (width < 6) return [];
     const th = this.theme;
-    const innerW = width - 4;
+    const innerW = this.contentWidth();
     const lines: string[] = [];
 
     const pad = (s: string, len: number): string => s + " ".repeat(Math.max(0, len - visibleWidth(s)));
@@ -250,8 +251,10 @@ export class TranscriptOverlay implements Component {
 
   // ---- Private ----
 
-  private innerWidth(): number {
-    return Math.max(0, this.tui.terminal.columns - 4);
+  // Content text width
+  private contentWidth(): number {
+    const overlayWidth = Math.floor((this.tui.terminal.columns * 90) / 100);
+    return Math.max(0, overlayWidth - 4);
   }
 
   private viewportHeight(): number {


### PR DESCRIPTION
# Fix: `/subagents:sessions` up/down arrow keys not scrolling from bottom

## Summary

The `/subagents:sessions` overlay's ↑/↓ arrow keys do not scroll the transcript when pressed from the bottom of the viewport. PageUp/PageDown work correctly.

The root cause is a width mismatch: `handleInput` uses the full terminal width (`termCols - 4`) to compute the content line count, while `render` uses the overlay's actual 90% width (`90% × termCols - 4`). The wider width in `handleInput` produces fewer wrapped lines → a smaller `maxScroll` → the `autoScroll` flag incorrectly stays `true` after pressing ↑, and `render` resets the view back to the bottom.

## Root Cause

`TranscriptOverlay.handleInput` and `TranscriptOverlay.render` call `buildContentLines()` with different widths:

```typescript
// handleInput — USES FULL TERMINAL WIDTH
private innerWidth(): number {
    return Math.max(0, this.tui.terminal.columns - 4);  // 196 - 4 = 192
}

// render — uses overlay width passed by compositeOverlays (90% of terminal)
render(width: number): string[] {
    const innerW = width - 4;  // 176 - 4 = 172
    const contentLines = this.buildContentLines(innerW);
```

On a 196-column terminal:

| Context | Width | Lines | maxScroll |
|---------|-------|-------|-----------|
| `handleInput` | 192 | 90 | 90 − 36 = **54** |
| `render` | 172 | 94 | 94 − 36 = **58** |

The wider width wraps text less, producing 4 fewer lines and a `maxScroll` 4 smaller than reality.

### Bug mechanism

When the user is at the bottom and presses ↑:

1. `handleInput` computes `maxScroll = 54` (wrong, based on width 192), decrements `scrollOffset` 58→57, and evaluates:

   ```typescript
   this.autoScroll = this.scrollOffset >= maxScroll;
   // 57 >= 54 → true  ← SHOULD BE FALSE!
   ```

2. `render` computes the real `maxScroll = 58` (based on width 172), sees `autoScroll = true`, and **resets `scrollOffset` back to 58** — scrolling up is cancelled.

### Real debug log evidence

```
handleInput: key=↑  innerW=192  totalLines=90   maxScroll=54  scroll: 58→57  auto: true→true
render:              innerW=172  contentLines=94  maxScroll=58  auto: true→true  scroll: 57→58  visibleStart=58
                                                                                  ↑ RESET TO BOTTOM
```

Each ↑ press: `handleInput` scrolls 58→57, `render` immediately resets 57→58. The view never moves.

PageUp is unaffected because it unconditionally sets `autoScroll = false`, bypassing the faulty comparison.

## Fix

Replace `innerWidth()` (full terminal width) with `contentWidth()` (90% overlay width, matching what `render` receives):

```diff
-  handleInput: this.innerWidth()           → termCols - 4        (= 192)
+  handleInput: this.contentWidth()         → 90% × termCols - 4  (= 172)

-  render:      width - 4                   → 90% × termCols - 4  (= 172)
+  render:      this.contentWidth()         → 90% × termCols - 4  (= 172)

-  private innerWidth(): number {
-    return Math.max(0, this.tui.terminal.columns - 4);
-  }
+  private contentWidth(): number {
+    const overlayWidth = Math.floor((this.tui.terminal.columns * 90) / 100);
+    return Math.max(0, overlayWidth - 4);
+  }
```

Both call sites now compute identical line counts and `maxScroll`. After the fix, pressing ↑ from the bottom correctly sets `autoScroll = false`, and the view scrolls up.

## Tests

1. Open `/subagents:sessions` and select any subagent with a transcript containing long lines (markdown paragraphs, code blocks, or tool output that wraps).
2. Press ↑ from the bottom of the viewport.
   - **Before**: view stays at bottom, no scrolling occurs.
   - **After**: view scrolls up by one line per keypress.

3. Press ↓, PageUp, PageDown, Home, End — all continue to work correctly.

4. Repeat with different terminal widths to confirm consistent behavior.
