### PR TITLE
feat(pi-permission-system): add launcher yolo override

### DIFF
--- a/packages/pi-permission-system/README.md
+++ b/packages/pi-permission-system/README.md
@@ -118,6 +118,11 @@ The optional `authorizerChain` field names registered case-by-case decision link
 A downstream extension registers a link via `getPermissionsService().registerAuthorizer(name, authorize)`; it decides nothing until you name it here (opt-in), config order fixes the chain order, and the chain owner caps any link's `allow` on `external_directory`/`path` to keep it within your policy — see [docs/configuration.md](docs/configuration.md#authorizer-chain--case-by-case-decision-links).
 [`@gotgenes/pi-permission-model-judge`](https://github.com/gotgenes/pi-packages/tree/main/packages/pi-permission-model-judge) is a first-party reference implementation of such a link — a deny-first reviewer that auto-denies mistyped out-of-directory paths.
 
+Trusted launchers can enable the existing deny-preserving yolo composition for one Pi process with `PI_PERMISSION_SYSTEM_YOLO=1 pi`.
+Only the exact value `1` enables the override, configuration reloads retain it, and it never changes global or project config files.
+The override converts `ask` results to `allow` while explicit `deny` rules remain enforced.
+See [the launcher-scoped yolo reference](docs/configuration.md#launcher-scoped-yolo-override) for the complete contract.
+
 For the full reference — all surfaces, runtime knobs, per-agent overrides, merge semantics, and common recipes — see [docs/configuration.md](docs/configuration.md).
 
 ## Upgrading

--- a/packages/pi-permission-system/docs/configuration.md
+++ b/packages/pi-permission-system/docs/configuration.md
@@ -112,6 +112,24 @@ This clamp is deny-preserving and, like `yoloMode`, applied at composition; when
 Both logs write to `~/.pi/agent/extensions/pi-permission-system/logs/`.
 No debug output is printed to the terminal.
 
+### Launcher-scoped yolo override
+
+A trusted launcher can enable the existing yolo composition for one Pi process and its descendants:
+
+```bash
+PI_PERMISSION_SYSTEM_YOLO=1 pi
+```
+
+Only the exact string `1` enables the override.
+Missing, empty, and other values leave the merged file configuration unchanged.
+The override converts effective `ask` results to `allow` while preserving every explicit `deny` rule.
+It remains active across configuration reloads for the lifetime of the process, and the status indicator, `/permission-system show`, and diagnostic records report the effective yolo-on state.
+The environment value is never written to global or project configuration.
+If settings are saved while the override is active, the existing file-backed `yoloMode` value is preserved.
+
+Treat this environment variable as a trusted-launcher API rather than a general shell default.
+Setting it globally would intentionally enable yolo for every Pi process inheriting that environment.
+
 ### Inline permission dialog (TUI)
 
 In an interactive **TUI** session, an `ask` decision opens an inline keybind dialog with one-key shortcuts:

--- a/packages/pi-permission-system/docs/plans/2026-07-27-session-yolo-launcher-override.md
+++ b/packages/pi-permission-system/docs/plans/2026-07-27-session-yolo-launcher-override.md
@@ -1,0 +1,394 @@
+---
+issue_title: "Add a process-scoped yolo launcher override"
+---
+
+# Session Yolo Launcher Override Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow a trusted launcher to activate the existing deny-preserving yolo composition for one Pi process without changing global or project configuration.
+
+**Architecture:** A pure runtime-override module parses an injected environment map and applies the resulting immutable override to normalized extension configuration.
+`index.ts` is the only production reader of `process.env`, and `ConfigStore` owns applying the override after initialization, refresh, and save while preserving the file-backed yolo value during persistence.
+
+**Tech Stack:** TypeScript, Vitest, pnpm, Pi extension API.
+
+## Global Constraints
+
+- The enabling contract is the exact process environment value `PI_PERMISSION_SYSTEM_YOLO=1`.
+- Missing, empty, or any other value leaves file-backed configuration unchanged.
+- The override reuses the existing `ask` to `allow` yolo rewrite and therefore preserves explicit `deny` decisions.
+- The override is process-scoped and must never be persisted to global or project configuration.
+- Configuration refreshes must retain the override for the lifetime of the process.
+- Status, config summaries, and diagnostics must report the effective yolo state.
+- No source module other than `src/index.ts` reads `process.env`.
+
+---
+
+### Task 1: Parse and apply the launcher override
+
+**Files:**
+
+- Create: `packages/pi-permission-system/src/runtime-config-overrides.ts`
+- Create: `packages/pi-permission-system/test/runtime-config-overrides.test.ts`
+
+**Interfaces:**
+
+Consumes: `PermissionSystemExtensionConfig` from `#src/extension-config`.
+
+Produces: `PI_PERMISSION_SYSTEM_YOLO_ENV`, `PermissionSystemRuntimeOverrides`, `readPermissionSystemRuntimeOverrides(environment)`, and `applyPermissionSystemRuntimeOverrides(config, overrides)`.
+
+- [ ] **Step 1: Write the failing parser and application tests**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { DEFAULT_EXTENSION_CONFIG } from "#src/extension-config";
+import {
+  applyPermissionSystemRuntimeOverrides,
+  readPermissionSystemRuntimeOverrides,
+} from "#src/runtime-config-overrides";
+
+describe("readPermissionSystemRuntimeOverrides", () => {
+  it("enables yolo only for the exact string 1", () => {
+    expect(
+      readPermissionSystemRuntimeOverrides({
+        PI_PERMISSION_SYSTEM_YOLO: "1",
+      }),
+    ).toEqual({ yoloMode: true });
+  });
+
+  it.each([undefined, "", "0", "true", "yes"])(
+    "does not enable yolo for %s",
+    (value) => {
+      expect(
+        readPermissionSystemRuntimeOverrides({
+          PI_PERMISSION_SYSTEM_YOLO: value,
+        }),
+      ).toEqual({});
+    },
+  );
+});
+
+describe("applyPermissionSystemRuntimeOverrides", () => {
+  it("returns an effective yolo-on config without mutating the input", () => {
+    const config = { ...DEFAULT_EXTENSION_CONFIG, yoloMode: false };
+    const result = applyPermissionSystemRuntimeOverrides(config, {
+      yoloMode: true,
+    });
+    expect(result).toEqual({ ...config, yoloMode: true });
+    expect(config.yoloMode).toBe(false);
+  });
+
+  it("returns the file-backed values when no override is present", () => {
+    const config = { ...DEFAULT_EXTENSION_CONFIG, debugLog: true };
+    expect(applyPermissionSystemRuntimeOverrides(config, {})).toEqual(config);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify the missing-module failure**
+
+Run:
+
+```bash
+corepack pnpm --filter @gotgenes/pi-permission-system exec vitest run test/runtime-config-overrides.test.ts
+```
+
+Expected: FAIL because `#src/runtime-config-overrides` does not exist.
+
+- [ ] **Step 3: Implement the pure runtime-override module**
+
+```typescript
+import type { PermissionSystemExtensionConfig } from "./extension-config";
+
+export const PI_PERMISSION_SYSTEM_YOLO_ENV = "PI_PERMISSION_SYSTEM_YOLO";
+
+export interface PermissionSystemRuntimeOverrides {
+  yoloMode?: true;
+}
+
+type RuntimeEnvironment = Readonly<Record<string, string | undefined>>;
+
+export function readPermissionSystemRuntimeOverrides(
+  environment: RuntimeEnvironment,
+): PermissionSystemRuntimeOverrides {
+  return environment[PI_PERMISSION_SYSTEM_YOLO_ENV] === "1"
+    ? { yoloMode: true }
+    : {};
+}
+
+export function applyPermissionSystemRuntimeOverrides(
+  config: PermissionSystemExtensionConfig,
+  overrides: PermissionSystemRuntimeOverrides,
+): PermissionSystemExtensionConfig {
+  return overrides.yoloMode === true
+    ? { ...config, yoloMode: true }
+    : config;
+}
+```
+
+- [ ] **Step 4: Run the focused test and typecheck**
+
+Run:
+
+```bash
+corepack pnpm --filter @gotgenes/pi-permission-system exec vitest run test/runtime-config-overrides.test.ts
+corepack pnpm --filter @gotgenes/pi-permission-system run check
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 5: Commit the pure contract**
+
+```bash
+git add packages/pi-permission-system/src/runtime-config-overrides.ts packages/pi-permission-system/test/runtime-config-overrides.test.ts
+git commit -m "feat(pi-permission-system): add launcher yolo override contract"
+```
+
+### Task 2: Keep the override effective across the configuration lifecycle
+
+**Files:**
+
+- Modify: `packages/pi-permission-system/src/config-store.ts`
+- Modify: `packages/pi-permission-system/src/index.ts`
+- Modify: `packages/pi-permission-system/test/config-store.test.ts`
+- Modify: `packages/pi-permission-system/test/composition-root.test.ts`
+
+**Interfaces:**
+
+Consumes: `PermissionSystemRuntimeOverrides`, `readPermissionSystemRuntimeOverrides`, and `applyPermissionSystemRuntimeOverrides` from Task 1.
+
+Produces: `ConfigStore.current()` as the effective runtime configuration while `ConfigStore.save()` persists the pre-override yolo value.
+
+- [ ] **Step 1: Add failing `ConfigStore` lifecycle tests**
+
+Add `runtimeOverrides: {}` to `makeStore`'s default `ConfigStoreDeps`.
+Add these cases:
+
+```typescript
+it("applies a yolo runtime override before any refresh", () => {
+  const { store } = makeStore({ runtimeOverrides: { yoloMode: true } });
+  expect(store.current()).toEqual({
+    ...DEFAULT_EXTENSION_CONFIG,
+    yoloMode: true,
+  });
+});
+
+it("retains a yolo runtime override across refresh", () => {
+  const { store } = makeStore({ runtimeOverrides: { yoloMode: true } });
+  mockLoadAndMergeConfigs.mockReturnValue({
+    merged: { ...DEFAULT_EXTENSION_CONFIG, yoloMode: false },
+    issues: [],
+  });
+  store.refresh(undefined, true);
+  expect(store.current().yoloMode).toBe(true);
+});
+
+it("syncs the effective yolo state after refresh", () => {
+  const { store } = makeStore({ runtimeOverrides: { yoloMode: true } });
+  const ctx = makeCtx({ hasUI: true });
+  store.refresh(ctx, true);
+  expect(mockSyncPermissionSystemStatus).toHaveBeenCalledWith(ctx, {
+    ...DEFAULT_EXTENSION_CONFIG,
+    yoloMode: true,
+  });
+});
+
+it("does not persist the process-scoped yolo override", () => {
+  const { store } = makeStore({ runtimeOverrides: { yoloMode: true } });
+  mockLoadUnifiedConfig.mockReturnValue({
+    config: { yoloMode: false },
+  });
+  store.save(store.current(), makeCommandCtx());
+  expect(mockWriteFileSync).toHaveBeenCalledWith(
+    expect.stringContaining(".tmp"),
+    expect.stringContaining('"yoloMode": false'),
+    "utf-8",
+  );
+  expect(store.current().yoloMode).toBe(true);
+});
+```
+
+- [ ] **Step 2: Add the failing composition-root integration test**
+
+```typescript
+describe("process-scoped yolo launcher override", () => {
+  it("rewrites asks while preserving explicit denies", async () => {
+    vi.stubEnv("PI_PERMISSION_SYSTEM_YOLO", "1");
+    writeGlobalConfig({
+      yoloMode: false,
+      permission: { "*": "allow", demo: "ask", blockedDemo: "deny" },
+    });
+    const cwd = mkdtempSync(join(tmpdir(), "pi-perm-yolo-env-cwd-"));
+    const pi = makeFakePi({ toolNames: ["demo", "blockedDemo"] });
+    piPermissionSystemExtension(pi as unknown as ExtensionAPI);
+    await fireSessionStart(pi, makeChildCtx(cwd, "yolo-env-session"));
+
+    const service = getPermissionsService();
+    const allowed = service!.checkPermission("demo");
+    const denied = service!.checkPermission("blockedDemo");
+    expect(allowed.state).toBe("allow");
+    expect(allowed.origin).toBe("yolo");
+    expect(denied.state).toBe("deny");
+    expect(denied.origin).not.toBe("yolo");
+    rmSync(cwd, { recursive: true, force: true });
+  });
+});
+```
+
+- [ ] **Step 3: Run both tests and verify they fail for the missing wiring**
+
+Run:
+
+```bash
+corepack pnpm --filter @gotgenes/pi-permission-system exec vitest run test/config-store.test.ts test/composition-root.test.ts
+```
+
+Expected: FAIL because `ConfigStoreDeps` has no runtime override and `index.ts` does not read the launcher environment.
+
+- [ ] **Step 4: Apply overrides inside `ConfigStore`**
+
+Add a required `runtimeOverrides: PermissionSystemRuntimeOverrides` field to `ConfigStoreDeps`.
+Use one private method as the only application point:
+
+```typescript
+export interface ConfigStoreDeps {
+  agentDir: string;
+  policyPaths: ResolvedPolicyPathProvider;
+  logger: DebugReviewLogger;
+  runtimeOverrides: PermissionSystemRuntimeOverrides;
+}
+
+constructor(private readonly deps: ConfigStoreDeps) {
+  this.config = this.applyRuntimeOverrides({
+    ...DEFAULT_EXTENSION_CONFIG,
+  });
+}
+
+private applyRuntimeOverrides(
+  config: PermissionSystemExtensionConfig,
+): PermissionSystemExtensionConfig {
+  return applyPermissionSystemRuntimeOverrides(
+    config,
+    this.deps.runtimeOverrides,
+  );
+}
+```
+
+In `refresh`, replace the direct normalized assignment with:
+
+```typescript
+const fileConfig = normalizePermissionSystemConfig(mergeResult.merged);
+const runtimeConfig = this.applyRuntimeOverrides(fileConfig);
+this.config = runtimeConfig;
+```
+
+In `save`, preserve the file-backed yolo value whenever the runtime override is active:
+
+```typescript
+const normalized = normalizePermissionSystemConfig(next);
+const globalPath = getGlobalConfigPath(this.deps.agentDir);
+const existing = loadUnifiedConfig(globalPath);
+const persistedYoloMode =
+  this.deps.runtimeOverrides.yoloMode === true
+    ? existing.config.yoloMode === true
+    : normalized.yoloMode;
+const persistedConfig = { ...normalized, yoloMode: persistedYoloMode };
+const merged = {
+  ...existing.config,
+  debugLog: persistedConfig.debugLog,
+  permissionReviewLog: persistedConfig.permissionReviewLog,
+  yoloMode: persistedConfig.yoloMode,
+};
+```
+
+After the successful rename, assign and report the effective configuration:
+
+```typescript
+this.config = this.applyRuntimeOverrides(persistedConfig);
+syncPermissionSystemStatus(ctx, this.config);
+this.lastConfigWarning = null;
+this.deps.logger.debug("config.saved", {
+  debugLog: this.config.debugLog,
+  permissionReviewLog: this.config.permissionReviewLog,
+  yoloMode: this.config.yoloMode,
+});
+```
+
+- [ ] **Step 5: Wire the environment at the composition root**
+
+```typescript
+const runtimeOverrides = readPermissionSystemRuntimeOverrides(process.env);
+
+configStore = new ConfigStore({
+  agentDir,
+  policyPaths: permissionManager,
+  logger,
+  runtimeOverrides,
+});
+```
+
+Keep this read in `src/index.ts`, alongside the existing `process.platform` composition-root read.
+
+- [ ] **Step 6: Run the focused tests and package typecheck**
+
+Run:
+
+```bash
+corepack pnpm --filter @gotgenes/pi-permission-system exec vitest run test/config-store.test.ts test/composition-root.test.ts test/permission-manager-yolo.test.ts test/status.test.ts
+corepack pnpm --filter @gotgenes/pi-permission-system run check
+```
+
+Expected: all commands PASS, including the existing hard-deny yolo regression tests.
+
+- [ ] **Step 7: Commit the lifecycle wiring**
+
+```bash
+git add packages/pi-permission-system/src/config-store.ts packages/pi-permission-system/src/index.ts packages/pi-permission-system/test/config-store.test.ts packages/pi-permission-system/test/composition-root.test.ts
+git commit -m "feat(pi-permission-system): honor launcher yolo override"
+```
+
+### Task 3: Document and verify the launcher API
+
+**Files:**
+
+- Modify: `packages/pi-permission-system/README.md`
+- Modify: `packages/pi-permission-system/docs/configuration.md`
+
+**Interfaces:**
+
+Consumes: the exact `PI_PERMISSION_SYSTEM_YOLO=1` contract implemented in Tasks 1 and 2.
+
+Produces: user-facing launcher guidance that states scope, exact parsing, persistence, and deny preservation.
+
+- [ ] **Step 1: Add user documentation**
+
+Document the environment variable as a trusted-launcher integration.
+State that only exact `1` enables it, it applies to one Pi process and descendants, configuration reloads retain it, config files are never changed by it, and explicit deny rules remain deny.
+Include this minimal example:
+
+```bash
+PI_PERMISSION_SYSTEM_YOLO=1 pi
+```
+
+- [ ] **Step 2: Run formatting, lint, tests, and dead-code checks**
+
+Run:
+
+```bash
+corepack pnpm exec rumdl fmt packages/pi-permission-system/README.md packages/pi-permission-system/docs/configuration.md packages/pi-permission-system/docs/plans/2026-07-27-session-yolo-launcher-override.md
+corepack pnpm --filter @gotgenes/pi-permission-system run check
+corepack pnpm --filter @gotgenes/pi-permission-system exec vitest run
+corepack pnpm run lint
+corepack pnpm fallow dead-code
+```
+
+Expected: 130 or more test files pass, lint reports no errors, and dead-code analysis passes.
+
+- [ ] **Step 3: Commit the documentation**
+
+```bash
+git add packages/pi-permission-system/README.md packages/pi-permission-system/docs/configuration.md packages/pi-permission-system/docs/plans/2026-07-27-session-yolo-launcher-override.md
+git commit -m "docs(pi-permission-system): document launcher yolo override"
+```

--- a/packages/pi-permission-system/src/config-store.ts
+++ b/packages/pi-permission-system/src/config-store.ts
@@ -26,6 +26,10 @@ import {
   type PermissionSystemExtensionConfig,
 } from "./extension-config";
 import type { ResolvedPolicyPaths } from "./policy-loader";
+import {
+  applyPermissionSystemRuntimeOverrides,
+  type PermissionSystemRuntimeOverrides,
+} from "./runtime-config-overrides";
 import type { DebugReviewLogger } from "./session-logger";
 import { syncPermissionSystemStatus } from "./status";
 
@@ -67,6 +71,7 @@ export interface ConfigStoreDeps {
   agentDir: string;
   policyPaths: ResolvedPolicyPathProvider;
   logger: DebugReviewLogger;
+  runtimeOverrides: PermissionSystemRuntimeOverrides;
 }
 
 /**
@@ -84,7 +89,9 @@ export class ConfigStore implements SessionConfigStore, CommandConfigStore {
   private lastConfigWarning: string | null = null;
 
   constructor(private readonly deps: ConfigStoreDeps) {
-    this.config = { ...DEFAULT_EXTENSION_CONFIG };
+    this.config = this.applyRuntimeOverrides({
+      ...DEFAULT_EXTENSION_CONFIG,
+    });
   }
 
   /** Return the current extension config. */
@@ -108,7 +115,8 @@ export class ConfigStore implements SessionConfigStore, CommandConfigStore {
       EXTENSION_ROOT,
       { includeProjectScope: projectTrusted },
     );
-    const runtimeConfig = normalizePermissionSystemConfig(mergeResult.merged);
+    const fileConfig = normalizePermissionSystemConfig(mergeResult.merged);
+    const runtimeConfig = this.applyRuntimeOverrides(fileConfig);
     this.config = runtimeConfig;
 
     if (ctx?.hasUI) {
@@ -150,11 +158,19 @@ export class ConfigStore implements SessionConfigStore, CommandConfigStore {
     const globalPath = getGlobalConfigPath(this.deps.agentDir);
 
     const existing = loadUnifiedConfig(globalPath);
+    const persistedYoloMode =
+      this.deps.runtimeOverrides.yoloMode === true
+        ? existing.config.yoloMode === true
+        : normalized.yoloMode;
+    const persistedConfig = {
+      ...normalized,
+      yoloMode: persistedYoloMode,
+    };
     const merged = {
       ...existing.config,
-      debugLog: normalized.debugLog,
-      permissionReviewLog: normalized.permissionReviewLog,
-      yoloMode: normalized.yoloMode,
+      debugLog: persistedConfig.debugLog,
+      permissionReviewLog: persistedConfig.permissionReviewLog,
+      yoloMode: persistedConfig.yoloMode,
     };
 
     const tmpPath = `${globalPath}.tmp`;
@@ -178,14 +194,14 @@ export class ConfigStore implements SessionConfigStore, CommandConfigStore {
       return;
     }
 
-    this.config = normalized;
-    syncPermissionSystemStatus(ctx, normalized);
+    this.config = this.applyRuntimeOverrides(persistedConfig);
+    syncPermissionSystemStatus(ctx, this.config);
     this.lastConfigWarning = null;
 
     this.deps.logger.debug("config.saved", {
-      debugLog: normalized.debugLog,
-      permissionReviewLog: normalized.permissionReviewLog,
-      yoloMode: normalized.yoloMode,
+      debugLog: this.config.debugLog,
+      permissionReviewLog: this.config.permissionReviewLog,
+      yoloMode: this.config.yoloMode,
     });
   }
 
@@ -221,6 +237,15 @@ export class ConfigStore implements SessionConfigStore, CommandConfigStore {
     this.deps.logger.debug(
       "config.resolved",
       entry as unknown as Record<string, unknown>,
+    );
+  }
+
+  private applyRuntimeOverrides(
+    config: PermissionSystemExtensionConfig,
+  ): PermissionSystemExtensionConfig {
+    return applyPermissionSystemRuntimeOverrides(
+      config,
+      this.deps.runtimeOverrides,
     );
   }
 }

--- a/packages/pi-permission-system/src/index.ts
+++ b/packages/pi-permission-system/src/index.ts
@@ -36,6 +36,7 @@ import { PermissionManager } from "./permission-manager";
 import { PermissionResolver } from "./permission-resolver";
 import { PermissionSession } from "./permission-session";
 import { LocalPermissionsService } from "./permissions-service";
+import { readPermissionSystemRuntimeOverrides } from "./runtime-config-overrides";
 import { PermissionServiceLifecycle } from "./service-lifecycle";
 import { PermissionSessionLogger } from "./session-logger";
 import { SessionRules } from "./session-rules";
@@ -53,6 +54,7 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
   // must not read process.platform (enforced by the eslint guard scoped to
   // src/) and never re-derive the win32 flavor — they receive this product.
   const hostFlavor = pathFlavorForPlatform(process.platform);
+  const runtimeOverrides = readPermissionSystemRuntimeOverrides(process.env);
   const sessionRules = new SessionRules();
   const subagentRegistry = getSubagentSessionRegistry();
   // Single owner of subagent detection, shared across every consumer instead of
@@ -98,6 +100,7 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
     agentDir,
     policyPaths: permissionManager,
     logger,
+    runtimeOverrides,
   });
 
   const prompter = new PermissionPrompter({ logger });

--- a/packages/pi-permission-system/src/runtime-config-overrides.ts
+++ b/packages/pi-permission-system/src/runtime-config-overrides.ts
@@ -1,0 +1,26 @@
+import type { PermissionSystemExtensionConfig } from "./extension-config";
+
+export const PI_PERMISSION_SYSTEM_YOLO_ENV = "PI_PERMISSION_SYSTEM_YOLO";
+
+export interface PermissionSystemRuntimeOverrides {
+  yoloMode?: true;
+}
+
+type RuntimeEnvironment = Readonly<Record<string, string | undefined>>;
+
+export function readPermissionSystemRuntimeOverrides(
+  environment: RuntimeEnvironment,
+): PermissionSystemRuntimeOverrides {
+  return environment[PI_PERMISSION_SYSTEM_YOLO_ENV] === "1"
+    ? { yoloMode: true }
+    : {};
+}
+
+export function applyPermissionSystemRuntimeOverrides(
+  config: PermissionSystemExtensionConfig,
+  overrides: PermissionSystemRuntimeOverrides,
+): PermissionSystemExtensionConfig {
+  return overrides.yoloMode === true
+    ? { ...config, yoloMode: true }
+    : config;
+}

--- a/packages/pi-permission-system/src/runtime-config-overrides.ts
+++ b/packages/pi-permission-system/src/runtime-config-overrides.ts
@@ -20,7 +20,5 @@ export function applyPermissionSystemRuntimeOverrides(
   config: PermissionSystemExtensionConfig,
   overrides: PermissionSystemRuntimeOverrides,
 ): PermissionSystemExtensionConfig {
-  return overrides.yoloMode === true
-    ? { ...config, yoloMode: true }
-    : config;
+  return overrides.yoloMode === true ? { ...config, yoloMode: true } : config;
 }

--- a/packages/pi-permission-system/test/composition-root.test.ts
+++ b/packages/pi-permission-system/test/composition-root.test.ts
@@ -801,6 +801,29 @@ describe("bash bare-token path gating (#509, #645)", () => {
   });
 });
 
+describe("process-scoped yolo launcher override", () => {
+  it("rewrites asks while preserving explicit denies", async () => {
+    vi.stubEnv("PI_PERMISSION_SYSTEM_YOLO", "1");
+    writeGlobalConfig({
+      yoloMode: false,
+      permission: { "*": "allow", demo: "ask", blockedDemo: "deny" },
+    });
+    const cwd = mkdtempSync(join(tmpdir(), "pi-perm-yolo-env-cwd-"));
+    const pi = makeFakePi({ toolNames: ["demo", "blockedDemo"] });
+    piPermissionSystemExtension(pi as unknown as ExtensionAPI);
+    await fireSessionStart(pi, makeChildCtx(cwd, "yolo-env-session"));
+
+    const service = getPermissionsService();
+    const allowed = service!.checkPermission("demo");
+    const denied = service!.checkPermission("blockedDemo");
+    expect(allowed.state).toBe("allow");
+    expect(allowed.origin).toBe("yolo");
+    expect(denied.state).toBe("deny");
+    expect(denied.origin).not.toBe("yolo");
+    rmSync(cwd, { recursive: true, force: true });
+  });
+});
+
 describe("multi-instance global service interplay", () => {
   // The fix (#302) scopes the process-global service slot to the publishing
   // instance. The parent publishes at its session_start; an in-process child

--- a/packages/pi-permission-system/test/config-store.test.ts
+++ b/packages/pi-permission-system/test/config-store.test.ts
@@ -124,6 +124,7 @@ function makeStore(overrides: Partial<ConfigStoreDeps> = {}): {
     agentDir: "/test/agent",
     policyPaths: makePolicyPathProvider(),
     logger,
+    runtimeOverrides: {},
     ...overrides,
   };
   return { store: new ConfigStore(deps), logger };
@@ -155,6 +156,16 @@ describe("ConfigStore", () => {
     it("returns DEFAULT_EXTENSION_CONFIG before any refresh", () => {
       const { store } = makeStore();
       expect(store.current()).toEqual(DEFAULT_EXTENSION_CONFIG);
+    });
+
+    it("applies a yolo runtime override before any refresh", () => {
+      const { store } = makeStore({
+        runtimeOverrides: { yoloMode: true },
+      });
+      expect(store.current()).toEqual({
+        ...DEFAULT_EXTENSION_CONFIG,
+        yoloMode: true,
+      });
     });
   });
 
@@ -203,6 +214,18 @@ describe("ConfigStore", () => {
       store.refresh(undefined, true);
       expect(store.current().debugLog).toBe(true);
       expect(store.current().permissionReviewLog).toBe(false);
+    });
+
+    it("retains a yolo runtime override across refresh", () => {
+      const { store } = makeStore({
+        runtimeOverrides: { yoloMode: true },
+      });
+      mockLoadAndMergeConfigs.mockReturnValue({
+        merged: { ...DEFAULT_EXTENSION_CONFIG, yoloMode: false },
+        issues: [],
+      });
+      store.refresh(undefined, true);
+      expect(store.current().yoloMode).toBe(true);
     });
 
     it("writes config.loaded debug log", () => {
@@ -298,6 +321,18 @@ describe("ConfigStore", () => {
         ctx,
         expect.any(Object),
       );
+    });
+
+    it("syncs the effective yolo state after refresh", () => {
+      const { store } = makeStore({
+        runtimeOverrides: { yoloMode: true },
+      });
+      const ctx = makeCtx({ hasUI: true });
+      store.refresh(ctx, true);
+      expect(mockSyncPermissionSystemStatus).toHaveBeenCalledWith(ctx, {
+        ...DEFAULT_EXTENSION_CONFIG,
+        yoloMode: true,
+      });
     });
 
     it("does not call syncPermissionSystemStatus when hasUI is false", () => {
@@ -423,6 +458,22 @@ describe("ConfigStore", () => {
         expect.stringContaining('"piInfrastructureReadPaths"'),
         "utf-8",
       );
+    });
+
+    it("does not persist the process-scoped yolo override", () => {
+      const { store } = makeStore({
+        runtimeOverrides: { yoloMode: true },
+      });
+      mockLoadUnifiedConfig.mockReturnValue({
+        config: { yoloMode: false },
+      });
+      store.save(store.current(), makeCommandCtx());
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        expect.stringContaining(".tmp"),
+        expect.stringContaining('"yoloMode": false'),
+        "utf-8",
+      );
+      expect(store.current().yoloMode).toBe(true);
     });
   });
 

--- a/packages/pi-permission-system/test/runtime-config-overrides.test.ts
+++ b/packages/pi-permission-system/test/runtime-config-overrides.test.ts
@@ -15,16 +15,19 @@ describe("readPermissionSystemRuntimeOverrides", () => {
     ).toEqual({ yoloMode: true });
   });
 
-  it.each([undefined, "", "0", "true", "yes"])(
-    "does not enable yolo for %s",
-    (value) => {
-      expect(
-        readPermissionSystemRuntimeOverrides({
-          PI_PERMISSION_SYSTEM_YOLO: value,
-        }),
-      ).toEqual({});
-    },
-  );
+  it.each([
+    undefined,
+    "",
+    "0",
+    "true",
+    "yes",
+  ])("does not enable yolo for %s", (value) => {
+    expect(
+      readPermissionSystemRuntimeOverrides({
+        PI_PERMISSION_SYSTEM_YOLO: value,
+      }),
+    ).toEqual({});
+  });
 });
 
 describe("applyPermissionSystemRuntimeOverrides", () => {

--- a/packages/pi-permission-system/test/runtime-config-overrides.test.ts
+++ b/packages/pi-permission-system/test/runtime-config-overrides.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_EXTENSION_CONFIG } from "#src/extension-config";
+import {
+  applyPermissionSystemRuntimeOverrides,
+  readPermissionSystemRuntimeOverrides,
+} from "#src/runtime-config-overrides";
+
+describe("readPermissionSystemRuntimeOverrides", () => {
+  it("enables yolo only for the exact string 1", () => {
+    expect(
+      readPermissionSystemRuntimeOverrides({
+        PI_PERMISSION_SYSTEM_YOLO: "1",
+      }),
+    ).toEqual({ yoloMode: true });
+  });
+
+  it.each([undefined, "", "0", "true", "yes"])(
+    "does not enable yolo for %s",
+    (value) => {
+      expect(
+        readPermissionSystemRuntimeOverrides({
+          PI_PERMISSION_SYSTEM_YOLO: value,
+        }),
+      ).toEqual({});
+    },
+  );
+});
+
+describe("applyPermissionSystemRuntimeOverrides", () => {
+  it("returns an effective yolo-on config without mutating the input", () => {
+    const config = { ...DEFAULT_EXTENSION_CONFIG, yoloMode: false };
+    const result = applyPermissionSystemRuntimeOverrides(config, {
+      yoloMode: true,
+    });
+    expect(result).toEqual({ ...config, yoloMode: true });
+    expect(config.yoloMode).toBe(false);
+  });
+
+  it("returns the file-backed values when no override is present", () => {
+    const config = { ...DEFAULT_EXTENSION_CONFIG, debugLog: true };
+    expect(applyPermissionSystemRuntimeOverrides(config, {})).toEqual(config);
+  });
+});


### PR DESCRIPTION
## Summary

- add the exact `PI_PERMISSION_SYSTEM_YOLO=1` launcher contract
- apply it as an in-memory runtime override across startup and config refresh
- keep explicit deny rules enforced and prevent the override from being persisted
- document the process-scoped compatibility boundary

## Verification

- `corepack pnpm --filter @gotgenes/pi-permission-system test` (131 files, 2685 tests)
- `corepack pnpm --filter @gotgenes/pi-permission-system run check`
- `corepack pnpm run lint`
- `corepack pnpm fallow dead-code`

## Integration

This is the package side of the FirstMate `+yolo` integration tracked as OPS-232. FirstMate will set the variable only for delegated Pi ship/scout processes in projects whose effective mode is `+yolo`; yolo-off, secondmate, non-Pi, and standalone Pi behavior remains unchanged.
