### PR TITLE
fix(pi-subagents): make the /subagents:sessions preview responsive on large transcripts

### DIFF
--- a/packages/pi-subagents/src/ui/session-navigation.ts
+++ b/packages/pi-subagents/src/ui/session-navigation.ts
@@ -71,7 +71,7 @@ export interface TranscriptSource {
   /** Current message history. */
   getMessages(): readonly SessionMessage[];
   /** Subscribe to changes; returns an unsubscribe, or undefined for a static snapshot. */
-  subscribe(onChange: () => void): (() => void) | undefined;
+  subscribe(onChange: (event?: AgentSessionEvent) => void): (() => void) | undefined;
   /** Running-agent streaming state, or undefined when not streaming. */
   streaming(): StreamingState | undefined;
   /** Resolve a registered tool definition by name, for Pi's tool-execution components. */
@@ -129,7 +129,7 @@ export function fileSnapshotSource(
 export function liveSource(record: NavigableSubagent): TranscriptSource {
   return {
     getMessages: () => record.agentMessages,
-    subscribe: (onChange) => record.subscribeToUpdates(() => onChange()),
+    subscribe: (onChange) => record.subscribeToUpdates(onChange),
     streaming: () =>
       isRunningStatus(record.status)
         ? { activeTools: record.activeTools, responseText: record.responseText }

--- a/packages/pi-subagents/src/ui/session-navigator.ts
+++ b/packages/pi-subagents/src/ui/session-navigator.ts
@@ -15,6 +15,7 @@
  * snapshot (`fileSnapshotSource`) swaps in without touching the renderer or the overlay.
  */
 
+import type { AssistantMessage } from "@earendil-works/pi-ai";
 import {
   AssistantMessageComponent,
   BashExecutionComponent,
@@ -38,7 +39,7 @@ import {
   visibleWidth,
 } from "@earendil-works/pi-tui";
 import type { AgentConfigLookup } from "#src/config/agent-types";
-import type { SessionMessage } from "#src/types";
+import type { AgentSessionEvent, SessionMessage } from "#src/types";
 import { describeActivity, type Theme } from "#src/ui/display";
 import { GLYPHS } from "#src/ui/glyphs";
 import { fileSnapshotSource, listNavigableAgents, liveSource, type NavigableSubagent, type TranscriptSource } from "#src/ui/session-navigation";
@@ -130,11 +131,11 @@ export class SessionNavigatorHandler {
 /**
  * Read-only scrollable transcript overlay.
  *
- * Caches a `Container` of Pi's per-entry components and rebuilds it only when the
- * source changes (live agents) — each paint reuses the cached tree, so markdown
- * highlighting does not re-run per frame. This class owns scroll state, chrome,
- * and the running-agent streaming indicator; the component mapping lives in
- * `buildTranscriptComponents`.
+ * Caches the settled transcript's rendered lines per overlay width and rebuilds
+ * Pi's rich per-entry component tree only when messages settle. Streaming deltas
+ * use a lightweight activity row, so paint/scroll stay O(viewport) instead of
+ * O(total transcript). This class owns scroll state, chrome, and live activity;
+ * component mapping lives in `buildTranscriptComponents`.
  */
 export class TranscriptOverlay implements Component {
   private scrollOffset = 0;
@@ -149,6 +150,17 @@ export class TranscriptOverlay implements Component {
   private readonly cwd: string;
   private readonly markdownTheme: MarkdownTheme;
   private content: Container;
+  /** Last inner width supplied by the overlay compositor; input must use this layout. */
+  private renderedInnerWidth: number | undefined;
+  /**
+   * Width-keyed rendering of the settled transcript. Rendering Pi's rich
+   * per-entry components is O(total transcript); keeping those lines stable
+   * makes paint and scroll O(viewport) instead of O(10k+ lines).
+   */
+  private settledLinesCache: { width: number; lines: readonly string[] } | undefined;
+  /** Current assistant message, rendered separately so deltas never touch settled history. */
+  private liveAssistant: AssistantMessageComponent | undefined;
+  private liveAssistantLinesCache: { width: number; lines: readonly string[] } | undefined;
 
   constructor({ tui, theme, source, done, cwd, markdownTheme }: TranscriptOverlayOptions) {
     this.tui = tui;
@@ -158,11 +170,7 @@ export class TranscriptOverlay implements Component {
     this.cwd = cwd;
     this.markdownTheme = markdownTheme;
     this.content = this.rebuild();
-    this.unsubscribe = source.subscribe(() => {
-      if (this.closed) return;
-      this.content = this.rebuild();
-      this.tui.requestRender();
-    });
+    this.unsubscribe = source.subscribe((event) => this.handleSourceChange(event));
   }
 
   handleInput(data: string): void {
@@ -172,7 +180,7 @@ export class TranscriptOverlay implements Component {
       return;
     }
 
-    const totalLines = this.buildContentLines(this.innerWidth()).length;
+    const totalLines = this.contentLineCount(this.renderedInnerWidth ?? this.innerWidth());
     const viewportHeight = this.viewportHeight();
     const maxScroll = Math.max(0, totalLines - viewportHeight);
 
@@ -201,6 +209,7 @@ export class TranscriptOverlay implements Component {
     if (width < 6) return [];
     const th = this.theme;
     const innerW = width - 4;
+    this.renderedInnerWidth = innerW;
     const lines: string[] = [];
 
     const pad = (s: string, len: number): string => s + " ".repeat(Math.max(0, len - visibleWidth(s)));
@@ -214,20 +223,20 @@ export class TranscriptOverlay implements Component {
     lines.push(row(th.bold("Subagent session")));
     lines.push(hrMid);
 
-    const contentLines = this.buildContentLines(innerW);
+    const totalLines = this.contentLineCount(innerW);
     const viewportHeight = this.viewportHeight();
-    const maxScroll = Math.max(0, contentLines.length - viewportHeight);
+    const maxScroll = Math.max(0, totalLines - viewportHeight);
     if (this.autoScroll) this.scrollOffset = maxScroll;
     const visibleStart = Math.min(this.scrollOffset, maxScroll);
-    const visible = contentLines.slice(visibleStart, visibleStart + viewportHeight);
+    const visible = this.visibleContentLines(innerW, visibleStart, viewportHeight);
     for (let i = 0; i < viewportHeight; i++) lines.push(row(visible[i] ?? ""));
 
     lines.push(hrMid);
     const scrollPct =
-      contentLines.length <= viewportHeight
+      totalLines <= viewportHeight
         ? "100%"
-        : `${Math.round(((visibleStart + viewportHeight) / contentLines.length) * 100)}%`;
-    const footerLeft = th.fg("dim", `${contentLines.length} lines · ${scrollPct}`);
+        : `${Math.round(((visibleStart + viewportHeight) / totalLines) * 100)}%`;
+    const footerLeft = th.fg("dim", `${totalLines} lines · ${scrollPct}`);
     const footerRight = th.fg("dim", "↑↓ scroll · PgUp/PgDn · Esc close");
     const footerGap = Math.max(1, innerW - visibleWidth(footerLeft) - visibleWidth(footerRight));
     lines.push(row(footerLeft + " ".repeat(footerGap) + footerRight));
@@ -239,6 +248,9 @@ export class TranscriptOverlay implements Component {
   // fallow-ignore-next-line unused-class-member
   invalidate(): void {
     this.content.invalidate();
+    this.liveAssistant?.invalidate();
+    this.settledLinesCache = undefined;
+    this.liveAssistantLinesCache = undefined;
   }
 
   dispose(): void {
@@ -260,27 +272,130 @@ export class TranscriptOverlay implements Component {
     return Math.max(MIN_VIEWPORT, maxRows - CHROME_LINES);
   }
 
-  private buildContentLines(innerW: number): string[] {
+  /** Settled transcript lines, rendered once per width/content version. */
+  private settledLines(innerW: number): readonly string[] {
     if (innerW <= 0) return [];
-    const lines = this.content.render(innerW);
+    if (this.settledLinesCache?.width === innerW) return this.settledLinesCache.lines;
+    const lines = this.content.render(innerW).map((line) => truncateToWidth(line, innerW));
+    this.settledLinesCache = { width: innerW, lines };
+    return lines;
+  }
+
+  /** Current rich assistant message, re-rendered independently of settled history. */
+  private liveAssistantLines(innerW: number): readonly string[] {
+    if (!this.liveAssistant) return [];
+    if (this.liveAssistantLinesCache?.width === innerW) return this.liveAssistantLinesCache.lines;
+    const lines = this.liveAssistant.render(innerW).map((line) => truncateToWidth(line, innerW));
+    this.liveAssistantLinesCache = { width: innerW, lines };
+    return lines;
+  }
+
+  /** Rich live tail plus lightweight activity rows; settled history stays untouched. */
+  private streamingLines(innerW: number): readonly string[] {
+    const lines = [...this.liveAssistantLines(innerW)];
     const streaming = this.source.streaming();
-    if (streaming) {
-      lines.push(
-        "",
+    if (!streaming) return lines;
+    lines.push(
+      "",
+      truncateToWidth(
         `${GLYPHS.streaming} ${describeActivity(streaming.activeTools, streaming.responseText)}`,
-      );
+        innerW,
+      ),
+    );
+    return lines;
+  }
+
+  private contentLineCount(innerW: number): number {
+    return this.settledLines(innerW).length + this.streamingLines(innerW).length;
+  }
+
+  /**
+   * Slice directly across settled + streaming rows. This avoids copying or
+   * mapping the full transcript on every keypress/paint.
+   */
+  private visibleContentLines(innerW: number, start: number, count: number): string[] {
+    const settled = this.settledLines(innerW);
+    const streaming = this.streamingLines(innerW);
+    const end = start + count;
+    const visible = settled.slice(start, Math.min(end, settled.length));
+    if (end > settled.length) {
+      const streamingStart = Math.max(0, start - settled.length);
+      const streamingEnd = Math.max(0, end - settled.length);
+      visible.push(...streaming.slice(streamingStart, streamingEnd));
     }
-    return lines.map((l) => truncateToWidth(l, innerW));
+    return visible;
+  }
+
+  private handleSourceChange(event?: AgentSessionEvent): void {
+    if (this.closed) return;
+    if (
+      event &&
+      (event.type === "message_start" || event.type === "message_update") &&
+      event.message.role === "assistant"
+    ) {
+      this.updateLiveAssistant(event.message);
+    } else if (eventSettlesTranscript(event)) {
+      this.rebuildSettledContent();
+    }
+    this.tui.requestRender();
+  }
+
+  /**
+   * On the first partial event, split a trailing in-progress assistant message
+   * out of settled history. Later deltas update only this one component.
+   */
+  private updateLiveAssistant(message: AssistantMessage): void {
+    if (!this.liveAssistant) {
+      const messages = this.source.getMessages();
+      const last = messages.at(-1);
+      const lastIsLiveAssistant =
+        last?.role === "assistant" &&
+        (last === message || last.timestamp === message.timestamp);
+      this.content = this.buildComponents(
+        lastIsLiveAssistant ? messages.slice(0, -1) : messages,
+      );
+      this.settledLinesCache = undefined;
+      this.liveAssistant = new AssistantMessageComponent(
+        message,
+        false,
+        this.markdownTheme,
+      );
+    } else {
+      this.liveAssistant.updateContent(message);
+    }
+    this.liveAssistantLinesCache = undefined;
+  }
+
+  private rebuildSettledContent(): void {
+    this.content = this.rebuild();
+    this.liveAssistant = undefined;
+    this.settledLinesCache = undefined;
+    this.liveAssistantLinesCache = undefined;
   }
 
   private rebuild(): Container {
-    return buildTranscriptComponents(this.source.getMessages(), {
+    return this.buildComponents(this.source.getMessages());
+  }
+
+  private buildComponents(messages: readonly SessionMessage[]): Container {
+    return buildTranscriptComponents(messages, {
       tui: this.tui,
       cwd: this.cwd,
       markdownTheme: this.markdownTheme,
       getToolDefinition: (name) => this.source.getToolDefinition(name),
     });
   }
+}
+
+/**
+ * High-frequency partial events are represented by the lightweight streaming
+ * row. Rebuild the rich transcript only when a message is settled, the agent
+ * finishes, or compaction replaces the message history. An undefined event is
+ * treated conservatively for synthetic/static sources used by extensions.
+ */
+function eventSettlesTranscript(event?: AgentSessionEvent): boolean {
+  if (!event) return true;
+  return event.type === "message_end" || event.type === "agent_end" || event.type === "compaction_end";
 }
 
 /** Dependencies the per-entry component tree needs from the SDK/TUI environment. */

--- a/packages/pi-subagents/src/ui/session-navigator.ts
+++ b/packages/pi-subagents/src/ui/session-navigator.ts
@@ -24,13 +24,13 @@ import {
   getMarkdownTheme,
   parseSkillBlock,
   SkillInvocationMessageComponent,
-  type ToolDefinition,
   ToolExecutionComponent,
   UserMessageComponent,
 } from "@earendil-works/pi-coding-agent";
 import {
   type Component,
   Container,
+  type KeyId,
   type MarkdownTheme,
   matchesKey,
   Spacer,
@@ -131,11 +131,12 @@ export class SessionNavigatorHandler {
 /**
  * Read-only scrollable transcript overlay.
  *
- * Caches the settled transcript's rendered lines per overlay width and rebuilds
- * Pi's rich per-entry component tree only when messages settle. Streaming deltas
- * use a lightweight activity row, so paint/scroll stay O(viewport) instead of
- * O(total transcript). This class owns scroll state, chrome, and live activity;
- * component mapping lives in `buildTranscriptComponents`.
+ * The settled transcript is held as per-message blocks of Pi's rich components
+ * (`consumeMessage`), each caching its rendered lines per overlay width. New
+ * messages append blocks, tool results mutate only their own block, and paint
+ * or scroll slices a flat line cache — O(changed message) and O(viewport),
+ * never O(total transcript). This class owns scroll state, chrome, and live
+ * activity.
  */
 export class TranscriptOverlay implements Component {
   private scrollOffset = 0;
@@ -149,17 +150,28 @@ export class TranscriptOverlay implements Component {
   private readonly done: (result: undefined) => void;
   private readonly cwd: string;
   private readonly markdownTheme: MarkdownTheme;
-  private content: Container;
   /** Last inner width supplied by the overlay compositor; input must use this layout. */
   private renderedInnerWidth: number | undefined;
-  /**
-   * Width-keyed rendering of the settled transcript. Rendering Pi's rich
-   * per-entry components is O(total transcript); keeping those lines stable
-   * makes paint and scroll O(viewport) instead of O(10k+ lines).
-   */
-  private settledLinesCache: { width: number; lines: readonly string[] } | undefined;
+  /** Settled transcript as per-message component blocks, appended in message order. */
+  private settledBlocks: SettledBlock[] = [];
+  /** How many source messages have been consumed into `settledBlocks`. */
+  private settledCount = 0;
+  /** Identity guard: the last consumed message; a mismatch means history was rewritten. */
+  private lastConsumed: SessionMessage | undefined;
+  /** Whether any consumed block holds visible components (drives user-message spacing). */
+  private hasVisibleContent = false;
+  /** Width the block line caches were rendered at. */
+  private settledWidth: number | undefined;
+  /** Concatenation of every block's cached lines at `settledWidth`. */
+  private settledFlat: readonly string[] | undefined;
+  /** In-flight tool components by toolCallId, pairing later results to their block. */
+  private readonly pendingTools = new Map<
+    string,
+    { component: ToolExecutionComponent; block: SettledBlock }
+  >();
   /** Current assistant message, rendered separately so deltas never touch settled history. */
   private liveAssistant: AssistantMessageComponent | undefined;
+  private liveMessage: AssistantMessage | undefined;
   private liveAssistantLinesCache: { width: number; lines: readonly string[] } | undefined;
 
   constructor({ tui, theme, source, done, cwd, markdownTheme }: TranscriptOverlayOptions) {
@@ -169,7 +181,7 @@ export class TranscriptOverlay implements Component {
     this.done = done;
     this.cwd = cwd;
     this.markdownTheme = markdownTheme;
-    this.content = this.rebuild();
+    this.consumeNewSettled();
     this.unsubscribe = source.subscribe((event) => this.handleSourceChange(event));
   }
 
@@ -181,28 +193,14 @@ export class TranscriptOverlay implements Component {
     }
 
     const totalLines = this.contentLineCount(this.renderedInnerWidth ?? this.innerWidth());
-    const viewportHeight = this.viewportHeight();
-    const maxScroll = Math.max(0, totalLines - viewportHeight);
+    const viewport = this.viewportHeight();
+    const maxScroll = Math.max(0, totalLines - viewport);
 
-    if (matchesKey(data, "up") || matchesKey(data, "k")) {
-      this.scrollOffset = Math.max(0, this.scrollOffset - 1);
-      this.autoScroll = this.scrollOffset >= maxScroll;
-    } else if (matchesKey(data, "down") || matchesKey(data, "j")) {
-      this.scrollOffset = Math.min(maxScroll, this.scrollOffset + 1);
-      this.autoScroll = this.scrollOffset >= maxScroll;
-    } else if (matchesKey(data, "pageUp") || matchesKey(data, "shift+up")) {
-      this.scrollOffset = Math.max(0, this.scrollOffset - viewportHeight);
-      this.autoScroll = false;
-    } else if (matchesKey(data, "pageDown") || matchesKey(data, "shift+down")) {
-      this.scrollOffset = Math.min(maxScroll, this.scrollOffset + viewportHeight);
-      this.autoScroll = this.scrollOffset >= maxScroll;
-    } else if (matchesKey(data, "home")) {
-      this.scrollOffset = 0;
-      this.autoScroll = false;
-    } else if (matchesKey(data, "end")) {
-      this.scrollOffset = maxScroll;
-      this.autoScroll = true;
-    }
+    const binding = SCROLL_BINDINGS.find(({ keys }) => keys.some((key) => matchesKey(data, key)));
+    if (!binding) return;
+    const next = binding.next({ offset: this.scrollOffset, maxScroll, viewport });
+    this.scrollOffset = next.offset;
+    this.autoScroll = next.autoScroll;
   }
 
   render(width: number): string[] {
@@ -247,9 +245,12 @@ export class TranscriptOverlay implements Component {
 
   // fallow-ignore-next-line unused-class-member
   invalidate(): void {
-    this.content.invalidate();
+    for (const block of this.settledBlocks) {
+      block.container.invalidate();
+      block.lines = undefined;
+    }
+    this.settledFlat = undefined;
     this.liveAssistant?.invalidate();
-    this.settledLinesCache = undefined;
     this.liveAssistantLinesCache = undefined;
   }
 
@@ -272,13 +273,22 @@ export class TranscriptOverlay implements Component {
     return Math.max(MIN_VIEWPORT, maxRows - CHROME_LINES);
   }
 
-  /** Settled transcript lines, rendered once per width/content version. */
+  /** Settled transcript lines; each block renders once per width/content version. */
   private settledLines(innerW: number): readonly string[] {
     if (innerW <= 0) return [];
-    if (this.settledLinesCache?.width === innerW) return this.settledLinesCache.lines;
-    const lines = this.content.render(innerW).map((line) => truncateToWidth(line, innerW));
-    this.settledLinesCache = { width: innerW, lines };
-    return lines;
+    if (this.settledWidth !== innerW) {
+      this.settledWidth = innerW;
+      for (const block of this.settledBlocks) block.lines = undefined;
+      this.settledFlat = undefined;
+    }
+    if (this.settledFlat) return this.settledFlat;
+    const flat: string[] = [];
+    for (const block of this.settledBlocks) {
+      block.lines ??= block.container.render(innerW).map((line) => truncateToWidth(line, innerW));
+      for (const line of block.lines) flat.push(line);
+    }
+    this.settledFlat = flat;
+    return flat;
   }
 
   /** Current rich assistant message, re-rendered independently of settled history. */
@@ -328,171 +338,251 @@ export class TranscriptOverlay implements Component {
 
   private handleSourceChange(event?: AgentSessionEvent): void {
     if (this.closed) return;
-    if (
-      event &&
-      (event.type === "message_start" || event.type === "message_update") &&
-      event.message.role === "assistant"
-    ) {
-      this.updateLiveAssistant(event.message);
-    } else if (eventSettlesTranscript(event)) {
-      this.rebuildSettledContent();
-    }
+    this.applySourceEvent(event);
     this.tui.requestRender();
   }
 
+  /** Route one session event to the narrowest settled/live update. */
+  private applySourceEvent(event?: AgentSessionEvent): void {
+    if (!event || event.type === "agent_end" || event.type === "compaction_end") {
+      // Catch-alls: run/compaction boundaries may rewrite or mutate history
+      // in place, and event-less sources give no narrower signal.
+      this.resetSettledContent();
+      return;
+    }
+    if (event.type === "message_start" || event.type === "message_update") {
+      this.applyPartialMessage(event.message);
+      return;
+    }
+    // Any other session event is a cheap catch-up: consume messages that
+    // settled since the last check, or no-op when nothing is new.
+    if (event.type === "message_end" && this.isLiveMessage(event.message)) {
+      this.clearLiveAssistant();
+    }
+    this.consumeNewSettled();
+  }
+
+  /** A partial for the in-flight assistant updates the live component; other roles settle. */
+  private applyPartialMessage(message: SessionMessage): void {
+    if (message.role === "assistant") this.updateLiveAssistant(message);
+    else this.consumeNewSettled();
+  }
+
   /**
-   * On the first partial event, split a trailing in-progress assistant message
-   * out of settled history. Later deltas update only this one component.
+   * On the first partial event, mount the in-progress assistant message as its
+   * own rich component. Later deltas update only this one component; the
+   * settled prefix is caught up once, not per token.
    */
   private updateLiveAssistant(message: AssistantMessage): void {
     if (!this.liveAssistant) {
-      const messages = this.source.getMessages();
-      const last = messages.at(-1);
-      const lastIsLiveAssistant =
-        last?.role === "assistant" &&
-        (last === message || last.timestamp === message.timestamp);
-      this.content = this.buildComponents(
-        lastIsLiveAssistant ? messages.slice(0, -1) : messages,
-      );
-      this.settledLinesCache = undefined;
-      this.liveAssistant = new AssistantMessageComponent(
-        message,
-        false,
-        this.markdownTheme,
-      );
+      this.consumeNewSettled();
+      this.liveAssistant = new AssistantMessageComponent(message, false, this.markdownTheme);
     } else {
       this.liveAssistant.updateContent(message);
     }
+    this.liveMessage = message;
     this.liveAssistantLinesCache = undefined;
   }
 
-  private rebuildSettledContent(): void {
-    this.content = this.rebuild();
+  private isLiveMessage(message: SessionMessage): boolean {
+    if (!this.liveMessage || message.role !== "assistant") return false;
+    return message === this.liveMessage || message.timestamp === this.liveMessage.timestamp;
+  }
+
+  private clearLiveAssistant(): void {
     this.liveAssistant = undefined;
-    this.settledLinesCache = undefined;
+    this.liveMessage = undefined;
     this.liveAssistantLinesCache = undefined;
   }
 
-  private rebuild(): Container {
-    return this.buildComponents(this.source.getMessages());
+  /** Drop all settled state and re-consume the source from scratch. */
+  private resetSettledContent(): void {
+    this.settledBlocks = [];
+    this.settledCount = 0;
+    this.lastConsumed = undefined;
+    this.hasVisibleContent = false;
+    this.settledFlat = undefined;
+    this.pendingTools.clear();
+    this.clearLiveAssistant();
+    this.consumeNewSettled();
   }
 
-  private buildComponents(messages: readonly SessionMessage[]): Container {
-    return buildTranscriptComponents(messages, {
-      tui: this.tui,
-      cwd: this.cwd,
-      markdownTheme: this.markdownTheme,
-      getToolDefinition: (name) => this.source.getToolDefinition(name),
-    });
+  /**
+   * Append blocks for messages settled since the last check. The agent runtime
+   * pushes a message into its state before emitting `message_end`, so at event
+   * time the settled prefix is already visible through `getMessages()`.
+   */
+  private consumeNewSettled(): void {
+    const messages = this.source.getMessages();
+    if (
+      this.settledCount > messages.length ||
+      (this.settledCount > 0 && messages[this.settledCount - 1] !== this.lastConsumed)
+    ) {
+      // The consumed prefix no longer mirrors the source: history was
+      // rewritten wholesale (e.g. compaction/branching). Start over.
+      this.resetSettledContent();
+      return;
+    }
+    let end = messages.length;
+    if (end > this.settledCount && this.isLiveMessage(messages[end - 1])) end -= 1;
+    if (end === this.settledCount) return;
+    for (let i = this.settledCount; i < end; i++) this.consumeMessage(messages[i]);
+    this.settledCount = end;
+    this.lastConsumed = messages[end - 1];
+    this.settledFlat = undefined;
+  }
+
+  /**
+   * Map one settled message onto Pi's per-entry components, mirroring Pi's own
+   * interactive-mode `renderSessionContext` mapping. Tool results are matched
+   * to their tool-call components by id, exactly as Pi does. `custom`-role
+   * messages are skipped — rendering them needs the child session's
+   * message-renderer registry, which the navigator does not hold.
+   */
+  private consumeMessage(message: SessionMessage): void {
+    switch (message.role) {
+      case "assistant":
+        this.consumeAssistantMessage(message);
+        break;
+      case "toolResult":
+        this.consumeToolResult(message);
+        break;
+      case "user":
+        this.consumeUserMessage(message);
+        break;
+      case "bashExecution":
+        this.consumeBashExecution(message);
+        break;
+      case "compactionSummary":
+        this.consumeSummary(new CompactionSummaryMessageComponent(message, this.markdownTheme));
+        break;
+      case "branchSummary":
+        this.consumeSummary(new BranchSummaryMessageComponent(message, this.markdownTheme));
+        break;
+    }
+  }
+
+  private consumeAssistantMessage(message: AssistantMessage): void {
+    const block = this.newBlock();
+    block.container.addChild(new AssistantMessageComponent(message, false, this.markdownTheme));
+    for (const content of message.content) {
+      if (content.type !== "toolCall") continue;
+      const tool = new ToolExecutionComponent(
+        content.name,
+        content.id,
+        content.arguments,
+        { showImages: false },
+        this.source.getToolDefinition(content.name),
+        this.tui,
+        this.cwd,
+      );
+      tool.setExpanded(true);
+      block.container.addChild(tool);
+      this.pendingTools.set(content.id, { component: tool, block });
+    }
+    this.hasVisibleContent = true;
+  }
+
+  private consumeToolResult(message: Extract<SessionMessage, { role: "toolResult" }>): void {
+    const entry = this.pendingTools.get(message.toolCallId);
+    if (!entry) return;
+    entry.component.updateResult(message);
+    entry.block.lines = undefined;
+    this.settledFlat = undefined;
+    this.pendingTools.delete(message.toolCallId);
+  }
+
+  private consumeUserMessage(message: Extract<SessionMessage, { role: "user" }>): void {
+    const block = this.newBlock();
+    addUserComponents(block.container, message.content, this.markdownTheme, this.hasVisibleContent);
+    if (block.container.children.length > 0) this.hasVisibleContent = true;
+  }
+
+  private consumeBashExecution(message: Extract<SessionMessage, { role: "bashExecution" }>): void {
+    const block = this.newBlock();
+    const bash = new BashExecutionComponent(message.command, this.tui, message.excludeFromContext);
+    if (message.output) bash.appendOutput(message.output);
+    bash.setComplete(message.exitCode, message.cancelled, undefined, message.fullOutputPath);
+    block.container.addChild(bash);
+    this.hasVisibleContent = true;
+  }
+
+  /** Compaction and branch summaries share the same spacer + expanded-block shape. */
+  private consumeSummary(
+    summary: CompactionSummaryMessageComponent | BranchSummaryMessageComponent,
+  ): void {
+    const block = this.newBlock();
+    block.container.addChild(new Spacer(1));
+    summary.setExpanded(true);
+    block.container.addChild(summary);
+    this.hasVisibleContent = true;
+  }
+
+  private newBlock(): SettledBlock {
+    const block: SettledBlock = { container: new Container(), lines: undefined };
+    this.settledBlocks.push(block);
+    return block;
   }
 }
 
-/**
- * High-frequency partial events are represented by the lightweight streaming
- * row. Rebuild the rich transcript only when a message is settled, the agent
- * finishes, or compaction replaces the message history. An undefined event is
- * treated conservatively for synthetic/static sources used by extensions.
- */
-function eventSettlesTranscript(event?: AgentSessionEvent): boolean {
-  if (!event) return true;
-  return event.type === "message_end" || event.type === "agent_end" || event.type === "compaction_end";
+/** One consumed message's rich components plus its width-cached rendered lines. */
+interface SettledBlock {
+  container: Container;
+  lines: readonly string[] | undefined;
 }
 
-/** Dependencies the per-entry component tree needs from the SDK/TUI environment. */
-interface TranscriptRenderOptions {
-  tui: TUI;
-  cwd: string;
-  markdownTheme: MarkdownTheme;
-  getToolDefinition: (name: string) => ToolDefinition | undefined;
+/** Inputs a scroll binding needs to produce the next scroll state. */
+interface ScrollContext {
+  offset: number;
+  maxScroll: number;
+  viewport: number;
 }
 
-/**
- * Build a `Container` of Pi's per-entry components from a message snapshot,
- * mirroring Pi's own interactive-mode `renderSessionContext` mapping. Tool
- * results are matched to their tool-call components by id, exactly as Pi does.
- * `custom`-role messages are skipped — rendering them needs the child session's
- * message-renderer registry, which the navigator does not hold.
- */
-function buildTranscriptComponents(
-  messages: readonly SessionMessage[],
-  opts: TranscriptRenderOptions,
-): Container {
-  const container = new Container();
-  const pendingTools = new Map<string, ToolExecutionComponent>();
-  for (const message of messages) {
-    addMessageComponents(container, message, pendingTools, opts);
-  }
-  return container;
+interface ScrollState {
+  offset: number;
+  autoScroll: boolean;
 }
 
-function addMessageComponents(
-  container: Container,
-  message: SessionMessage,
-  pendingTools: Map<string, ToolExecutionComponent>,
-  opts: TranscriptRenderOptions,
-): void {
-  switch (message.role) {
-    case "assistant": {
-      container.addChild(new AssistantMessageComponent(message, false, opts.markdownTheme));
-      for (const content of message.content) {
-        if (content.type !== "toolCall") continue;
-        const tool = new ToolExecutionComponent(
-          content.name,
-          content.id,
-          content.arguments,
-          { showImages: false },
-          opts.getToolDefinition(content.name),
-          opts.tui,
-          opts.cwd,
-        );
-        tool.setExpanded(true);
-        container.addChild(tool);
-        pendingTools.set(content.id, tool);
-      }
-      break;
-    }
-    case "toolResult": {
-      pendingTools.get(message.toolCallId)?.updateResult(message);
-      pendingTools.delete(message.toolCallId);
-      break;
-    }
-    case "user": {
-      addUserComponents(container, message.content, opts.markdownTheme);
-      break;
-    }
-    case "bashExecution": {
-      const bash = new BashExecutionComponent(message.command, opts.tui, message.excludeFromContext);
-      if (message.output) bash.appendOutput(message.output);
-      bash.setComplete(message.exitCode, message.cancelled, undefined, message.fullOutputPath);
-      container.addChild(bash);
-      break;
-    }
-    case "compactionSummary": {
-      container.addChild(new Spacer(1));
-      const summary = new CompactionSummaryMessageComponent(message, opts.markdownTheme);
-      summary.setExpanded(true);
-      container.addChild(summary);
-      break;
-    }
-    case "branchSummary": {
-      container.addChild(new Spacer(1));
-      const summary = new BranchSummaryMessageComponent(message, opts.markdownTheme);
-      summary.setExpanded(true);
-      container.addChild(summary);
-      break;
-    }
-  }
+/** Clamped offset with auto-scroll re-armed whenever it reaches the bottom. */
+function scrolledTo(offset: number, maxScroll: number): ScrollState {
+  return { offset, autoScroll: offset >= maxScroll };
 }
+
+/** Keyboard bindings for the transcript viewport, applied over the rendered layout. */
+const SCROLL_BINDINGS: ReadonlyArray<{
+  keys: readonly KeyId[];
+  next: (context: ScrollContext) => ScrollState;
+}> = [
+  {
+    keys: ["up", "k"],
+    next: ({ offset, maxScroll }) => scrolledTo(Math.max(0, offset - 1), maxScroll),
+  },
+  {
+    keys: ["down", "j"],
+    next: ({ offset, maxScroll }) => scrolledTo(Math.min(maxScroll, offset + 1), maxScroll),
+  },
+  {
+    keys: ["pageUp", "shift+up"],
+    next: ({ offset, viewport }) => ({ offset: Math.max(0, offset - viewport), autoScroll: false }),
+  },
+  {
+    keys: ["pageDown", "shift+down"],
+    next: ({ offset, maxScroll, viewport }) => scrolledTo(Math.min(maxScroll, offset + viewport), maxScroll),
+  },
+  { keys: ["home"], next: () => ({ offset: 0, autoScroll: false }) },
+  { keys: ["end"], next: ({ maxScroll }) => ({ offset: maxScroll, autoScroll: true }) },
+];
 
 /** Render a user message (skill block + text) into the container, mirroring Pi. */
 function addUserComponents(
   container: Container,
   content: string | readonly { type: string; text?: string }[],
   markdownTheme: MarkdownTheme,
+  hasPrecedingContent: boolean,
 ): void {
   const text = userMessageText(content);
   if (!text) return;
-  if (container.children.length > 0) container.addChild(new Spacer(1));
+  if (hasPrecedingContent) container.addChild(new Spacer(1));
 
   const skillBlock = parseSkillBlock(text);
   if (!skillBlock) {

--- a/packages/pi-subagents/test/ui/session-navigation.test.ts
+++ b/packages/pi-subagents/test/ui/session-navigation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { AgentTypeRegistry } from "#src/config/agent-types";
-import type { SessionMessage } from "#src/types";
+import type { AgentSessionEvent, SessionMessage } from "#src/types";
 import { fileSnapshotSource, listNavigableAgents, liveSource, type NavigableSubagent, type TranscriptSource } from "#src/ui/session-navigation";
 import { makeNavigable } from "#test/helpers/make-navigable";
 
@@ -80,8 +80,9 @@ describe("liveSource", () => {
     const onChange = vi.fn();
     const returned = liveSource(record).subscribe(onChange);
     expect(record.subscribeToUpdates).toHaveBeenCalledOnce();
-    captured?.({ type: "turn_end" });
-    expect(onChange).toHaveBeenCalledOnce();
+    const event = { type: "turn_end" } as AgentSessionEvent;
+    captured?.(event);
+    expect(onChange).toHaveBeenCalledWith(event);
     expect(returned).toBe(unsub);
   });
 

--- a/packages/pi-subagents/test/ui/session-navigator.test.ts
+++ b/packages/pi-subagents/test/ui/session-navigator.test.ts
@@ -1,8 +1,8 @@
 import { getMarkdownTheme, initTheme } from "@earendil-works/pi-coding-agent";
-import type { Component, TUI } from "@earendil-works/pi-tui";
+import { type Component, Container, type TUI } from "@earendil-works/pi-tui";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { AgentTypeRegistry } from "#src/config/agent-types";
-import type { SessionMessage } from "#src/types";
+import type { AgentSessionEvent, SessionMessage } from "#src/types";
 import type { TranscriptSource } from "#src/ui/session-navigation";
 import { SessionNavigatorHandler, TranscriptOverlay } from "#src/ui/session-navigator";
 import { makeNavigable } from "#test/helpers/make-navigable";
@@ -32,6 +32,27 @@ function fakeSource(overrides: Partial<TranscriptSource> = {}): TranscriptSource
     getToolDefinition: () => undefined,
     ...overrides,
   };
+}
+
+
+function assistantSessionEvent(
+  type: "message_start" | "message_update" | "message_end",
+  content: { type: "text"; text: string } | { type: "thinking"; thinking: string },
+  timestamp = 1,
+): AgentSessionEvent {
+  const message = {
+    role: "assistant",
+    content: [content],
+    stopReason: "stop",
+    timestamp,
+  };
+  if (type !== "message_update") return { type, message } as unknown as AgentSessionEvent;
+  const delta = content.type === "text" ? content.text : content.thinking;
+  const assistantMessageEvent = {
+    type: content.type === "text" ? "text_delta" : "thinking_delta",
+    delta,
+  };
+  return { type, message, assistantMessageEvent } as unknown as AgentSessionEvent;
 }
 
 function makeOverlay(opts: { source?: TranscriptSource; done?: (r: undefined) => void; tui?: TUI } = {}) {
@@ -119,7 +140,7 @@ describe("TranscriptOverlay", () => {
 
   it("rebuilds the component tree when the source changes", () => {
     let messages = [{ role: "user", content: "first" }] as unknown as SessionMessage[];
-    let captured: (() => void) | undefined;
+    let captured: ((event?: AgentSessionEvent) => void) | undefined;
     const source = fakeSource({
       getMessages: () => messages,
       subscribe: (onChange) => {
@@ -130,8 +151,157 @@ describe("TranscriptOverlay", () => {
     const overlay = makeOverlay({ source });
     expect(overlay.render(80).join("\n")).toContain("first");
     messages = [{ role: "user", content: "second" }] as unknown as SessionMessage[];
-    captured?.();
+    captured?.({ type: "message_end" } as AgentSessionEvent);
     expect(overlay.render(80).join("\n")).toContain("second");
+  });
+
+  describe("large-transcript performance invariants", () => {
+    it("reuses rendered transcript lines across paints and scrolling at the same width", () => {
+      const messages = Array.from(
+        { length: 200 },
+        (_, i) => ({ role: "user", content: `message ${i}\n${"body\n".repeat(20)}` }),
+      ) as unknown as SessionMessage[];
+      // Overlay renders at 90% of the terminal width in production. Keep the
+      // terminal wider than the component width so input must reuse the actual
+      // rendered layout rather than recomputing at terminal width.
+      const overlay = makeOverlay({
+        source: fakeSource({ getMessages: () => messages }),
+        tui: mockTui(40, 160),
+      });
+      const containerRender = vi.spyOn(Container.prototype, "render");
+      try {
+        const initialOutput = overlay.render(80);
+        const initialRenderCalls = containerRender.mock.calls.length;
+
+        overlay.render(80);
+        overlay.handleInput("\x1b[A");
+        const scrolledOutput = overlay.render(80);
+
+        expect(containerRender).toHaveBeenCalledTimes(initialRenderCalls);
+        expect(scrolledOutput).not.toEqual(initialOutput);
+      } finally {
+        containerRender.mockRestore();
+      }
+    });
+
+    it("invalidates rendered transcript lines when width changes", () => {
+      const overlay = makeOverlay();
+      const containerRender = vi.spyOn(Container.prototype, "render");
+      try {
+        overlay.render(80);
+        const initialRenderCalls = containerRender.mock.calls.length;
+
+        overlay.render(100);
+
+        expect(containerRender.mock.calls.length).toBeGreaterThan(initialRenderCalls);
+      } finally {
+        containerRender.mockRestore();
+      }
+    });
+
+    it("does not rebuild the transcript tree for high-frequency streaming updates", () => {
+      const tui = mockTui();
+      const getMessages = vi.fn(
+        () => [{ role: "user", content: "stable" }] as unknown as SessionMessage[],
+      );
+      let captured: ((event: AgentSessionEvent) => void) | undefined;
+      const source = fakeSource({
+        getMessages,
+        subscribe: (onChange) => {
+          captured = onChange;
+          return () => {};
+        },
+      });
+      makeOverlay({ source, tui });
+      captured?.(assistantSessionEvent("message_start", { type: "text", text: "" }));
+      const setupMessageReads = getMessages.mock.calls.length;
+
+      captured?.(assistantSessionEvent("message_update", { type: "text", text: "token" }));
+      captured?.({ type: "tool_execution_update" } as AgentSessionEvent);
+
+      expect(getMessages).toHaveBeenCalledTimes(setupMessageReads);
+      expect(tui.requestRender).toHaveBeenCalledTimes(3);
+    });
+
+
+    it("keeps the lightweight streaming row live while settled transcript lines stay cached", () => {
+      let responseText = "first token";
+      let captured: ((event: AgentSessionEvent) => void) | undefined;
+      const getMessages = vi.fn(
+        () => [{ role: "user", content: "settled" }] as unknown as SessionMessage[],
+      );
+      const source = fakeSource({
+        getMessages,
+        streaming: () => ({ activeTools: new Map(), responseText }),
+        subscribe: (onChange) => {
+          captured = onChange;
+          return () => {};
+        },
+      });
+      const overlay = makeOverlay({ source });
+      expect(overlay.render(80).join("\n")).toContain("first token");
+
+      responseText = "second token";
+      captured?.({ type: "tool_execution_update" } as AgentSessionEvent);
+
+      expect(overlay.render(80).join("\n")).toContain("second token");
+      expect(getMessages).toHaveBeenCalledOnce();
+    });
+
+
+    it("streams the current rich assistant message without rebuilding settled history", () => {
+      let captured: ((event: AgentSessionEvent) => void) | undefined;
+      const getMessages = vi.fn(
+        () => [{ role: "user", content: "settled history" }] as unknown as SessionMessage[],
+      );
+      const source = fakeSource({
+        getMessages,
+        streaming: () => ({ activeTools: new Map(), responseText: "" }),
+        subscribe: (onChange) => {
+          captured = onChange;
+          return () => {};
+        },
+      });
+      const overlay = makeOverlay({ source });
+      captured?.(assistantSessionEvent("message_start", { type: "thinking", thinking: "" }));
+      captured?.(
+        assistantSessionEvent("message_update", {
+          type: "thinking",
+          thinking: "live full thinking block",
+        }),
+      );
+      const setupMessageReads = getMessages.mock.calls.length;
+
+      expect(overlay.render(80).join("\n")).toContain("live full thinking block");
+
+      captured?.(
+        assistantSessionEvent("message_update", {
+          type: "thinking",
+          thinking: "updated full thinking block",
+        }),
+      );
+      expect(overlay.render(80).join("\n")).toContain("updated full thinking block");
+      expect(getMessages).toHaveBeenCalledTimes(setupMessageReads);
+    });
+
+    it("does rebuild the transcript tree when a message settles", () => {
+      const getMessages = vi.fn(
+        () => [{ role: "user", content: "stable" }] as unknown as SessionMessage[],
+      );
+      let captured: ((event: AgentSessionEvent) => void) | undefined;
+      const source = fakeSource({
+        getMessages,
+        subscribe: (onChange) => {
+          captured = onChange;
+          return () => {};
+        },
+      });
+      makeOverlay({ source });
+
+      captured?.({ type: "message_end" } as AgentSessionEvent);
+
+      expect(getMessages).toHaveBeenCalledTimes(2);
+    });
   });
 });
 

--- a/packages/pi-subagents/test/ui/session-navigator.test.ts
+++ b/packages/pi-subagents/test/ui/session-navigator.test.ts
@@ -201,9 +201,8 @@ describe("TranscriptOverlay", () => {
 
     it("does not rebuild the transcript tree for high-frequency streaming updates", () => {
       const tui = mockTui();
-      const getMessages = vi.fn(
-        () => [{ role: "user", content: "stable" }] as unknown as SessionMessage[],
-      );
+      const messages = [{ role: "user", content: "stable" }] as unknown as SessionMessage[];
+      const getMessages = vi.fn(() => messages);
       let captured: ((event: AgentSessionEvent) => void) | undefined;
       const source = fakeSource({
         getMessages,
@@ -217,7 +216,7 @@ describe("TranscriptOverlay", () => {
       const setupMessageReads = getMessages.mock.calls.length;
 
       captured?.(assistantSessionEvent("message_update", { type: "text", text: "token" }));
-      captured?.({ type: "tool_execution_update" } as AgentSessionEvent);
+      captured?.(assistantSessionEvent("message_update", { type: "text", text: "token two" }));
 
       expect(getMessages).toHaveBeenCalledTimes(setupMessageReads);
       expect(tui.requestRender).toHaveBeenCalledTimes(3);
@@ -227,11 +226,9 @@ describe("TranscriptOverlay", () => {
     it("keeps the lightweight streaming row live while settled transcript lines stay cached", () => {
       let responseText = "first token";
       let captured: ((event: AgentSessionEvent) => void) | undefined;
-      const getMessages = vi.fn(
-        () => [{ role: "user", content: "settled" }] as unknown as SessionMessage[],
-      );
+      const messages = [{ role: "user", content: "settled" }] as unknown as SessionMessage[];
       const source = fakeSource({
-        getMessages,
+        getMessages: () => messages,
         streaming: () => ({ activeTools: new Map(), responseText }),
         subscribe: (onChange) => {
           captured = onChange;
@@ -241,11 +238,16 @@ describe("TranscriptOverlay", () => {
       const overlay = makeOverlay({ source });
       expect(overlay.render(80).join("\n")).toContain("first token");
 
-      responseText = "second token";
-      captured?.({ type: "tool_execution_update" } as AgentSessionEvent);
+      const containerRender = vi.spyOn(Container.prototype, "render");
+      try {
+        responseText = "second token";
+        captured?.({ type: "tool_execution_update" } as AgentSessionEvent);
 
-      expect(overlay.render(80).join("\n")).toContain("second token");
-      expect(getMessages).toHaveBeenCalledOnce();
+        expect(overlay.render(80).join("\n")).toContain("second token");
+        expect(containerRender).not.toHaveBeenCalled();
+      } finally {
+        containerRender.mockRestore();
+      }
     });
 
 
@@ -284,23 +286,170 @@ describe("TranscriptOverlay", () => {
       expect(getMessages).toHaveBeenCalledTimes(setupMessageReads);
     });
 
-    it("does rebuild the transcript tree when a message settles", () => {
-      const getMessages = vi.fn(
-        () => [{ role: "user", content: "stable" }] as unknown as SessionMessage[],
-      );
+    it("consumes newly settled messages when a message settles", () => {
+      const messages = [{ role: "user", content: "stable" }] as unknown as SessionMessage[];
       let captured: ((event: AgentSessionEvent) => void) | undefined;
       const source = fakeSource({
-        getMessages,
+        getMessages: () => messages,
         subscribe: (onChange) => {
           captured = onChange;
           return () => {};
         },
       });
-      makeOverlay({ source });
+      const overlay = makeOverlay({ source });
+      overlay.render(80);
 
-      captured?.({ type: "message_end" } as AgentSessionEvent);
+      const settled = { role: "user", content: "just settled" } as unknown as SessionMessage;
+      messages.push(settled);
+      captured?.({ type: "message_end", message: settled } as unknown as AgentSessionEvent);
 
-      expect(getMessages).toHaveBeenCalledTimes(2);
+      expect(overlay.render(80).join("\n")).toContain("just settled");
+    });
+  });
+
+  describe("incremental settlement", () => {
+    function liveFixture(initial: SessionMessage[]) {
+      const messages = initial;
+      let captured: ((event?: AgentSessionEvent) => void) | undefined;
+      const source = fakeSource({
+        getMessages: () => messages,
+        subscribe: (onChange) => {
+          captured = onChange;
+          return () => {};
+        },
+      });
+      return {
+        messages,
+        source,
+        emit: (event: AgentSessionEvent | undefined) => captured?.(event),
+      };
+    }
+
+    it("renders only the newly settled message's components when a message settles", () => {
+      const fixture = liveFixture(
+        Array.from(
+          { length: 200 },
+          (_, i) => ({ role: "user", content: `message ${i}\n${"body\n".repeat(20)}` }),
+        ) as unknown as SessionMessage[],
+      );
+      const overlay = makeOverlay({ source: fixture.source, tui: mockTui(40, 160) });
+      overlay.render(80);
+
+      const containerRender = vi.spyOn(Container.prototype, "render");
+      try {
+        const settled = { role: "user", content: "fresh settled message" } as unknown as SessionMessage;
+        fixture.messages.push(settled);
+        fixture.emit({ type: "message_end", message: settled } as unknown as AgentSessionEvent);
+
+        expect(overlay.render(80).join("\n")).toContain("fresh settled message");
+        expect(containerRender.mock.calls.length).toBeLessThanOrEqual(4);
+      } finally {
+        containerRender.mockRestore();
+      }
+    });
+
+    it("updates only the affected tool block when its result settles", () => {
+      const assistant = {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "tc-1", name: "read", arguments: { path: "/x.ts" } }],
+        stopReason: "toolUse",
+        timestamp: 1,
+      } as unknown as SessionMessage;
+      const padding = Array.from(
+        { length: 50 },
+        (_, i) => ({ role: "user", content: `filler ${i}` }),
+      ) as unknown as SessionMessage[];
+      const fixture = liveFixture([...padding, assistant]);
+      const overlay = makeOverlay({ source: fixture.source, tui: mockTui(40, 160) });
+      const before = overlay.render(80).join("\n");
+
+      const containerRender = vi.spyOn(Container.prototype, "render");
+      try {
+        const result = {
+          role: "toolResult",
+          toolCallId: "tc-1",
+          toolName: "read",
+          content: [{ type: "text", text: "tool result body" }],
+          isError: false,
+        } as unknown as SessionMessage;
+        fixture.messages.push(result);
+        fixture.emit({ type: "message_end", message: result } as unknown as AgentSessionEvent);
+
+        const after = overlay.render(80).join("\n");
+        expect(after).not.toEqual(before);
+        expect(containerRender.mock.calls.length).toBeLessThanOrEqual(4);
+      } finally {
+        containerRender.mockRestore();
+      }
+    });
+
+    it("produces the same lines as a freshly built overlay after incremental settles", () => {
+      const user = (text: string) => ({ role: "user", content: text }) as unknown as SessionMessage;
+      const assistant = {
+        role: "assistant",
+        content: [
+          { type: "text", text: "let me read that" },
+          { type: "toolCall", id: "tc-9", name: "read", arguments: { path: "/y.ts" } },
+        ],
+        stopReason: "toolUse",
+        timestamp: 5,
+      } as unknown as SessionMessage;
+      const result = {
+        role: "toolResult",
+        toolCallId: "tc-9",
+        toolName: "read",
+        content: [{ type: "text", text: "y file body" }],
+        isError: false,
+      } as unknown as SessionMessage;
+      const fixture = liveFixture([user("alpha")]);
+      const overlay = makeOverlay({ source: fixture.source });
+      overlay.render(80);
+
+      for (const settled of [assistant, result, user("beta"), user("gamma")]) {
+        fixture.messages.push(settled);
+        fixture.emit({ type: "message_end", message: settled } as unknown as AgentSessionEvent);
+      }
+
+      const fresh = makeOverlay({
+        source: fakeSource({ getMessages: () => fixture.messages }),
+      });
+      expect(overlay.render(80)).toEqual(fresh.render(80));
+    });
+
+    it("re-renders settled history on agent_end to capture in-place mutations", () => {
+      const message = { role: "user", content: "before mutation" } as unknown as SessionMessage;
+      const fixture = liveFixture([message]);
+      const overlay = makeOverlay({ source: fixture.source });
+      expect(overlay.render(80).join("\n")).toContain("before mutation");
+
+      (message as unknown as { content: string }).content = "after mutation";
+      fixture.emit({ type: "agent_end" } as unknown as AgentSessionEvent);
+
+      expect(overlay.render(80).join("\n")).toContain("after mutation");
+    });
+
+    it("falls back to a full rebuild when settled history shrinks under the overlay", () => {
+      let messages = [
+        { role: "user", content: "one" },
+        { role: "user", content: "two" },
+      ] as unknown as SessionMessage[];
+      let captured: ((event?: AgentSessionEvent) => void) | undefined;
+      const source = fakeSource({
+        getMessages: () => messages,
+        subscribe: (onChange) => {
+          captured = onChange;
+          return () => {};
+        },
+      });
+      const overlay = makeOverlay({ source });
+      expect(overlay.render(80).join("\n")).toContain("two");
+
+      messages = [{ role: "user", content: "rewritten" }] as unknown as SessionMessage[];
+      captured?.({ type: "turn_end" } as unknown as AgentSessionEvent);
+
+      const out = overlay.render(80).join("\n");
+      expect(out).toContain("rewritten");
+      expect(out).not.toContain("two");
     });
   });
 });


### PR DESCRIPTION
Fixes #689.

## What this changes

`/subagents:sessions` became progressively unresponsive on large live transcripts (reference session: 165 tool uses / 10,876 rendered lines): rich output streamed far slower than the parent TUI, and arrow keys appeared frozen. Two commits, reviewable independently:

### 1. `fix: make session preview rendering viewport-bound`

- Forward `AgentSessionEvent` through `TranscriptSource.subscribe` instead of discarding it.
- Cache settled transcript lines keyed by the compositor's **actual overlay width**; paint and scroll slice the cache instead of re-rendering and re-truncating every line per keypress.
- Keep the in-progress assistant message as its own `AssistantMessageComponent`, updated per delta — the same model as Pi's interactive mode. Full live thinking/text fidelity is preserved; deltas never touch settled history.
- `handleInput` reuses the width the overlay actually rendered at, fixing the 100%-vs-90% width mismatch (scroll bounds were computed against a layout that was never displayed). This is the same root cause independently diagnosed in #670 by @aqua2k1 — this commit covers it as part of the broader change; happy to rebase if #670 lands first.

### 2. `perf: settle session-preview messages incrementally`

After commit 1, every settling event (`message_end` fires for each assistant message **and each tool result**) still rebuilt the full component tree and re-rendered all lines: ~101 ms per settle on a 200-message fixture at production width, i.e. a visible stutter per tool completion on large sessions.

- Hold the settled transcript as per-message blocks, each caching its rendered lines. New messages append blocks; a tool result mutates only its paired tool component's block; the flat line array is a cheap concat.
- Correctness rests on a verified runtime invariant: agent-core reduces state before awaiting listeners (`Agent.processEvents` pushes into `state.messages` before `message_end` listeners run), so consuming at event time always sees the settled prefix; the streaming message lives outside `state.messages`, so live and settled never overlap.
- An identity guard on the last consumed message falls back to a full rebuild whenever history is rewritten wholesale (compaction, branching, or sources that fabricate message arrays per call). `agent_end` and `compaction_end` keep full-rebuild semantics to capture in-place mutations (e.g. abort `errorMessage` patches).
- Known boundary, unchanged from before: `custom`-role messages are still skipped (rendering them needs the child session's message-renderer registry).
- The implementation stays below the repository's Fallow complexity gates without suppressions: scroll input is table-driven, message consumption dispatches by role, and source-event routing uses narrow helpers.

## Measurements

Deterministic Vitest fixture, 200 multiline messages (~4.4k rendered lines), production width 144:

| Hot path                       | before                 | after commit 1 | after commit 2     |
| ------------------------------ | ---------------------- | -------------- | ------------------ |
| Settle (`message_end` + paint) | ~101 ms (full rebuild) | ~101 ms        | **1.06 ms (~95×)** |
| Streaming delta + paint        | full rebuild per delta | 1.56 ms        | **0.43 ms**        |
| Scroll + paint                 | full re-render per key | 0.09 ms        | **0.09 ms**        |

The reported 10.9k-line session is ~2.5× this fixture and tool-component-heavy, so absolute gains there are larger.

## Verification

- TDD, red → green on both commits. New tests pin: O(changed-message) settle render counts, tool-result updates touching only the affected block, **line-for-line equivalence between incremental settles and a freshly built overlay**, `agent_end` capturing in-place mutations, the rewritten-history fallback, 90%-overlay-width input behavior, width-change invalidation, and full-fidelity live thinking/text streaming.
- Suite: 64 files / 1,146 tests green; `tsc --noEmit`, Biome, ESLint, and markdown lint clean.
- `pnpm fallow audit --base origin/main` clean with no complexity suppressions; GitHub Actions `check` passes.
- End-to-end: real `pi -ne -e src/index.ts` sessions spawning subagents through this branch returned expected results (foreground and background).

As with the previous rounds — take the direction and reimplement if that fits your process better; the diagnosis and tests should transfer either way.



