### PR TITLE
fix(pi-subagents): replace turn glyph (#669)

### DIFF
--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -65,11 +65,11 @@ The extension renders a persistent widget above the editor showing active backgr
 
 ```text
 ● Agents
-├─ ⠹ Agent  Refactor auth module · ⟳5≤30 · 5 tool uses · 33.8k token (62%) · 12.3s
+├─ ⠹ Agent  Refactor auth module · ↻5≤30 · 5 tool uses · 33.8k token (62%) · 12.3s
 │    ⎿  editing 2 files…
-├─ ⠹ Explore  Find auth files · ⟳3 · 3 tool uses · 12.4k token (8%) · 4.1s
+├─ ⠹ Explore  Find auth files · ↻3 · 3 tool uses · 12.4k token (8%) · 4.1s
 │    ⎿  searching…
-├─ ⠹ Agent  Long-running task · ⟳42 · 38 tool uses · 91.0k token (84% · ↻2) · 2m17s
+├─ ⠹ Agent  Long-running task · ↻42 · 38 tool uses · 91.0k token (84% · ⇊2) · 2m17s
 │    ⎿  reading…
 └─ 2 queued
 ```
@@ -78,19 +78,19 @@ The token field is annotated with two optional signals inside parens:
 
 - **`NN%`** — context-window utilization (color-coded: <70% dim, 70–85% warning, ≥85% error).
   Omitted when the model has no declared `contextWindow`, or briefly right after compaction.
-- **`↻N`** — number of times the session has compacted, when > 0.
+- **`⇊N`** — number of times the session has compacted, when > 0.
   Stays dim; the percent's color carries urgency.
 
 Individual agent results render inline in the conversation:
 
 | State          | Example                                                                                  |
 | -------------- | ---------------------------------------------------------------------------------------- |
-| **Running**    | `⠹ ⟳3≤30 · 3 tool uses · 12.4k token (8%)` / `⎿ searching, reading 3 files…`             |
-| **Completed**  | `✓ ⟳8 · 5 tool uses · 33.8k token (62%) · 12.3s` / `⎿ Done`                              |
-| **Wrapped up** | `✓ ⟳50≤50 · 50 tool uses · 89.1k token (84% · ↻2) · 45.2s` / `⎿ Wrapped up (turn limit)` |
-| **Stopped**    | `■ ⟳3 · 3 tool uses · 12.4k token (8%)` / `⎿ Stopped`                                    |
-| **Error**      | `✗ ⟳3 · 3 tool uses · 12.4k token (8%)` / `⎿ Error: timeout`                             |
-| **Aborted**    | `✗ ⟳55≤50 · 55 tool uses · 102.3k token (95% · ↻3)` / `⎿ Aborted (max turns exceeded)`   |
+| **Running**    | `⠹ ↻3≤30 · 3 tool uses · 12.4k token (8%)` / `⎿ searching, reading 3 files…`             |
+| **Completed**  | `✓ ↻8 · 5 tool uses · 33.8k token (62%) · 12.3s` / `⎿ Done`                              |
+| **Wrapped up** | `✓ ↻50≤50 · 50 tool uses · 89.1k token (84% · ⇊2) · 45.2s` / `⎿ Wrapped up (turn limit)` |
+| **Stopped**    | `■ ↻3 · 3 tool uses · 12.4k token (8%)` / `⎿ Stopped`                                    |
+| **Error**      | `✗ ↻3 · 3 tool uses · 12.4k token (8%)` / `⎿ Error: timeout`                             |
+| **Aborted**    | `✗ ↻55≤50 · 55 tool uses · 102.3k token (95% · ⇊3)` / `⎿ Aborted (max turns exceeded)`   |
 
 Completed results can be expanded (ctrl+o in pi) to show the full agent output inline.
 
@@ -98,7 +98,7 @@ Background agent completion notifications render as styled boxes:
 
 ```text
 ✓ Find auth files completed
-  ⟳3 · 3 tool uses · 12.4k token · 4.1s
+  ↻3 · 3 tool uses · 12.4k token · 4.1s
   ⎿  Found 5 files related to authentication...
   transcript: .pi/output/agent-abc123.jsonl
 ```

--- a/packages/pi-subagents/src/tools/result-renderer.ts
+++ b/packages/pi-subagents/src/tools/result-renderer.ts
@@ -103,7 +103,7 @@ export function renderFailed(details: AgentDetails, theme: Theme): string {
 // ---- Shared helper ----
 
 /**
- * Build the stats string: "haiku · thinking: high · ⟳5≤30 · 3 tool uses · 33.8k token".
+ * Build the stats string: "haiku · thinking: high · ↻5≤30 · 3 tool uses · 33.8k token".
  * Returns an empty string when all fields are absent or zero.
  */
 export function renderStats(details: AgentDetails, theme: Theme): string {

--- a/packages/pi-subagents/src/ui/display.ts
+++ b/packages/pi-subagents/src/ui/display.ts
@@ -71,12 +71,12 @@ export function formatTokens(count: number): string {
 /**
  * Token count with optional context-fill % and compaction-count annotations.
  * Thresholds for percent: <70% dim, 70–85% warning, ≥85% error.
- * Compaction count rendered as `↻N` in dim.
+ * Compaction count rendered as `⇊N` in dim.
  *
  *   "12.3k token"               — no annotations
  *   "12.3k token (45%)"         — percent only
- *   "12.3k token (↻2)"          — compactions only (e.g. right after compact)
- *   "12.3k token (45% · ↻2)"    — both
+ *   "12.3k token (⇊2)"          — compactions only (e.g. right after compact)
+ *   "12.3k token (45% · ⇊2)"    — both
  */
 export function formatSessionTokens(
   tokens: number,
@@ -91,16 +91,16 @@ export function formatSessionTokens(
     annot.push(theme.fg(color, `${Math.round(percent)}%`));
   }
   if (compactions > 0) {
-    annot.push(theme.fg("dim", `↻${compactions}`));
+    annot.push(theme.fg("dim", `⇊${compactions}`));
   }
   if (annot.length === 0) return tokenStr;
   const sep = theme.fg("dim", " · ");
   return `${tokenStr} ${theme.fg("dim", "(")}${annot.join(sep)}${theme.fg("dim", ")")}`;
 }
 
-/** Format turn count with optional max limit: "⟳5≤30" or "⟳5". */
+/** Format turn count with optional max limit: "↻5≤30" or "↻5". */
 export function formatTurns(turnCount: number, maxTurns?: number | null): string {
-  return maxTurns != null ? `⟳${turnCount}≤${maxTurns}` : `⟳${turnCount}`;
+  return maxTurns != null ? `↻${turnCount}≤${maxTurns}` : `↻${turnCount}`;
 }
 
 /** Format milliseconds as human-readable duration. */

--- a/packages/pi-subagents/test/display.test.ts
+++ b/packages/pi-subagents/test/display.test.ts
@@ -78,11 +78,11 @@ describe("formatSessionTokens", () => {
 
   it("annotates compaction count alongside percent", () => {
     // compactions only (e.g. immediately post-compaction, percent null)
-    expect(formatSessionTokens(1234, null, theme, 1)).toBe("1.2k token <dim>(</dim><dim>↻1</dim><dim>)</dim>");
-    expect(formatSessionTokens(1234, null, theme, 3)).toBe("1.2k token <dim>(</dim><dim>↻3</dim><dim>)</dim>");
+    expect(formatSessionTokens(1234, null, theme, 1)).toBe("1.2k token <dim>(</dim><dim>⇊1</dim><dim>)</dim>");
+    expect(formatSessionTokens(1234, null, theme, 3)).toBe("1.2k token <dim>(</dim><dim>⇊3</dim><dim>)</dim>");
     // percent + compactions, joined with ` · `
-    expect(formatSessionTokens(1234, 45, theme, 2)).toBe("1.2k token <dim>(</dim><dim>45%</dim><dim> · </dim><dim>↻2</dim><dim>)</dim>");
-    expect(formatSessionTokens(1234, 88, theme, 4)).toBe("1.2k token <dim>(</dim><error>88%</error><dim> · </dim><dim>↻4</dim><dim>)</dim>");
+    expect(formatSessionTokens(1234, 45, theme, 2)).toBe("1.2k token <dim>(</dim><dim>45%</dim><dim> · </dim><dim>⇊2</dim><dim>)</dim>");
+    expect(formatSessionTokens(1234, 88, theme, 4)).toBe("1.2k token <dim>(</dim><error>88%</error><dim> · </dim><dim>⇊4</dim><dim>)</dim>");
     // compactions=0 omitted
     expect(formatSessionTokens(1234, 45, theme, 0)).toBe("1.2k token <dim>(</dim><dim>45%</dim><dim>)</dim>");
   });

--- a/packages/pi-subagents/test/observation/renderer.test.ts
+++ b/packages/pi-subagents/test/observation/renderer.test.ts
@@ -87,7 +87,7 @@ describe("buildStatsParts", () => {
       totalTokens: 1000,
       durationMs: 5000,
     });
-    expect(parts).toEqual(["⟳5≤10", "3 tool uses", "1.0k token", "5.0s"]);
+    expect(parts).toEqual(["↻5≤10", "3 tool uses", "1.0k token", "5.0s"]);
   });
 
   it("omits a part when its field is zero", () => {
@@ -96,13 +96,13 @@ describe("buildStatsParts", () => {
     ).toEqual(["3 tool uses", "1.0k token", "5.0s"]);
     expect(
       buildStatsParts({ turnCount: 5, maxTurns: 10, toolUses: 0, totalTokens: 1000, durationMs: 5000 }),
-    ).toEqual(["⟳5≤10", "1.0k token", "5.0s"]);
+    ).toEqual(["↻5≤10", "1.0k token", "5.0s"]);
     expect(
       buildStatsParts({ turnCount: 5, maxTurns: 10, toolUses: 3, totalTokens: 0, durationMs: 5000 }),
-    ).toEqual(["⟳5≤10", "3 tool uses", "5.0s"]);
+    ).toEqual(["↻5≤10", "3 tool uses", "5.0s"]);
     expect(
       buildStatsParts({ turnCount: 5, maxTurns: 10, toolUses: 3, totalTokens: 1000, durationMs: 0 }),
-    ).toEqual(["⟳5≤10", "3 tool uses", "1.0k token"]);
+    ).toEqual(["↻5≤10", "3 tool uses", "1.0k token"]);
   });
 
   it("returns an empty array when all fields are zero", () => {

--- a/packages/pi-subagents/test/tools/result-renderer.test.ts
+++ b/packages/pi-subagents/test/tools/result-renderer.test.ts
@@ -52,22 +52,22 @@ describe("renderStats", () => {
 
 	it("includes turn count with max turns", () => {
 		const details = makeDetails({ turnCount: 5, maxTurns: 30 });
-		expect(renderStats(details, theme)).toContain("[dim:⟳5≤30]");
+		expect(renderStats(details, theme)).toContain("[dim:↻5≤30]");
 	});
 
 	it("includes turn count without max turns", () => {
 		const details = makeDetails({ turnCount: 5 });
-		expect(renderStats(details, theme)).toContain("[dim:⟳5]");
+		expect(renderStats(details, theme)).toContain("[dim:↻5]");
 	});
 
 	it("excludes turn count when turnCount is 0", () => {
 		const details = makeDetails({ turnCount: 0 });
-		expect(renderStats(details, theme)).not.toContain("⟳");
+		expect(renderStats(details, theme)).not.toContain("↻");
 	});
 
 	it("excludes turn count when turnCount is undefined", () => {
 		const details = makeDetails({ turnCount: undefined });
-		expect(renderStats(details, theme)).not.toContain("⟳");
+		expect(renderStats(details, theme)).not.toContain("↻");
 	});
 
 	it("includes singular tool use", () => {

--- a/packages/pi-subagents/test/ui/agent-widget.test.ts
+++ b/packages/pi-subagents/test/ui/agent-widget.test.ts
@@ -239,7 +239,7 @@ describe("AgentWidget — projection reads activity off Subagent records", () =>
 		const lines = renderFn!(stubTui, stubTheme).render();
 		const allText = lines.join("\n");
 		// Turn 3 from the record should appear
-		expect(allText).toContain("⟳3");
+		expect(allText).toContain("↻3");
 		// Active tool "read" → "reading…"
 		expect(allText).toContain("reading");
 	});

--- a/packages/pi-subagents/test/widget-renderer.test.ts
+++ b/packages/pi-subagents/test/widget-renderer.test.ts
@@ -52,7 +52,7 @@ describe("renderFinishedLine", () => {
 		// Duration (5000ms = 5.0s)
 		expect(line).toContain("5.0s");
 		// Turn count with max
-		expect(line).toContain("⟳3≤10");
+		expect(line).toContain("↻3≤10");
 		// No trailing status text for completed
 		expect(line).not.toContain("error");
 		expect(line).not.toContain("aborted");
@@ -78,7 +78,7 @@ describe("renderFinishedLine", () => {
 		const agent = makeAgent(); // defaults: turnCount: 3, maxTurns: 10
 		const line = renderFinishedLine(agent, testRegistry, theme);
 		// Finished agents now always show turn count — accepted behavior change (#421)
-		expect(line).toContain("⟳3≤10");
+		expect(line).toContain("↻3≤10");
 	});
 
 	it("uses Date.now() for duration when completedAt is undefined", () => {
@@ -159,7 +159,7 @@ describe("renderRunningLines", () => {
 		expect(header).toContain("**Agent**");
 		expect(header).toContain("[muted:test task]");
 		// Stats: turn count
-		expect(header).toContain("⟳2≤10");
+		expect(header).toContain("↻2≤10");
 		// Tool uses
 		expect(header).toContain("5 tool uses");
 
@@ -199,7 +199,7 @@ describe("renderRunningLines", () => {
 		// Context percent
 		expect(header).toContain("45%");
 		// Compaction count
-		expect(header).toContain("↻1");
+		expect(header).toContain("⇊1");
 	});
 
 	it("omits token display when lifetimeUsage totals zero", () => {


### PR DESCRIPTION
Fixes the pi-subagents turn-count glyph overflow in monospace terminals.

This is directly from the upstream fix for tintinweb/pi-subagents#84 (https://github.com/tintinweb/pi-subagents/commit/aad202a3583c8008d03760be8e8ac4323d38bec7).

- Replace the turn-count glyph from `⟳` to `↻`.
- Move the compaction-count glyph from `↻` to `⇊` to keep the indicators distinct.
- Update rendered-output tests and README examples.

This is a visual-only output change.

Fixes #669.