### PR TITLE
feat(pi-permission-system): persist approved permission rules

### DIFF
--- a/.pi/skills/package-pi-permission-system/SKILL.md
+++ b/.pi/skills/package-pi-permission-system/SKILL.md
@@ -68,13 +68,15 @@ This lesson comes from issue [#296]: the regression where `permission-bridge.ts`
 
 ## Configuration
 
-One unified config file per scope, following the `pi-autoformat` convention (`extensions/<id>/config.json`).
+Unified config follows the `pi-autoformat` convention (`extensions/<id>/config.json`), with a user-local project override used only for explicit persistent approvals.
 
 - **Global config**: `~/.pi/agent/extensions/pi-permission-system/config.json` (respects `PI_CODING_AGENT_DIR`)
-- **Project config**: `<cwd>/.pi/extensions/pi-permission-system/config.json`
+- **Shared project config**: `<cwd>/.pi/extensions/pi-permission-system/config.json`
+- **Project-local config**: `<cwd>/.pi/extensions/pi-permission-system/config.local.json`
 - **Per-agent overrides**: YAML frontmatter in agent definition files
 
-Merge precedence: project overrides global; per-agent frontmatter overrides both.
+Merge precedence: shared project overrides global; project-local overrides shared project; global-agent and project-agent frontmatter remain higher.
+Automatic project persistence writes only trusted-project `config.local.json`, never the shared project file.
 The `permission` object uses deep-shallow merge; scalar fields use simple replacement.
 
 - Zod source of truth: `src/config-schema.ts` (the composable schemas, the `z.infer` config types, and `buildPermissionsJsonSchema`).

--- a/packages/pi-permission-system/README.md
+++ b/packages/pi-permission-system/README.md
@@ -64,10 +64,11 @@ All permissions use one of three states:
 | `deny`  | Blocks the action with an error message  |
 | `ask`   | Prompts the user for confirmation via UI |
 
-When the dialog prompts, you can approve once or approve a pattern for the rest of the session.
-In an interactive TUI session the prompt is an inline keybind dialog — `y` approve, `s` approve for this session, `n` deny, `r` deny with a reason — where each hotkey arms and a second press confirms (configurable via `doublePressToConfirm`).
-Pi's tool-expansion binding (`app.tools.expand`, `Ctrl+O` by default) keeps working while the dialog is open, so you can expand a truncated tool preview before deciding.
-See [docs/configuration.md](docs/configuration.md#inline-permission-dialog-tui) for the hotkeys and [docs/session-approvals.md](docs/session-approvals.md) for session-scoped rules and pattern suggestions.
+When a local dialog prompts, you can approve once, approve an editable pattern for the session, or persist an editable `allow` rule for this project or globally.
+Durable choices can show the exact surface, patterns, scope, action, and destination before writing; toggle the sticky summary preference with `t` or `/permission-system` settings.
+The inline TUI keeps single-letter shortcuts and arrow navigation for every choice: `y` approve, `s` approve for this session, `e` edit, `p` persist for the project, `g` persist globally, `n` deny, and `r` deny with a reason.
+Pi's tool-expansion binding keeps working there.
+See [docs/configuration.md](docs/configuration.md#inline-permission-dialog-tui) for prompt behavior and [docs/session-approvals.md](docs/session-approvals.md) for approval lifetimes and pattern suggestions.
 
 The `path` surface is a cross-cutting gate that applies to **all** file access — Pi tools, bash commands, MCP calls, and extension tools alike.
 Extension and MCP tools that operate on paths (via `input.path`, MCP's `input.arguments.path`, or a registered access extractor) are gated by default, so a `path` deny cannot be overridden by a per-tool allow — making it the right place to protect sensitive files like `.env` or `~/.ssh/*` from every tool at once.
@@ -102,12 +103,14 @@ See [docs/configuration.md](docs/configuration.md) for the full recipe.
 
 Config lives in one JSON file per scope:
 
-| Scope   | Path                                                      |
-| ------- | --------------------------------------------------------- |
-| Global  | `~/.pi/agent/extensions/pi-permission-system/config.json` |
-| Project | `<cwd>/.pi/extensions/pi-permission-system/config.json`   |
+| Scope         | Path                                                          |
+| ------------- | ------------------------------------------------------------- |
+| Global        | `~/.pi/agent/extensions/pi-permission-system/config.json`     |
+| Project       | `<cwd>/.pi/extensions/pi-permission-system/config.json`       |
+| Project-local | `<cwd>/.pi/extensions/pi-permission-system/config.local.json` |
 
-Project overrides global; per-agent YAML frontmatter overrides both.
+Shared project config overrides global, project-local config overrides shared project config, and per-agent YAML frontmatter overrides file config.
+The prompt writes project approvals only to `config.local.json`; normally add that file to your own `.gitignore`.
 Project config (policy and runtime knobs) is loaded only once the project is trusted — in an untrusted directory only global config applies, so an untrusted repository cannot loosen your global policy (see [Upgrading](#2200--project-config-requires-project-trust)).
 
 Within a surface map like `bash` or `mcp`, **last matching rule wins** — put broad catch-alls first and specific overrides after.
@@ -170,6 +173,7 @@ Run `pnpm install` to set up hooks automatically.
 
 This project began as a fork of [MasuRii/pi-permission-system](https://github.com/MasuRii/pi-permission-system).
 Thank you to [MasuRii](https://github.com/MasuRii) for the original work that made this possible.
+The durable-approval design also builds on prior persistence and editable-pattern work by [rienkim in PR #73](https://github.com/gotgenes/pi-packages/pull/73).
 
 Thank you to the [OpenCode](https://opencode.ai) team for the permission model design that inspired the flat config format and evaluation semantics used in this extension.
 

--- a/packages/pi-permission-system/config/config.example.json
+++ b/packages/pi-permission-system/config/config.example.json
@@ -5,6 +5,7 @@
   "permissionReviewLog": true,
   "yoloMode": false,
   "doublePressToConfirm": true,
+  "showPersistenceSummary": true,
 
   "toolInputPreviewMaxLength": 400,
   "toolTextSummaryMaxLength": 120,

--- a/packages/pi-permission-system/docs/architecture/architecture.md
+++ b/packages/pi-permission-system/docs/architecture/architecture.md
@@ -702,7 +702,9 @@ src/
 ├── expand-home.ts            ~/$HOME expansion for patterns and path values
 ├── session-approval.ts        SessionApproval value object - owns the single/multi-pattern union; exposes representativePattern and toGateApproval()
 ├── session-rules.ts          Session approval store (Ruleset wrapper); `implements SessionApprovalRecorder`; injected into `GateRunner` as the recorder role
-├── policy-loader.ts          PolicyLoader interface + FilePolicyLoader (file I/O, mtime caching); marks a present-but-unloadable non-global scope `invalid` (an absent file stays a plain empty scope) so composition can fail closed
+├── policy-loader.ts          PolicyLoader interface + FilePolicyLoader (file I/O, mtime caching); merges trusted project-local config after shared project config and marks a present-but-unloadable non-global scope `invalid`
+├── persistent-approval-service.ts Trusted target resolution, trust recheck, immediate policy reload/rollback, and persistence review events
+├── persistent-permission-writer.ts JSONC-preserving validated atomic `allow` rule upsert with containment/symlink checks and restoration
 ├── scope-merge.ts            Cross-scope permission merge + origin-map bookkeeping
 ├── permission-manager.ts     Scope loading + rule composition + `check(intent)` (single resolution entry point); delegates I/O to PolicyLoader; floors the composed ruleset `allow`→`ask` (origin `fail-closed`) when a non-global scope is `invalid`, and appends a fail-closed notice to `getConfigIssues`. Constraint: stays string-based — must not import `AccessPath` (the ADR 0002 string boundary, lint-guarded by `no-restricted-imports`)
 ├── permission-gate.ts        Pure deny/ask/allow gate (injected IO)
@@ -767,7 +769,7 @@ src/
 ├── permission-events.ts      Event channel constants, payload types, emit helpers
 ├── permission-ui-prompt.ts   Centralized construction for `permissions:ui_prompt` event payloads - `buildUiPrompt` is the single builder for direct and forwarded asks, keeping the emitted contract shape in one place
 ├── config-store.ts           `ConfigStore` class — owns `config` + `lastConfigWarning`; `ConfigReader`, `SessionConfigStore`, `CommandConfigStore` narrow interfaces
-├── config-loader.ts          File I/O, format detection, strict zod validation (fail-closed) for config files
+├── config-loader.ts          File I/O, format detection, strict zod validation (fail-closed), and global → shared-project → project-local runtime merge
 ├── config-schema.ts          Zod schemas - single source of truth for the config shape; derives the JSON Schema (buildPermissionsJsonSchema) and the config types
 ├── config-paths.ts           Path derivation
 ├── extension-paths.ts        `ExtensionPaths` value object - immutable path constants derived from `agentDir` (and optional Pi `getPackageDir()`) at startup (`computeExtensionPaths`)
@@ -801,10 +803,11 @@ src/
 │   ├── authorizer-chain.ts    `composeAuthorizerChain(links, terminal, query, log)` - folds non-terminal links ahead of the context-selected terminal (`defer` → next link, `allow`/`deny` → decision), injecting `query` and the review-log `log` into each link; zero links returns the terminal instance (identity)
 │   ├── authorizer-registry.ts `AuthorizerRegistry` (+ `AuthorizerLookup`/`AuthorizerRegistrar` ISP interfaces) - name → link `authorize` map mirroring `ToolAccessExtractorRegistry`; one instance in `index.ts`, exposed cross-extension via `PermissionsService.registerAuthorizer`; throw-on-duplicate, identity-guarded disposer
 │   ├── delegation-envelope.ts `encloseInDelegationEnvelope(authorize)` + `DELEGATION_EXCLUDED_SURFACES` - the bounded-delegation checkpoint (ADR 0007 §5): caps a link's `allow` on an excluded surface (`external_directory`/`path`, or an undetermined surface, fail-safe) to `defer`; deny/defer pass through
-│   ├── local-user-authorizer.ts `LocalUserAuthorizer` class - `TerminalAuthorizer` for a session with UI and the single `permissions:ui_prompt` emit site: renders a forwarded ask's provenance as a non-degraded broadcast + `(Subagent)` title, then dispatches to the inline keybind dialog (TUI) or the `select`/`input` fallback
-│   ├── permission-dialog.ts   Dialog option semantics + `requestPermissionDecisionFromUi` (`select`/`input` fallback); the mode dispatch lives in `permission-prompt-component.ts`
-│   ├── permission-prompt-decision.ts Pure decision model (`reducePrompt` + `PromptModelConfig`/`PromptViewState`) for the inline keybind dialog - hotkey arming (double-press), step transitions, reason validation; no SDK/TUI imports
-│   ├── permission-prompt-component.ts Inline `ctx.ui.custom<PermissionPromptDecision>` keybind dialog (TUI) driven by the decision model + the `requestPermissionDecision` mode dispatcher (tui → inline, else fallback); forwards Pi's `app.tools.expand` action in the decision/scope steps only, never during reason entry
+│   ├── interactive-permission-choice.ts Private union separating ordinary prompt decisions from explicit durable policy-mutation choices
+│   ├── local-user-authorizer.ts `LocalUserAuthorizer` class - `TerminalAuthorizer` for a session with UI and the single `permissions:ui_prompt` emit site; resolves durable local choices through `PersistentApprovalService`, while forwarded asks remain once/session-only
+│   ├── permission-dialog.ts   Dialog option semantics + editable session/project/global choices and exact durable confirmation through the SDK `select`/`input` flow
+│   ├── permission-prompt-decision.ts Pure decision model (`reducePrompt` + `PromptModelConfig`/`PromptViewState`) for the inline keybind dialog - hotkey arming (double-press), pattern editing, optional durable summary, and reason/session-scope steps; no SDK/TUI imports
+│   ├── permission-prompt-component.ts Inline TUI keybind dialog (`y`/`s`/`e`/`p`/`g`/`n`/`r` plus arrow/`j`/`k` navigation) with edit, sticky summary toggle, and optional durable-summary sub-steps, plus the non-TUI `select`/`input` dispatcher
 │   ├── denying-authorizer.ts  `DenyingAuthorizer` class - least-privilege `TerminalAuthorizer` for a session with no reachable authority; denies with the `confirmationUnavailable` marker so the ask path derives the `confirmation_unavailable` resolution
 │   ├── authorizer-selection.ts `AuthorizerSelection` class - context-owning `AskEscalator` implementation (`escalate(details)`); selects the terminal once per activation, and per ask resolves the `authorizerChain` config to registered links (config order; unregistered names skipped fail-safe with an `authorizer_chain_unregistered_link` review event; each wrapped in the delegation envelope), composes them via `composeAuthorizerChain`, and delegates via `PermissionPrompter`
 │   ├── permission-prompter.ts `PermissionPrompter` class (`PermissionPrompterApi`) - review-log bracketing (waiting → approved/denied) around `authorizer.authorize(details)`; `PromptPermissionDetails` type (carries the child-fixed `accessIntent` facts a forwarded ask relays)

--- a/packages/pi-permission-system/docs/configuration.md
+++ b/packages/pi-permission-system/docs/configuration.md
@@ -4,12 +4,15 @@
 
 One unified config file per scope:
 
-| Scope   | Path                                                                                       |
-| ------- | ------------------------------------------------------------------------------------------ |
-| Global  | `~/.pi/agent/extensions/pi-permission-system/config.json` (respects `PI_CODING_AGENT_DIR`) |
-| Project | `<cwd>/.pi/extensions/pi-permission-system/config.json`                                    |
+| Scope         | Path                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------ |
+| Global        | `~/.pi/agent/extensions/pi-permission-system/config.json` (respects `PI_CODING_AGENT_DIR`) |
+| Project       | `<cwd>/.pi/extensions/pi-permission-system/config.json`                                    |
+| Project-local | `<cwd>/.pi/extensions/pi-permission-system/config.local.json`                              |
 
-Project config overrides global config; per-agent frontmatter overrides both.
+Shared project config overrides global config; project-local config overrides shared project config; per-agent frontmatter overrides file config.
+The permission prompt writes project approvals only to `config.local.json`, never shared `config.json`.
+The local file is user-owned and should normally be ignored by Git.
 
 **Project config requires project trust.**
 Project and project-agent scopes (both permission policy and runtime config such as `yoloMode`) are loaded only when Pi reports the project as trusted (`ctx.isProjectTrusted()`).
@@ -31,15 +34,16 @@ See [migration/0644-project-trust-gating.md](migration/0644-project-trust-gating
 **Precedence order (later wins):**
 
 1. Global config file
-2. Project config file
-3. Global agent frontmatter
-4. Project agent frontmatter
+2. Shared project config file
+3. Project-local config file
+4. Global agent frontmatter
+5. Project agent frontmatter
 
 The `permission` object uses deep-shallow merge: string-vs-string replaces; both-object shallow-merges pattern maps; string-vs-object the override wins entirely.
-Scalar fields (`debugLog`, `permissionReviewLog`, `yoloMode`, `doublePressToConfirm`) use simple replacement.
+Scalar fields (`debugLog`, `permissionReviewLog`, `yoloMode`, `doublePressToConfirm`, `showPersistenceSummary`) use simple replacement.
 
 **Invalid higher-precedence scope fails closed.**
-If a non-global scope (project config, global agent frontmatter, or project agent frontmatter) is present but fails to load or validate, it no longer contributes an empty scope that silently inherits the lower scope's rules.
+If a non-global scope (shared/local project config, global agent frontmatter, or project agent frontmatter) is present but fails to load or validate, it no longer contributes an empty scope that silently inherits the lower scope's rules.
 Instead the effective policy is floored so nothing resolves more permissively than `ask`: every `allow` (including one inherited from a lower scope) is clamped to `ask`, while `deny` and `ask` are unchanged.
 So a global `bash: allow` cannot remain effective behind a project scope that was meant to deny bash but contains a typo — bash prompts until the invalid config is fixed.
 A validation warning plus a distinct fail-closed notice are emitted, and a fix + reload restores the intended policy.
@@ -57,6 +61,7 @@ This clamp is deny-preserving and, like `yoloMode`, applied at composition; when
   "permissionReviewLog": true,
   "yoloMode": false,
   "doublePressToConfirm": true,
+  "showPersistenceSummary": true,
   "toolInputPreviewMaxLength": 400,
   "toolTextSummaryMaxLength": 120,
   "piInfrastructureReadPaths": [],
@@ -104,6 +109,7 @@ This clamp is deny-preserving and, like `yoloMode`, applied at composition; when
 | `permissionReviewLog`       | `true`  | Enables the permission request/denial review log at `logs/pi-permission-system-permission-review.jsonl`. Records bash command strings verbatim — see [Log file sensitivity](#log-file-sensitivity) |
 | `yoloMode`                  | `false` | Auto-approves `ask` results instead of prompting when yolo mode is enabled                                                                                                                         |
 | `doublePressToConfirm`      | `true`  | Requires a confirming second press of a decision hotkey in the inline TUI dialog (see below). TUI sessions only; set to `false` for single-press.                                                  |
+| `showPersistenceSummary`    | `true`  | Shows the exact rule and destination before saving a durable approval. Toggle persistently with `t` in the inline prompt or through `/permission-system`.                                          |
 | `toolInputPreviewMaxLength` | `200`   | Max characters of inline JSON shown in permission prompts for tool inputs. Omit to use the default. Set to a large value to disable truncation.                                                    |
 | `toolTextSummaryMaxLength`  | `80`    | Max characters of inline pattern/path summaries (grep patterns, find globs, ls paths) in permission prompts. Omit to use the default.                                                              |
 | `piInfrastructureReadPaths` | `[]`    | Extra directories to auto-allow for reads, bypassing the `external_directory` gate. Supports `~`/`$HOME` expansion and wildcard patterns (`*`, `?`).                                               |
@@ -119,13 +125,21 @@ In an interactive **TUI** session, an `ask` decision opens an inline keybind dia
 | Key | Action                                                            |
 | --- | ----------------------------------------------------------------- |
 | `y` | Approve once                                                      |
-| `s` | Approve for this session                                          |
+| `s` | Approve the proposed pattern for this session                     |
+| `e` | Edit the proposed pattern(s)                                      |
+| `p` | Persist the proposed pattern(s) for this trusted project          |
+| `g` | Persist the proposed pattern(s) globally                          |
 | `n` | Deny                                                              |
 | `r` | Deny with a reason (opens an inline editor; a reason is required) |
 
-Arrow keys / `j`/`k` move the highlight, `enter` confirms the highlighted option, and `esc` denies.
-With `doublePressToConfirm` enabled (the default), a letter hotkey **arms** its action and shows a `Press y again to approve.` hint; press the same key again to commit.
-Set `doublePressToConfirm` to `false` to commit on the first press.
+Project persistence is omitted when the project is not trusted.
+Arrow keys / `j`/`k` move the highlight, `enter` confirms the highlighted option, and `esc` denies at the decision list or returns from a sub-step.
+The edit field supports backspace and `Ctrl+U` to clear.
+Press `t` to toggle the sticky `showPersistenceSummary` preference; when enabled, `p` or `g` opens the exact-rule summary and `enter` saves it.
+When the summary is disabled, `p` or `g` saves directly after the configured hotkey confirmation.
+With `doublePressToConfirm` enabled (the default), a terminal letter hotkey **arms** its action and shows a `Press y again to approve.` hint; press the same key again to commit.
+The non-destructive `e` edit step and `p`/`g` summary step open on their first press.
+Set `doublePressToConfirm` to `false` to commit terminal actions on the first press.
 
 Pi's tool-expansion binding (`app.tools.expand`, `Ctrl+O` by default) stays live while the dialog is open, so you can expand a truncated tool preview before deciding.
 It only toggles the display — it never resolves, commits, or arms the pending decision.

--- a/packages/pi-permission-system/docs/plans/0691-persist-approved-permission-rules.md
+++ b/packages/pi-permission-system/docs/plans/0691-persist-approved-permission-rules.md
@@ -1,0 +1,418 @@
+---
+issue: 691
+issue_title: "pi-permission-system: persist approved permission rules at project or global scope"
+---
+
+# Persist approved permission rules
+
+## Release Recommendation
+
+**Release:** ship independently
+
+Issue #691 is not part of an architecture-roadmap release batch.
+It adds an opt-in permission-prompt capability without changing existing policy defaults, so it should ship as an independent feature release.
+
+## Problem Statement
+
+An interactive `ask` decision can currently approve one request or add the gate's suggested rule to the in-memory session ruleset.
+Persisting the same approval requires the user to reconstruct its permission surface and wildcard, find the right config file, and edit policy outside the decision context.
+That repetition creates approval fatigue and makes accidental over-broad policy more likely.
+
+Issue #603 already requests project-scoped persistence from the prompt.
+Issue #691 subsumes that narrower request and adds global scope, editable suggestions, a project-local destination, trust gating, an optional sticky summary, atomic writes, audit logging, and fail-closed behavior.
+Issue #604 remains related because editing the proposal also lets a user widen a local session approval manually, but this issue does not add a configurable default suggestion granularity.
+
+## Goals
+
+- Let a direct interactive user approve once, approve an editable proposal for the session, or persist it at project or global scope.
+- Make the exact surface, complete pattern list, action, scope, and destination available in an optional pre-save summary.
+- Write automatic project approvals only to trusted-project `.pi/extensions/pi-permission-system/config.local.json`.
+- Load the local project file after shared project `config.json` while keeping global-agent and project-agent policy higher in precedence.
+- Preserve unrelated JSONC comments, formatting, fields, rule order, and rules while appending the approved rule at last-match-wins precedence.
+- Validate and write atomically, reload policy immediately, and block the pending call when persistence fails.
+- Keep explicit denies and most-restrictive cross-surface composition authoritative.
+- Record persistence requests, success, and failure in the permission review log.
+- Credit [PR #73] and preserve its authorship for any source code carried forward.
+
+This change is not breaking.
+Existing hotkeys and decisions keep their behavior, no rule is written without a new explicit user choice, and project-local policy remains trust-gated.
+
+## Non-Goals
+
+- Do not persist approvals selected in forwarded subagent prompts in this release.
+  Forwarded prompts keep their current once, requesting-session, and serving-session choices without edit or durable options.
+  Requester-side persistence requires a separate forwarding-protocol change so the requester can check its own project trust and report write failure before execution.
+- Do not let an `Authorizer` chain link, model judge, non-UI terminal, or automatic decision write policy.
+- Do not modify shared project `config.json`, Pi `settings.json`, per-agent frontmatter, or `.gitignore` automatically.
+- Do not add a configurable default pattern breadth for #604.
+- Do not alter the capability or permission-surface model being considered in #639.
+- Do not make a global rule override higher-precedence project or per-agent policy.
+- Do not weaken `path` / `external_directory` most-restrictive composition or the authorizer delegation envelope.
+
+## Background
+
+The current ask path is:
+
+1. A gate creates a `SessionApproval` carrying the evaluated surface and one or more suggested patterns.
+2. `GateRunner` passes its serializable projection through `PromptPermissionDetails`.
+3. `AuthorizerSelection` invokes the live chain and then `LocalUserAuthorizer` for a direct UI session.
+4. `requestPermissionDecision` dispatches to the inline TUI component or the `select()` / `input()` fallback.
+5. `GateRunner` records the original proposal in `SessionRules` only for `approved_for_session`.
+
+The inline prompt is already split between a pure reducer (`permission-prompt-decision.ts`) and a thin TUI adapter (`permission-prompt-component.ts`).
+The fallback path in `permission-dialog.ts` remains the supported UI abstraction for RPC and custom frontend embeddings, so durable choices must work there as well as in TUI mode.
+
+`FilePolicyLoader` currently reads one dedicated project file, and `loadAndMergeConfigs` uses the same source for runtime config.
+Both paths are gated by the `projectTrusted` decision added in #644.
+The new local file must participate in both paths after shared project config and must inherit the same invalid-higher-scope fail-closed behavior.
+
+[PR #73] by `rienkim` implemented valuable prior art: editable candidate patterns, project/global persistence, config upsert, atomic temporary-file replacement, tests, and documentation.
+It closed unmerged without discussion or a stated reason, its branch was deleted, and current `main` is thousands of commits beyond its base.
+Its design wrote shared project config directly, lacked current trust and confirmation boundaries, and rewrote JSONC wholesale, so the implementation should port applicable concepts rather than resurrect the patch.
+If source is copied or closely adapted from commit `1b27ab6`, the relevant commit must retain `Co-authored-by: rienkim25 <github@rienkim.com>`.
+
+Open [PR #675] adds Pi `settings.json` policy sources.
+Whether or not it lands first, the new dedicated local file has one stable precedence requirement: global sources < shared project settings/config < project-local config < global-agent policy < project-agent policy.
+If #675 lands before implementation, extend its source-merging helper and cache stamp rather than introducing a parallel merge path.
+
+Package constraints that apply:
+
+- Config is the source of truth, and all file input is strictly validated.
+- Project policy is unavailable until `ctx.isProjectTrusted()` returns `true`.
+- Pattern maps are last-match-wins.
+- `path`, `external_directory`, per-tool, and `bash` gates compose most-restrictively.
+- Review-log writes go through `PermissionSessionLogger` so existing structural redaction and owner-only file modes remain in force.
+- `PermissionManager` stays string-based and must not import `AccessPath`.
+
+## Design Review
+
+Adding persistence directly to the existing dependency bags would make already-wide wiring worse.
+The following structural corrections belong in this feature rather than a separate refactor.
+
+| Smell                          | Location                                                                                 | Evidence                                                                                         | Planned correction                                                                                    |
+| ------------------------------ | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| Wide interface                 | `AuthorizerSelectionDeps`                                                                | Seven fields; three exist only to construct `LocalUserAuthorizer`                                | Replace those three fields with a `createLocalAuthorizer(ctx)` factory                                |
+| Growing dependency bag         | `LocalUserAuthorizerDeps`                                                                | Five fields before persistence; adding paths, trust, writer, and logger would exceed one concern | Inject `PermissionPromptPresenter` and `PersistentApprovalService` collaborators beside the event bus |
+| Scope-coupled result           | Prompt returns `PermissionPromptDecision` directly                                       | UI choice and policy mutation would otherwise be conflated                                       | Return a private `InteractivePermissionChoice`, then resolve it at the local-authority boundary       |
+| Raw dependency cluster         | Destination path, trust state, and scope                                                 | These values must agree at summary and write time                                                | Introduce a `PersistentApprovalTarget` value object resolved by one service                           |
+| Repeated persistence mechanics | `ConfigStore.save` and forwarding writes already implement partial atomic-write patterns | Reusing either directly would rewrite JSONC or couple unrelated policy                           | Add one focused JSONC-preserving permission writer and leave existing writers unchanged               |
+
+No current Law of Demeter reach-through, output-argument mutation, or scattered reset needs a preparatory refactor.
+The decision-state comparisons remain centralized in the prompt reducer, prompt-to-authority adapter, and pure gate, so new variants must extend those exhaustive dispatch points rather than adding ad hoc string checks.
+
+## Design Overview
+
+### Interactive choice is separate from final authority
+
+The prompt layer returns a private choice rather than performing file IO:
+
+```typescript
+type InteractivePermissionChoice =
+  | { kind: "allow_once" }
+  | {
+      kind: "allow_session";
+      proposal: PermissionRuleProposalData;
+      grant: "requesting_session" | "serving_session";
+    }
+  | {
+      kind: "persist";
+      scope: "project" | "global";
+      proposal: PermissionRuleProposalData;
+      target: PersistentApprovalTarget;
+    }
+  | { kind: "deny"; reason?: string };
+
+interface PermissionRuleProposalData {
+  surface: string;
+  patterns: readonly string[];
+}
+```
+
+`LocalUserAuthorizer` is the only adapter from this choice to `PermissionPromptDecision`.
+An allow-once choice maps to the existing `approved` decision.
+A session choice maps to the existing session state and carries the edited proposal back to `GateRunner`, which records that returned proposal instead of the descriptor's original one.
+A durable choice calls `PersistentApprovalService.persist()` and returns `approved` only after the service succeeds.
+A persistence failure maps to a denied decision with an actionable reason, so the pending tool call is blocked.
+
+The public cross-extension `Authorizer` verdict remains `allow | deny | defer` and cannot construct a durable choice.
+Forwarded asks do not receive durable or edit options, and the forwarding request/response schema is unchanged.
+
+### Prompt behavior
+
+Local asks start with the gate's complete proposal, including every pattern from multi-path `external_directory` gates.
+The user may edit patterns before choosing session, project, or global scope.
+For multiple patterns, the editor presents each pattern explicitly rather than flattening them into an ambiguous delimiter-separated string.
+Blank patterns and duplicates are rejected before confirmation.
+
+The inline reducer gains `edit` and optional `persistent-confirm` steps while retaining its pure state-machine design.
+The TUI component renders state, translates keystrokes, and persists the sticky `showPersistenceSummary` preference through the config store.
+The fallback uses `select()` and `input()` to expose the same choices to RPC/custom frontends.
+
+When enabled, the durable summary displays:
+
+```text
+Scope:   project-local
+Surface: bash
+Patterns:
+  - gh workflow run *
+Action:  allow
+File:    <cwd>/.pi/extensions/pi-permission-system/config.local.json
+```
+
+The summary defaults on and can be toggled persistently with `t` in the inline prompt or through `/permission-system` settings.
+When disabled, a project or global persistence choice saves without a separate summary or typed acknowledgement.
+Cancellation at any edit or summary step returns to a safe earlier step or denies without writing.
+
+### Target resolution and trust
+
+`PersistentApprovalTargetResolver` derives only two targets:
+
+```typescript
+interface PersistentApprovalTarget {
+  scope: "project" | "global";
+  path: string;
+}
+```
+
+The project target is unavailable when `ctx.isProjectTrusted()` is false.
+The service rechecks trust immediately before a project write to close the prompt-to-write race.
+Global persistence remains available in an untrusted directory, but policy reload must pass `undefined` rather than that cwd so the reload cannot accidentally activate untrusted project config.
+
+The extension does not inspect Git tracking state or edit `.gitignore`.
+
+The writer rejects a destination that resolves outside the expected global or project root and does not follow a final-component symlink.
+It uses a unique owner-only temporary file in the destination directory and an atomic rename.
+
+### JSONC-preserving rule mutation
+
+Add `jsonc-parser` as a direct runtime dependency and use its edit API rather than serializing the parsed object.
+The writer:
+
+1. Reads the original bytes or starts from an empty object.
+2. Rejects an existing file that cannot be parsed or validated.
+3. Upserts `permission.<surface>.<pattern> = "allow"` for every proposed pattern.
+4. Converts a string surface shorthand to `{ "*": <old-action>, ...newRules }` without changing its meaning.
+5. Moves an existing identical pattern to the end of that surface map so the approved rule has the documented last-match-wins position.
+6. Preserves unrelated comments, whitespace, fields, and pattern order.
+7. Parses and validates the complete candidate against `unifiedConfigSchema` before touching the destination.
+8. Writes and fsyncs a unique temporary file, then renames it over the destination.
+9. Restores the original bytes atomically if the subsequent policy reload throws.
+
+The writer mutates only the chosen destination.
+Project persistence never falls back to shared `config.json` when `config.local.json` cannot be written.
+
+### Project-local source precedence
+
+Add `getProjectLocalConfigPath(cwd)` and thread it through both config pipelines.
+
+For runtime config, `loadAndMergeConfigs` merges trusted project sources in this order:
+
+1. Legacy project policy.
+2. Shared project `config.json`.
+3. Project `config.local.json`.
+
+For policy, `FilePolicyLoader.loadProjectConfig()` merges the shared and local dedicated files into the existing `project` scope before global-agent and project-agent frontmatter are applied.
+Its cache stamp and resolved-path report include both files.
+An invalid present local file marks the project scope invalid, preserving #646's allow-to-ask clamp.
+An untrusted project reads neither shared nor local project sources.
+
+### Immediate application and deny preservation
+
+After a validated atomic write, `PersistentApprovalService` rebuilds the active `PermissionManager` with the same trust decision used by the lifecycle gate.
+The pending request is allowed by the direct human decision only after write and reload succeed.
+Subsequent requests resolve through the normal file-backed policy.
+
+A persisted allow affects only its originating surface.
+A `path` or `external_directory` deny on another gate still blocks through the existing sequential gates and most-restrictive composition.
+Higher-precedence per-agent policy also remains authoritative.
+The confirmation explains when a global rule may still be restricted by project or agent policy; persistence does not claim to override that policy.
+
+### Review logging
+
+`PersistentApprovalService` writes structured events through `ReviewLogger`:
+
+- `permission_rule.persistence_requested`
+- `permission_rule.persistence_succeeded`
+- `permission_rule.persistence_failed`
+
+Each entry records request ID, scope, surface, patterns, destination, and a bounded failure category/message.
+`PermissionPrompter` keeps its existing waiting/approved/denied bracket, with durable success distinguished by metadata on the final local decision.
+No automatic authorizer path receives the persistence service.
+
+## Module-Level Changes
+
+### New production modules
+
+- `src/authority/interactive-permission-choice.ts` — private choice and proposal-data unions shared by TUI and fallback presenters.
+- `src/persistent-approval-target.ts` — target value object, project/global path resolution, and trust eligibility.
+- `src/persistent-permission-writer.ts` — JSONC-preserving rule upsert, strict candidate validation, path/symlink checks, atomic replace, and restoration primitive.
+- `src/persistent-approval-service.ts` — prepare/persist orchestration, trust recheck, policy reload, failure mapping, and review logging.
+
+### Changed production modules
+
+- `src/config-paths.ts` — add `getProjectLocalConfigPath(cwd)`.
+- `src/config-loader.ts` — load trusted `config.local.json` after shared project config for runtime config and report its issues.
+- `src/policy-loader.ts` — add the local path option/cache stamp, merge it after shared project policy, preserve invalid-scope semantics, and report its resolved path.
+- `src/permission-manager.ts` — derive the local project path in `PolicyLoaderOptions`; keep trust-sensitive reload callers passing cwd or `undefined` explicitly.
+- `src/config-reporter.ts` — include project-local path/existence in resolved-config review entries.
+- `src/authority/permission-prompt-decision.ts` — add local edit/project/global choices and confirmation states while preserving existing once/session/deny behavior.
+- `src/authority/permission-prompt-component.ts` — render/edit complete proposals and durable confirmations; return `InteractivePermissionChoice`.
+- `src/authority/permission-dialog.ts` — make the fallback return the same private choice and expose edit/final-confirm flows through `select()` / `input()`.
+- `src/authority/local-user-authorizer.ts` — resolve choices, invoke persistence only for local direct asks, carry edited session proposals, and preserve the pre-dialog UI event.
+- `src/authority/authorizer.ts` — replace the three local-construction dependencies with `createLocalAuthorizer(ctx)` and keep the UI/subagent/deny dispatch centralized.
+- `src/authority/authorizer-selection.ts` — accept the narrowed factory-based selection dependencies without changing per-ask chain composition.
+- `src/authority/permission-prompter.ts` — include durable decision metadata in the existing review-log bracket.
+- `src/permission-gate.ts` — return the edited session proposal selected by the direct prompt instead of assuming the original descriptor proposal.
+- `src/handlers/gates/runner.ts` — record the proposal returned by the gate result; persistent decisions arrive as ordinary approved decisions only after successful mutation.
+- `src/index.ts` — construct the target resolver, writer, persistent service, and local-authorizer factory from per-session dependencies.
+- `package.json` and root `pnpm-lock.yaml` — add the audited `jsonc-parser` runtime dependency.
+
+If #675 lands first, its `settings-policy.ts`, scope merge helper, policy path report, and related tests become additional touch points.
+The implementation must rebase before cycle 1 and update this file list rather than duplicating its source machinery.
+
+### Tests
+
+- `test/config-paths.test.ts`
+- `test/config-loader.test.ts`
+- `test/config-pipeline.test.ts`
+- `test/policy-loader.test.ts`
+- `test/permission-manager-unified.test.ts`
+- `test/config-reporter.test.ts`
+- `test/config-store.test.ts`
+- `test/authority/permission-prompt-decision.test.ts`
+- `test/authority/permission-prompt-component.test.ts`
+- `test/authority/permission-dialog.test.ts`
+- `test/authority/local-user-authorizer.test.ts`
+- `test/authority/authorizer.test.ts`
+- `test/authority/authorizer-selection.test.ts`
+- `test/authority/permission-prompter.test.ts`
+- `test/permission-gate.test.ts`
+- `test/handlers/gates/runner.test.ts`
+- `test/composition-root.test.ts`
+- New focused tests for target resolution, JSONC mutation, and persistence orchestration.
+
+### User-facing and architecture documentation
+
+- `README.md` — add durable prompt choices, destinations, trust behavior, and precedence.
+- `docs/configuration.md` — document `config.local.json`, source precedence, the sticky summary preference, JSONC preservation, rollback/removal, and global limitations.
+- `docs/session-approvals.md` — distinguish once, edited session, project-local, and global lifetimes.
+- `docs/troubleshooting.md` — include the local path in resolved-config output and persistence-failure guidance.
+- `docs/architecture/architecture.md` — add the new modules and project-local source to current-behavior diagrams/module trees without adding roadmap provenance.
+
+No schema regeneration is needed because the `permission` shape is unchanged.
+
+## Test Impact Analysis
+
+1. New pure prompt tests cover option availability, local pattern editing, multi-pattern navigation, confirmation strength, cancellation, and forwarded-option suppression.
+2. New writer tests cover empty files, JSONC comments, string-surface expansion, existing-pattern relocation, multi-pattern atomicity, invalid input, symlinks, destination escape, rename failure, and restoration.
+3. New source-loading tests cover global/shared-project/local-project/global-agent/project-agent precedence and invalid local fail-closed behavior.
+4. New service tests cover trust loss between prepare and persist, global reload in an untrusted cwd, successful reload, reload rollback, and review events.
+5. Existing fallback dialog tests remain and are updated to assert the new private choice rather than a final decision.
+6. Existing TUI reducer/component tests remain the regression surface for once/session/deny/reason/scope hotkeys.
+7. Existing forwarding tests remain unchanged and gain assertions that forwarded asks expose no edit/project/global choices and emit no persistence event.
+8. Existing `GateRunner` tests remain the layer test for recording session rules; new cases prove edited patterns replace the original proposal while durable success does not add a session rule.
+9. Existing composition-root trust and same-cwd session-isolation tests remain unchanged and are supplemented by one filesystem-backed local/global persistence round trip.
+
+## Invariants at Risk
+
+- **Project trust gating (#644).**
+  `config.local.json` must be skipped on both runtime and policy paths when untrusted, and trust must be rechecked at mutation time.
+  Pin with config-loader, lifecycle/composition, and service tests.
+- **Invalid higher scope fails closed (#646).**
+  A present invalid local file must mark project scope invalid and floor inherited allows to `ask`.
+  Pin with policy-loader and manager integration tests.
+- **Single UI-prompt event site (#292/#555).**
+  `LocalUserAuthorizer` must emit `permissions:ui_prompt` once before any interactive choice.
+  Preserve the ordering assertion in `local-user-authorizer.test.ts`.
+- **Authorizer links are live-only (ADR 0007).**
+  Chain `allow` continues to map only to `approved`; no registry or chain interface receives persistence capability.
+  Pin with authorizer-chain and local-authorizer construction tests.
+- **Forwarding disclosure and authority boundary (ADR 0008).**
+  No requester cwd, target, or durable choice enters the forwarding schema in this release.
+  Pin with existing tolerant parser tests plus option-suppression tests.
+- **Most-restrictive path composition.**
+  Persisting an allow on one surface must not bypass `path` or `external_directory` deny on another.
+  Pin with composition-root tests that persist a per-tool allow while a cross-cutting deny remains blocking.
+- **Session approvals remain ephemeral.**
+  The existing session option writes only `SessionRules`, even after editing, and still clears on shutdown.
+  Pin with existing shutdown tests plus edited-session round-trip coverage.
+- **JSONC source integrity.**
+  Unrelated comments, formatting, fields, and rule order remain byte-identical outside the edited spans.
+  Pin with full-string writer assertions, not parsed-object subset assertions.
+
+## TDD Order
+
+1. **Project-local source loading.**
+   Add red path/loader/policy/reporter tests for `config.local.json`, precedence, trust skipping, cache invalidation, and invalid-local fail-closed behavior.
+   Implement the path and both load pipelines, adapting to #675 first if it has landed.
+   Run package typecheck and the full package suite because `PolicyLoaderOptions` and `ResolvedPolicyPaths` are shared interfaces.
+   Commit: `feat(pi-permission-system): load project-local permission overrides (#691)`.
+
+2. **JSONC-preserving atomic writer.**
+   Audit and add `jsonc-parser`, then add focused red tests for rule upsert, string-surface expansion, last-match order, multi-pattern atomicity, preservation, validation, containment, symlink rejection, IO failure, and restoration.
+   Implement `persistent-permission-writer.ts` and keep it independent of UI and session state.
+   Commit: `feat(pi-permission-system): add atomic persistent rule writer (#691)`.
+
+3. **Persistent target and orchestration service.**
+   Add red tests for target paths, trust eligibility/recheck, global reload without untrusted project scope, project reload, review events, and rollback on reload failure.
+   Implement the target resolver and service over narrow writer/reloader/logger interfaces.
+   Commit: `feat(pi-permission-system): orchestrate durable approval persistence (#691)`.
+
+4. **Pure interactive-choice model.**
+   Add red reducer tests for local edit/project/global choices, multiple patterns, cancellation, sticky summary enablement, and complete summary data.
+   Keep forwarded configuration on the current four-option model.
+   Implement the private choice union and pure state transitions alongside the existing final-decision types so the repository remains type-correct.
+   Commit: `feat(pi-permission-system): model durable permission choices (#691)`.
+
+5. **TUI and fallback presentation.**
+   Add red component and fallback tests that render the same choices, edit every proposed pattern, show the exact destination when enabled, and persist the sticky summary preference.
+   Change both presenters to return `InteractivePermissionChoice` while keeping current once/session/deny behavior and non-TUI support.
+   Update all presenter test fixtures in the same commit because the return type changes across the TUI/fallback boundary.
+   Commit: `feat(pi-permission-system): present editable durable approval choices (#691)`.
+
+6. **Local authority and session-proposal wiring.**
+   Add red local-authorizer, pure-gate, runner, and selection tests for edited session recording, durable success/failure, forwarded suppression, and no persistence capability in the authorizer chain.
+   Introduce the local-authorizer factory, narrow the dependency bags, resolve private choices, and thread returned edited session proposals through `PermissionPromptDecision` → `applyPermissionGate` → `GateRunner` in one compile-coupled commit.
+   Preserve the UI-event ordering and prompt review-log bracket.
+   Commit: `feat(pi-permission-system): apply direct durable approval choices (#691)`.
+
+7. **Composition and security regressions.**
+   Add filesystem-backed composition tests for bash, path-bearing tools, `path`, `external_directory`, project/global precedence, project trust, write failure, reload failure, session shutdown, and cross-surface denies.
+   Fix only integration gaps revealed by those tests; do not broaden forwarding.
+   If code from [PR #73] was carried forward in cycles 2–6, add its `Co-authored-by` trailer to the corresponding implementation commit before publication.
+   Commit: `test(pi-permission-system): cover persistent approval integration (#691)`.
+
+8. **Documentation.**
+   Update the README, configuration, session approval, troubleshooting, and current architecture documentation.
+   Document how to remove a persisted rule, why project-local files should be ignored, how the sticky summary preference behaves, and why higher-precedence denies still win.
+   Commit: `docs(pi-permission-system): document persistent approvals (#691)`.
+
+## Risks and Mitigations
+
+- **A malicious or stale project loosens global policy.**
+  Require Pi project trust at load, offer, and write time; write only the local project file; retain higher-precedence and cross-surface denies.
+- **A convenience feature becomes an automatic policy-writing capability.**
+  Keep the private choice and persistence service exclusively behind `LocalUserAuthorizer`; automatic links never receive them.
+- **A write corrupts config or strips operator context.**
+  Use JSONC edits, validate the complete candidate, write a same-directory temporary file, and preserve/restore original bytes on failure.
+- **A local file leaks personal paths or policy if committed.**
+  Keep it in a dedicated `config.local.json` and document that users should ignore it rather than modifying `.gitignore` automatically.
+- **An existing surface string loses catch-all meaning.**
+  Expand it to an explicit `"*"` entry before appending the narrower rule and test exact resulting text and behavior.
+- **A global rule appears ineffective because a higher source wins.**
+  State this in the confirmation and docs; never bypass project, project-agent, or another permission surface to make the global rule win.
+- **Open PR #675 creates source-order conflicts.**
+  Rebase before implementation and extend its merge/cache primitives if present; a precedence integration test pins the combined order.
+- **Prompt complexity harms the fast path.**
+  Keep existing hotkeys and double-press behavior, show durable choices only for local asks with a proposal, and place editing/confirmation in explicit substeps.
+- **Multi-pattern asks persist only what the UI happened to display.**
+  Carry and show the complete proposal list and write it as one atomic batch.
+
+## Open Questions
+
+- The exact TUI keys for project, global, and edit may be adjusted during cycle 4 if they conflict with current editor behavior, but the semantic choices and confirmation requirements are fixed.
+- If `jsonc-parser` cannot satisfy byte-preservation assertions for an existing-key relocation, prefer a smaller custom span edit for that operation rather than falling back to whole-file serialization.
+- Requester-side persistence for forwarded asks is deferred until the protocol can return the human choice to the requester, which must check its own trust and perform the write.
+
+[PR #73]: https://github.com/gotgenes/pi-packages/pull/73
+[PR #675]: https://github.com/gotgenes/pi-packages/pull/675

--- a/packages/pi-permission-system/docs/retro/0691-persist-approved-permission-rules.md
+++ b/packages/pi-permission-system/docs/retro/0691-persist-approved-permission-rules.md
@@ -1,0 +1,68 @@
+---
+issue: 691
+issue_title: "pi-permission-system: persist approved permission rules at project or global scope"
+---
+
+# Retro: #691 — pi-permission-system: persist approved permission rules at project or global scope
+
+## Stage: Planning (2026-08-01T15:41:52Z)
+
+### Session summary
+
+Filed and reconciled issue #691, then produced the committed implementation plan for trusted project-local and global persistent approvals.
+The plan covers prompt choices, JSONC-preserving atomic mutation, source precedence, trust and tracking checks, review logging, tests, documentation, and release guidance.
+
+### Observations
+
+- Automatically written project rules go only to trusted-project `config.local.json`; shared project `config.json`, Pi `settings.json`, frontmatter, and `.gitignore` remain manually owned.
+- Closed PR #73 is credited as prior art, but its stale patch is not resurrected; any source carried forward must preserve `rienkim`'s authorship.
+- Issue #603 is the direct narrower project-persistence request, while #604 remains related through editable session patterns.
+- Forwarded asks retain their current once/session choices in the first release because requester-side project persistence requires a protocol round trip and a trust check in the requesting session.
+- Open PR #675 may change the policy-source merge implementation before TDD begins, so cycle 1 must rebase and extend its merge/cache primitives if it lands.
+- Design review found that persistence should enter through a local-authorizer factory plus prompt/persistence collaborators rather than widening `AuthorizerSelectionDeps` and `LocalUserAuthorizerDeps`.
+
+## Stage: Implementation — TDD (2026-08-01T16:29:19Z)
+
+### Session summary
+
+Implemented trusted project-local and global durable approvals through red/green cycles covering source precedence, JSONC-preserving atomic writes, trust/tracking revalidation, interactive choices, session proposal editing, fail-closed reload, and documentation.
+The final workspace suite passes with 2,698 `pi-permission-system` tests; type checking, root lint, and `pnpm fallow dead-code` also pass.
+
+### Observations
+
+- Durable prompts use the SDK `select` / `input` flow in every UI mode so editable text, exact destination confirmation, and typed acknowledgements have one implementation; the existing four-choice fast path remains in the inline keybind component.
+- `PersistentApprovalTargetResolver` and orchestration live in one focused service module rather than the plan's two target/service files.
+- Project writes are contained beneath the trusted cwd even when an intermediate config directory is a symlink; global writes are contained beneath the Pi agent directory.
+- A persistence or reload failure restores the original bytes, emits `permission_rule.persistence_failed`, and returns a denied prompt decision, so the pending call cannot execute under an unsaved approval.
+- Session approvals now return and record the complete edited multi-pattern proposal rather than only the original representative pattern.
+- PR #675 remained open, so no settings-policy merge helper was available to extend.
+- No source was copied from PR #73; its design prior art is credited in the plan, issue, and README, so no source commit needed a co-author trailer.
+- The planned Tidy-First and pre-completion subagent dispatchers were unavailable in this harness; the plan's structural review was applied directly, including the narrowed local-authorizer factory.
+- Pre-completion review: **WARN** — all deterministic gates and acceptance checks pass, but `mmdc` is unavailable for Mermaid validation and requester-side forwarded persistence is tracked only as follow-up bead `ai-82g.4`, not a separate public issue.
+
+## Stage: Ship (worktree) (2026-08-01T16:30:12Z)
+
+### Session summary
+
+Root lint, type checking, the full workspace test suite, and `pnpm fallow dead-code` pass.
+The plan recommends shipping independently; requester-side forwarded persistence remains deferred.
+
+**Peer session transcript:** unknown — recover through the session-file listing for this worktree if needed.
+
+### Observations
+
+The branch is ready to rebase onto `origin/main` and publish to the contributor fork for upstream review.
+
+## Stage: Hands-on UX correction (2026-08-01)
+
+### Session summary
+
+Manual testing exposed two UX problems that automated acceptance checks had missed: durable choices had temporarily bypassed the established inline shortcuts, and the planned confirmation flow stacked hotkey confirmation, a summary, and typed acknowledgements.
+The inline shortcuts were restored first; subsequent user testing removed Git tracking detection and all typed acknowledgements, while retaining the exact-rule summary as a sticky, default-on preference.
+
+### Observations
+
+- `e` and persistence choices that open a summary are non-destructive navigation, so they should not require double-press before opening their sub-step.
+- The summary remains useful because it shows the exact stored pattern and destination, but users can toggle **Show summary before saving** with `t` or `/permission-system`; the global preference persists across restarts.
+- Persisting a machine-local file does not warrant special Git tracking detection or a typed `tracked` acknowledgement; documentation still recommends ignoring `config.local.json`.
+- Global persistence no longer requires typing `global`; selecting the explicit global action provides sufficient intent, with the optional summary available for review.

--- a/packages/pi-permission-system/docs/session-approvals.md
+++ b/packages/pi-permission-system/docs/session-approvals.md
@@ -1,15 +1,37 @@
 # Session-Scoped Approvals
 
-When any permission resolves to `ask`, the permission dialog offers four options:
+When a permission resolves to `ask`, the local permission dialog offers these outcomes:
 
-```text
-Yes | Yes, allow "<pattern>" for this session | No | No, provide reason
-```
+- Approve this request once.
+- Approve the proposed pattern for this session.
+- Edit the proposed pattern.
+- Persist an `allow` rule to trusted project-local policy.
+- Persist an `allow` rule to global policy.
+- Deny, optionally with a reason.
 
-Selecting **Yes, allow "\<pattern\>" for this session** approves the current request and records the suggested wildcard pattern as a session rule.
-Subsequent requests that match the pattern skip the prompt for the remainder of the session.
+Selecting the session choice approves the current request and records the displayed wildcard pattern in memory.
+Subsequent requests that match it skip the prompt until `session_shutdown`.
+Editing changes the rule that is recorded; it never changes the permission surface.
 
-Session approvals are ephemeral — they are never persisted to disk and are cleared on `session_shutdown`.
+## Durable Approvals
+
+Project persistence writes only to `<cwd>/.pi/extensions/pi-permission-system/config.local.json`, and is offered only after Pi trusts the project.
+It never modifies shared project `config.json`, agent frontmatter, Pi settings, or `.gitignore`.
+Global persistence writes `~/.pi/agent/extensions/pi-permission-system/config.json` (respecting `PI_CODING_AGENT_DIR`).
+
+By default, a summary shows the surface, every exact pattern, `allow`, scope, and destination before writing.
+Press `t` in the inline prompt, or use `/permission-system` settings, to persistently toggle **Show summary before saving**.
+When the summary is disabled, selecting project or global persistence saves after the configured hotkey confirmation without a separate summary or typed acknowledgement.
+
+Writes preserve unrelated JSONC comments and formatting, validate the complete result, and atomically replace the destination.
+Policy reloads immediately.
+If writing or reload fails, the pending request is denied, the original file is restored, and the failure is recorded in the review log.
+
+Persistent rules use normal precedence and most-restrictive composition.
+A global or project-local allow cannot override a higher-precedence agent rule or a deny on `path` / `external_directory`.
+To roll back, remove the generated pattern from the displayed destination and reload Pi.
+
+Forwarded subagent prompts do not offer editing or durable persistence in this release because the requester must perform its own project-trust check.
 
 ## Suggested Patterns
 
@@ -51,6 +73,9 @@ The review log records session approval decisions:
 
 - `resolution: "approved_for_session"` — when the user approves with the session pattern
 - `resolution: "session_approved"` — when a later request is matched by an existing session rule
+- `permission_rule.persistence_requested` — before trust revalidation and mutation
+- `permission_rule.persistence_succeeded` — after atomic write and immediate reload
+- `permission_rule.persistence_failed` — when validation, trust, write, or reload blocks persistence
 
 ## Permission Prompt Summaries
 

--- a/packages/pi-permission-system/docs/troubleshooting.md
+++ b/packages/pi-permission-system/docs/troubleshooting.md
@@ -2,15 +2,16 @@
 
 ## Common Issues
 
-| Problem                                                           | Cause                                                             | Solution                                                                                                                                          |
-| ----------------------------------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Config not applied (everything asks)                              | File not found or parse error                                     | Verify the global config at `~/.pi/agent/extensions/pi-permission-system/config.json` (respects `PI_CODING_AGENT_DIR`); check for trailing commas |
-| Per-agent override not applied                                    | Frontmatter parsing issue                                         | Ensure `---` delimiters at file top; keep YAML simple; restart session                                                                            |
-| Tool blocked as unregistered                                      | Unknown tool name                                                 | Use a registered `mcp` tool for server tools: `{ "tool": "server:tool" }`                                                                         |
-| `/skill:<name>` blocked                                           | Deny policy or confirmation unavailable                           | Check merged `skill` policy (global/project/agent layers). `ask` still requires UI or forwarded confirmation.                                     |
-| External file path blocked                                        | `external_directory` is `ask` without UI or `deny`                | Allow/ask the permission or keep file tools inside the active working directory.                                                                  |
-| Spurious external-path prompt for `cd <subdir> && grep … ../path` | Relative path was resolved against cwd instead of the `cd` target | Fixed in current version — paths after a leading `cd <subdir> &&` are resolved against the cd target, matching actual shell behavior.             |
-| Permission prompt is too verbose                                  | Generic extension tool input is large                             | Built-in file tools are summarized automatically; third-party tools are capped to a bounded one-line JSON preview.                                |
+| Problem                                                           | Cause                                                                                    | Solution                                                                                                                                          |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Config not applied (everything asks)                              | File not found or parse error                                                            | Verify the global config at `~/.pi/agent/extensions/pi-permission-system/config.json` (respects `PI_CODING_AGENT_DIR`); check for trailing commas |
+| Per-agent override not applied                                    | Frontmatter parsing issue                                                                | Ensure `---` delimiters at file top; keep YAML simple; restart session                                                                            |
+| Tool blocked as unregistered                                      | Unknown tool name                                                                        | Use a registered `mcp` tool for server tools: `{ "tool": "server:tool" }`                                                                         |
+| `/skill:<name>` blocked                                           | Deny policy or confirmation unavailable                                                  | Check merged `skill` policy (global/project/agent layers). `ask` still requires UI or forwarded confirmation.                                     |
+| External file path blocked                                        | `external_directory` is `ask` without UI or `deny`                                       | Allow/ask the permission or keep file tools inside the active working directory.                                                                  |
+| Spurious external-path prompt for `cd <subdir> && grep … ../path` | Relative path was resolved against cwd instead of the `cd` target                        | Fixed in current version — paths after a leading `cd <subdir> &&` are resolved against the cd target, matching actual shell behavior.             |
+| Permission prompt is too verbose                                  | Generic extension tool input is large                                                    | Built-in file tools are summarized automatically; third-party tools are capped to a bounded one-line JSON preview.                                |
+| Durable approval is denied                                        | Project is untrusted, config is invalid, or atomic write/reload failed                   | Read the `permission_rule.persistence_failed` review entry, fix the displayed destination, and retry; the pending tool call remains blocked.      |
 
 ## Diagnostic Logging
 
@@ -26,6 +27,8 @@ This makes it easy to verify which files the extension actually loaded:
   "globalConfigExists": true,
   "projectConfigPath": "/…/my-project/.pi/extensions/pi-permission-system/config.json",
   "projectConfigExists": false,
+  "projectLocalConfigPath": "/…/my-project/.pi/extensions/pi-permission-system/config.local.json",
+  "projectLocalConfigExists": false,
   "agentsDir": "/…/.pi/agent/agents",
   "agentsDirExists": true,
   "projectAgentsDir": "/…/my-project/.pi/agents",

--- a/packages/pi-permission-system/package.json
+++ b/packages/pi-permission-system/package.json
@@ -89,6 +89,7 @@
     "vitest": "catalog:"
   },
   "dependencies": {
+    "jsonc-parser": "^3.3.1",
     "tree-sitter-bash": "^0.25.1",
     "web-tree-sitter": "^0.26.9",
     "zod": "^4.4.3"

--- a/packages/pi-permission-system/schemas/permissions.schema.json
+++ b/packages/pi-permission-system/schemas/permissions.schema.json
@@ -31,6 +31,12 @@
       "default": true,
       "type": "boolean"
     },
+    "showPersistenceSummary": {
+      "description": "Show the exact rule and destination before saving a persistent approval.",
+      "markdownDescription": "Show a summary of the exact surface, patterns, scope, action, and destination before saving a project-local or global approval. The inline prompt can toggle this sticky preference with `t`.",
+      "default": true,
+      "type": "boolean"
+    },
     "toolInputPreviewMaxLength": {
       "description": "Maximum character length of the inline-JSON tool-input preview shown in permission prompts. Omit to use the default (200). Set to a large value to disable truncation.",
       "markdownDescription": "Maximum character length of the inline-JSON tool-input preview shown in permission prompts.\n\nOmit to use the default (200). Set to a large value (e.g. `10000`) to effectively disable truncation and see the full input.",

--- a/packages/pi-permission-system/src/authority/authorizer.ts
+++ b/packages/pi-permission-system/src/authority/authorizer.ts
@@ -1,16 +1,10 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { PermissionPromptDecision } from "#src/authority/permission-dialog";
-import type {
-  PromptPreferences,
-  requestPermissionDecision,
-} from "#src/authority/permission-prompt-component";
 import type { SubagentSessionRegistry } from "#src/authority/subagent-registry";
-import type { PermissionEventBus } from "#src/permission-events";
 import type { AuthorizerLog, PermissionQuery } from "#src/service";
 import type { DebugReviewLogger } from "#src/session-logger";
 import { ParentAuthorizer } from "./approval-escalator";
 import { DenyingAuthorizer } from "./denying-authorizer";
-import { LocalUserAuthorizer } from "./local-user-authorizer";
 import type { PromptPermissionDetails } from "./permission-prompter";
 import type { SubagentDetector } from "./subagent-detection";
 
@@ -62,12 +56,8 @@ export interface TerminalAuthorizer {
 export interface AuthorizerSelectionDeps {
   /** Single owner of subagent detection; the ParentAuthorizer-selection predicate. */
   detection: SubagentDetector;
-  /** Event bus used by `LocalUserAuthorizer` for the `permissions:ui_prompt` broadcast. */
-  events: PermissionEventBus;
-  /** Read live at prompt time; threaded into `LocalUserAuthorizer`. */
-  getPromptPreferences: () => PromptPreferences;
-  /** Injected for testability; production callers pass the real function. */
-  requestPermissionDecision: typeof requestPermissionDecision;
+  /** Construct the direct local terminal for the active UI context. */
+  createLocalAuthorizer(ctx: ExtensionContext): TerminalAuthorizer;
   /** Forwarding directory `ParentAuthorizer` reads/writes request and response files under. */
   forwardingDir: string;
   /** In-process subagent session registry for forwarding target resolution. */
@@ -88,13 +78,7 @@ export function selectAuthorizer(
   deps: AuthorizerSelectionDeps,
 ): TerminalAuthorizer {
   if (ctx.hasUI) {
-    return new LocalUserAuthorizer({
-      ui: ctx.ui,
-      mode: ctx.mode,
-      events: deps.events,
-      getPromptPreferences: deps.getPromptPreferences,
-      requestPermissionDecision: deps.requestPermissionDecision,
-    });
+    return deps.createLocalAuthorizer(ctx);
   }
   if (deps.detection.isSubagent(ctx)) {
     return new ParentAuthorizer(ctx, {

--- a/packages/pi-permission-system/src/authority/interactive-permission-choice.ts
+++ b/packages/pi-permission-system/src/authority/interactive-permission-choice.ts
@@ -1,0 +1,29 @@
+import type {
+  PersistentApprovalScope,
+  PersistentApprovalTarget,
+} from "#src/persistent-approval-service";
+import type { PermissionPromptDecision } from "./permission-dialog";
+
+export interface PermissionRuleProposalData {
+  surface: string;
+  patterns: readonly string[];
+}
+
+export interface PersistentPermissionChoice {
+  kind: "persist";
+  scope: PersistentApprovalScope;
+  proposal: PermissionRuleProposalData;
+  target: PersistentApprovalTarget;
+  /** True only after the exact durable rule summary was rendered and confirmed. */
+  summaryShown: boolean;
+}
+
+export type InteractivePermissionChoice =
+  | PermissionPromptDecision
+  | PersistentPermissionChoice;
+
+export function isPersistentPermissionChoice(
+  choice: InteractivePermissionChoice,
+): choice is PersistentPermissionChoice {
+  return "kind" in choice;
+}

--- a/packages/pi-permission-system/src/authority/local-user-authorizer.ts
+++ b/packages/pi-permission-system/src/authority/local-user-authorizer.ts
@@ -1,7 +1,9 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
-import type {
-  PermissionPromptDecision,
-  RequestPermissionOptions,
+import { isPersistentPermissionChoice } from "#src/authority/interactive-permission-choice";
+import {
+  createDeniedPermissionDecision,
+  type PermissionPromptDecision,
+  type RequestPermissionOptions,
 } from "#src/authority/permission-dialog";
 import type {
   PermissionPromptUi,
@@ -14,6 +16,10 @@ import {
   type PermissionEventBus,
 } from "#src/permission-events";
 import { buildUiPrompt } from "#src/permission-ui-prompt";
+import type {
+  PersistentApprovalApi,
+  PersistentApprovalTarget,
+} from "#src/persistent-approval-service";
 import type { TerminalAuthorizer } from "./authorizer";
 import type { PromptPermissionDetails } from "./permission-prompter";
 
@@ -27,8 +33,12 @@ export interface LocalUserAuthorizerDeps {
   events: PermissionEventBus;
   /** Read live at prompt time so a settings-modal toggle takes effect on the next prompt. */
   getPromptPreferences: () => PromptPreferences;
+  /** Persist the sticky summary preference changed from the inline prompt. */
+  setShowPersistenceSummary?: (enabled: boolean) => boolean;
   /** Injected for testability; production callers pass the real function. */
   requestPermissionDecision: typeof requestPermissionDecision;
+  /** Present only for direct local sessions that may mutate durable policy. */
+  persistentApprovalService?: PersistentApprovalApi;
 }
 
 /**
@@ -44,24 +54,75 @@ export interface LocalUserAuthorizerDeps {
 export class LocalUserAuthorizer implements TerminalAuthorizer {
   constructor(private readonly deps: LocalUserAuthorizerDeps) {}
 
-  authorize(
+  async authorize(
     details: PromptPermissionDetails,
   ): Promise<PermissionPromptDecision> {
     const uiPrompt = buildUiPrompt(details);
     emitUiPromptEvent(this.deps.events, uiPrompt);
-    return this.deps.requestPermissionDecision(
+    const preferences = this.deps.getPromptPreferences();
+    const choice = await this.deps.requestPermissionDecision(
       {
         mode: this.deps.mode,
         ui: this.deps.ui,
-        doublePressToConfirm:
-          this.deps.getPromptPreferences().doublePressToConfirm,
+        doublePressToConfirm: preferences.doublePressToConfirm,
+        showPersistenceSummary: preferences.showPersistenceSummary,
+        setShowPersistenceSummary: this.deps.setShowPersistenceSummary,
       },
       details.forwarding
         ? "Permission Required (Subagent)"
         : "Permission Required",
       details.message,
-      buildRequestOptions(details),
+      buildRequestOptions(details, this.deps.persistentApprovalService),
     );
+    if (!isPersistentPermissionChoice(choice)) return choice;
+
+    if (
+      this.deps.getPromptPreferences().showPersistenceSummary &&
+      !choice.summaryShown
+    ) {
+      return createDeniedPermissionDecision(
+        "Persistent approval summary was not shown.",
+      );
+    }
+
+    if (!this.deps.persistentApprovalService) {
+      return createDeniedPermissionDecision(
+        "Persistent approval is unavailable in this session.",
+      );
+    }
+    try {
+      this.deps.persistentApprovalService.persist({
+        requestId: details.requestId,
+        target: choice.target,
+        surface: choice.proposal.surface,
+        patterns: choice.proposal.patterns,
+      });
+      return { approved: true, state: "approved" };
+    } catch (error) {
+      return createDeniedPermissionDecision(persistenceFailureReason(error));
+    }
+  }
+}
+
+/** Keep filesystem paths and other error details out of agent-visible denial text. */
+function persistenceFailureReason(error: unknown): string {
+  const code = safeErrorCode(error);
+  return code
+    ? `Persistent approval failed (${code}).`
+    : "Persistent approval failed.";
+}
+
+function safeErrorCode(error: unknown): string | undefined {
+  try {
+    const code =
+      typeof error === "object" && error !== null
+        ? (error as { code?: unknown }).code
+        : undefined;
+    return typeof code === "string" && /^[A-Z][A-Z0-9_]{0,63}$/.test(code)
+      ? code
+      : undefined;
+  } catch {
+    return undefined;
   }
 }
 
@@ -72,6 +133,7 @@ export class LocalUserAuthorizer implements TerminalAuthorizer {
  */
 function buildRequestOptions(
   details: PromptPermissionDetails,
+  persistence?: PersistentApprovalApi,
 ): RequestPermissionOptions | undefined {
   const pattern = details.sessionApproval?.patterns[0];
   if (details.forwarding && details.sessionApproval && pattern) {
@@ -83,7 +145,30 @@ function buildRequestOptions(
       ),
     };
   }
-  return details.sessionLabel
-    ? { sessionLabel: details.sessionLabel }
-    : undefined;
+  if (details.forwarding) {
+    return details.sessionLabel
+      ? { sessionLabel: details.sessionLabel }
+      : undefined;
+  }
+
+  const proposal = details.sessionApproval;
+  if (!proposal || !persistence) {
+    return details.sessionLabel
+      ? { sessionLabel: details.sessionLabel }
+      : undefined;
+  }
+  let projectTarget: PersistentApprovalTarget | undefined;
+  try {
+    projectTarget = persistence.prepare("project");
+  } catch {
+    projectTarget = undefined;
+  }
+  return {
+    ...(details.sessionLabel ? { sessionLabel: details.sessionLabel } : {}),
+    persistent: {
+      proposal,
+      ...(projectTarget ? { projectTarget } : {}),
+      globalTarget: persistence.prepare("global"),
+    },
+  };
 }

--- a/packages/pi-permission-system/src/authority/permission-dialog.ts
+++ b/packages/pi-permission-system/src/authority/permission-dialog.ts
@@ -1,3 +1,9 @@
+import type { PersistentApprovalTarget } from "#src/persistent-approval-service";
+import type {
+  InteractivePermissionChoice,
+  PermissionRuleProposalData,
+} from "./interactive-permission-choice";
+
 export type PermissionDecisionState =
   | "approved"
   | "approved_for_session"
@@ -9,19 +15,9 @@ export type PermissionPromptDecision = {
   approved: boolean;
   state: PermissionDecisionState;
   denialReason?: string;
-  /**
-   * True when the decision was made automatically by yolo mode rather than
-   * by an interactive user prompt. Used by handlers to emit "auto_approved"
-   * rather than "user_approved" in the permissions:decision broadcast.
-   */
+  /** Edited proposal to record when this is a local session approval. */
+  sessionApproval?: PermissionRuleProposalData;
   autoApproved?: true;
-  /**
-   * True when no live authority was reachable and the DenyingAuthorizer denied
-   * this ask (a no-UI, non-subagent session). Consumed by deriveResolution (the
-   * decision-event resolution), the gate (block reason), and PermissionPrompter
-   * (review-entry resolution) to emit "confirmation_unavailable" rather than a
-   * plain user denial.
-   */
   confirmationUnavailable?: true;
 };
 
@@ -32,16 +28,17 @@ export interface PermissionDecisionUi {
 
 const APPROVE_OPTION = "Yes";
 const APPROVE_FOR_SESSION_OPTION = "Yes, for this session";
+const EDIT_PATTERNS_OPTION = "Edit proposed pattern(s)";
+const APPROVE_FOR_PROJECT_OPTION = "Persist for this project";
+const APPROVE_GLOBALLY_OPTION = "Persist globally";
 const DENY_OPTION = "No";
 const DENY_WITH_REASON_OPTION = "No, provide reason";
+const CONFIRM_OPTION = "Confirm";
 
 export function normalizePermissionDenialReason(
   value: unknown,
 ): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-
+  if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
 }
@@ -56,10 +53,7 @@ export function createDeniedPermissionDecision(
         state: "denied_with_reason",
         denialReason: normalizedReason,
       }
-    : {
-        approved: false,
-        state: "denied",
-      };
+    : { approved: false, state: "denied" };
 }
 
 export function isPermissionDecisionState(
@@ -74,18 +68,20 @@ export function isPermissionDecisionState(
   );
 }
 
+export interface PersistentPromptOptions {
+  proposal: PermissionRuleProposalData;
+  projectTarget?: PersistentApprovalTarget;
+  globalTarget: PersistentApprovalTarget;
+}
+
 export interface RequestPermissionOptions {
-  /** Override the "for this session" option label (e.g. to show the suggested pattern). */
   sessionLabel?: string;
-  /**
-   * Forwarded asks only: when set, choosing the "for this session" option opens
-   * a second select asking whether the grant applies to the requesting subagent
-   * only (the least-privilege default) or the whole serving session.
-   */
   sessionScope?: {
     subagentLabel: string;
     servingSessionLabel: string;
   };
+  /** Local direct asks only; omitted for forwarded prompts. */
+  persistent?: PersistentPromptOptions;
 }
 
 export async function requestPermissionDecisionFromUi(
@@ -93,58 +89,150 @@ export async function requestPermissionDecisionFromUi(
   title: string,
   message: string,
   options?: RequestPermissionOptions,
-): Promise<PermissionPromptDecision> {
+  showPersistenceSummary = true,
+): Promise<InteractivePermissionChoice> {
   const sessionOption = options?.sessionLabel ?? APPROVE_FOR_SESSION_OPTION;
-  const decisionOptions = [
-    APPROVE_OPTION,
-    sessionOption,
-    DENY_OPTION,
-    DENY_WITH_REASON_OPTION,
-  ] as const;
+  let proposal = options?.persistent?.proposal;
 
-  const selected = await ui.select(`${title}\n${message}`, [
-    ...decisionOptions,
-  ]);
-
-  if (selected === APPROVE_OPTION) {
-    return {
-      approved: true,
-      state: "approved",
-    };
-  }
-
-  if (selected === sessionOption) {
-    if (options?.sessionScope) {
-      const scope = await ui.select(`${title}\nApply this session grant to:`, [
-        options.sessionScope.subagentLabel,
-        options.sessionScope.servingSessionLabel,
-      ]);
-      return {
-        approved: true,
-        // A cancelled scope select (undefined) falls back to the
-        // least-privilege subagent scope.
-        state:
-          scope === options.sessionScope.servingSessionLabel
-            ? "approved_for_serving_session"
-            : "approved_for_session",
-      };
+  for (;;) {
+    const decisionOptions = [APPROVE_OPTION, sessionOption];
+    if (proposal) decisionOptions.push(EDIT_PATTERNS_OPTION);
+    if (options?.persistent?.projectTarget) {
+      decisionOptions.push(APPROVE_FOR_PROJECT_OPTION);
     }
+    if (options?.persistent) decisionOptions.push(APPROVE_GLOBALLY_OPTION);
+    decisionOptions.push(DENY_OPTION, DENY_WITH_REASON_OPTION);
+
+    const selected = await ui.select(`${title}\n${message}`, decisionOptions);
+
+    if (selected === APPROVE_OPTION) {
+      return { approved: true, state: "approved" };
+    }
+    if (selected === EDIT_PATTERNS_OPTION && proposal) {
+      const edited = await editProposal(ui, title, proposal);
+      if (edited) proposal = edited;
+      continue;
+    }
+    if (selected === sessionOption) {
+      return chooseSessionScope(ui, title, options, proposal);
+    }
+    if (
+      selected === APPROVE_FOR_PROJECT_OPTION &&
+      proposal &&
+      options?.persistent?.projectTarget
+    ) {
+      return showPersistenceSummary
+        ? confirmPersistence(
+            ui,
+            title,
+            proposal,
+            options.persistent.projectTarget,
+          )
+        : persistentChoice(proposal, options.persistent.projectTarget, false);
+    }
+    if (
+      selected === APPROVE_GLOBALLY_OPTION &&
+      proposal &&
+      options?.persistent
+    ) {
+      return showPersistenceSummary
+        ? confirmPersistence(
+            ui,
+            title,
+            proposal,
+            options.persistent.globalTarget,
+          )
+        : persistentChoice(proposal, options.persistent.globalTarget, false);
+    }
+    if (selected === DENY_WITH_REASON_OPTION) {
+      const denialReason = normalizePermissionDenialReason(
+        await ui.input(
+          `${title}\nShare why this request was denied (optional).`,
+          "Reason shown back to the agent",
+        ),
+      );
+      return createDeniedPermissionDecision(denialReason);
+    }
+    return createDeniedPermissionDecision();
+  }
+}
+
+async function editProposal(
+  ui: PermissionDecisionUi,
+  title: string,
+  proposal: PermissionRuleProposalData,
+): Promise<PermissionRuleProposalData | undefined> {
+  const patterns: string[] = [];
+  for (const pattern of proposal.patterns) {
+    const edited = (
+      await ui.input(
+        `${title}\nEdit the exact ${proposal.surface} pattern:`,
+        pattern,
+      )
+    )?.trim();
+    if (!edited) return undefined;
+    patterns.push(edited);
+  }
+  return { surface: proposal.surface, patterns: [...new Set(patterns)] };
+}
+
+async function chooseSessionScope(
+  ui: PermissionDecisionUi,
+  title: string,
+  options: RequestPermissionOptions | undefined,
+  proposal: PermissionRuleProposalData | undefined,
+): Promise<PermissionPromptDecision> {
+  if (!options?.sessionScope) {
     return {
       approved: true,
       state: "approved_for_session",
+      ...(proposal ? { sessionApproval: proposal } : {}),
     };
   }
+  const scope = await ui.select(`${title}\nApply this session grant to:`, [
+    options.sessionScope.subagentLabel,
+    options.sessionScope.servingSessionLabel,
+  ]);
+  return {
+    approved: true,
+    state:
+      scope === options.sessionScope.servingSessionLabel
+        ? "approved_for_serving_session"
+        : "approved_for_session",
+  };
+}
 
-  if (selected === DENY_WITH_REASON_OPTION) {
-    const denialReason = normalizePermissionDenialReason(
-      await ui.input(
-        `${title}\nShare why this request was denied (optional).`,
-        "Reason shown back to the agent",
-      ),
-    );
+async function confirmPersistence(
+  ui: PermissionDecisionUi,
+  title: string,
+  proposal: PermissionRuleProposalData,
+  target: PersistentApprovalTarget,
+): Promise<InteractivePermissionChoice> {
+  const summary = [
+    title,
+    `Scope: ${target.scope === "project" ? "project-local" : "global"}`,
+    `Surface: ${proposal.surface}`,
+    "Patterns:",
+    ...proposal.patterns.map((pattern) => `  - ${pattern}`),
+    "Action: allow",
+    `File: ${target.path}`,
+  ].join("\n");
+  const confirmed = await ui.select(summary, [CONFIRM_OPTION, "Cancel"]);
+  return confirmed === CONFIRM_OPTION
+    ? persistentChoice(proposal, target, true)
+    : createDeniedPermissionDecision();
+}
 
-    return createDeniedPermissionDecision(denialReason);
-  }
-
-  return createDeniedPermissionDecision();
+function persistentChoice(
+  proposal: PermissionRuleProposalData,
+  target: PersistentApprovalTarget,
+  summaryShown: boolean,
+): InteractivePermissionChoice {
+  return {
+    kind: "persist",
+    scope: target.scope,
+    proposal,
+    target,
+    summaryShown,
+  };
 }

--- a/packages/pi-permission-system/src/authority/permission-prompt-component.ts
+++ b/packages/pi-permission-system/src/authority/permission-prompt-component.ts
@@ -9,8 +9,8 @@ import {
   truncateToWidth,
   wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
+import type { InteractivePermissionChoice } from "#src/authority/interactive-permission-choice";
 import {
-  type PermissionPromptDecision,
   type RequestPermissionOptions,
   requestPermissionDecisionFromUi,
 } from "#src/authority/permission-dialog";
@@ -20,18 +20,11 @@ import {
   type PromptKey,
   type PromptModelConfig,
   type PromptViewState,
+  promptKeys,
   reducePrompt,
 } from "#src/authority/permission-prompt-decision";
 
-/**
- * Inline `ctx.ui.custom` permission dialog for TUI sessions.
- *
- * All interaction logic lives in the pure {@link reducePrompt} model; this
- * module is the thin adapter that renders the model's state to lines, maps raw
- * keystrokes to {@link PromptEvent}s, and resolves the `ctx.ui.custom` promise
- * with the committed {@link PermissionPromptDecision}. The component renders
- * inline (never as an overlay).
- */
+/** Inline `ctx.ui.custom` permission dialog for TUI sessions. */
 
 /** The subset of the session UI surface the inline dialog needs. */
 export type PermissionPromptUi = Pick<
@@ -47,30 +40,37 @@ export interface PermissionPromptView {
   mode: ExtensionContext["mode"];
   ui: PermissionPromptUi;
   doublePressToConfirm: boolean;
+  showPersistenceSummary: boolean;
+  /** Persist a changed summary preference; false leaves the current value unchanged. */
+  setShowPersistenceSummary?(enabled: boolean): boolean;
 }
 
-/** Live prompt-behavior preferences read at prompt time (see `doublePressToConfirm`). */
+/** Live prompt-behavior preferences read at prompt time. */
 export interface PromptPreferences {
   doublePressToConfirm: boolean;
+  showPersistenceSummary: boolean;
 }
 
 /**
- * Route a permission ask to the inline keybind dialog in TUI mode, or the
- * `select()`/`input()` flow otherwise (RPC / frontend — the #519 constraint).
- *
- * The single entry the `LocalUserAuthorizer` calls; keeps the mode dispatch in
- * one place so the fallback and the inline component never both render.
+ * Route TUI asks to the inline keybind dialog and non-TUI asks to the SDK
+ * select/input flow. Both presenters expose the same durable choices.
  */
 export function requestPermissionDecision(
   view: PermissionPromptView,
   title: string,
   message: string,
   options?: RequestPermissionOptions,
-): Promise<PermissionPromptDecision> {
+): Promise<InteractivePermissionChoice> {
   if (view.mode === "tui") {
     return presentInlinePermissionPrompt(view, title, message, options);
   }
-  return requestPermissionDecisionFromUi(view.ui, title, message, options);
+  return requestPermissionDecisionFromUi(
+    view.ui,
+    title,
+    message,
+    options,
+    view.showPersistenceSummary,
+  );
 }
 
 /** Minimal theme surface the dialog uses; satisfied by the real SDK theme. */
@@ -83,24 +83,27 @@ const DEFAULT_SESSION_LABEL = "Yes, for this session";
 const OPTION_LABELS: Record<PromptKey, string> = {
   y: "Yes",
   s: DEFAULT_SESSION_LABEL,
+  e: "Edit proposed pattern(s)",
+  p: "Persist for this project",
+  g: "Persist globally",
   n: "No",
   r: "No, provide reason",
 };
-
-const OPTION_ORDER: readonly PromptKey[] = ["y", "s", "n", "r"];
 
 export function presentInlinePermissionPrompt(
   view: PermissionPromptView,
   title: string,
   message: string,
   options?: RequestPermissionOptions,
-): Promise<PermissionPromptDecision> {
+): Promise<InteractivePermissionChoice> {
   const config: PromptModelConfig = {
     doublePressToConfirm: view.doublePressToConfirm,
     sessionLabel: options?.sessionLabel ?? DEFAULT_SESSION_LABEL,
+    showPersistenceSummary: view.showPersistenceSummary,
     sessionScope: options?.sessionScope,
+    persistent: options?.persistent,
   };
-  return view.ui.custom<PermissionPromptDecision>(
+  return view.ui.custom<InteractivePermissionChoice>(
     (tui, theme, keybindings, done) =>
       new PermissionPromptComponent(
         theme,
@@ -108,6 +111,9 @@ export function presentInlinePermissionPrompt(
         title,
         message,
         (data) => handleToolsExpandAction(data, keybindings, view.ui),
+        view.setShowPersistenceSummary
+          ? (enabled) => view.setShowPersistenceSummary?.(enabled) ?? false
+          : undefined,
         () => {
           tui.requestRender();
         },
@@ -117,27 +123,13 @@ export function presentInlinePermissionPrompt(
   );
 }
 
-/**
- * Forward Pi's tool-expansion action while the dialog holds keyboard focus.
- *
- * A focused `ctx.ui.custom` component consumes every keystroke, so `Ctrl+O`
- * would otherwise be dead for the duration of an ask — exactly when the user
- * most needs to see the full pending tool invocation. Returns `true` when the
- * keystroke was the action (and was handled), so the caller stops before
- * mapping it to a {@link PromptEvent}; expansion is a display concern and must
- * never reach the decision model.
- *
- * Deliberately does not request a render: `setToolsExpanded` re-renders the
- * host itself, and the dialog's own lines are unaffected by tool expansion.
- */
+/** Forward Pi's tool-expansion action while the dialog owns keyboard focus. */
 function handleToolsExpandAction(
   data: string,
   keybindings: PromptKeybindings,
   ui: PermissionPromptUi,
 ): boolean {
-  if (!keybindings.matches(data, "app.tools.expand")) {
-    return false;
-  }
+  if (!keybindings.matches(data, "app.tools.expand")) return false;
   ui.setToolsExpanded(!ui.getToolsExpanded());
   return true;
 }
@@ -145,15 +137,20 @@ function handleToolsExpandAction(
 class PermissionPromptComponent implements Component {
   private state: PromptViewState;
   private reasonBuffer = "";
+  private editBuffer = "";
+  private persistenceSummaryRendered = false;
 
   constructor(
     private readonly theme: PromptTheme,
-    private readonly config: PromptModelConfig,
+    private config: PromptModelConfig,
     private readonly title: string,
     private readonly message: string,
     private readonly handleAppAction: (data: string) => boolean,
+    private readonly setShowPersistenceSummary:
+      | ((enabled: boolean) => boolean)
+      | undefined,
     private readonly requestRender: () => void,
-    private readonly done: (decision: PermissionPromptDecision) => void,
+    private readonly done: (decision: InteractivePermissionChoice) => void,
   ) {
     this.state = initialPromptState(config);
   }
@@ -174,42 +171,86 @@ class PermissionPromptComponent implements Component {
         return this.renderReason();
       case "scope":
         return this.renderScope();
+      case "edit":
+        return this.renderEdit();
+      case "persistent-confirm":
+        this.persistenceSummaryRendered = true;
+        return this.renderPersistenceConfirmation();
     }
   }
 
   handleInput(data: string): void {
     if (this.state.step === "reason") {
-      this.handleReasonInput(data);
+      this.handleTextInput(data, "reason");
       return;
     }
-    if (this.handleAppAction(data)) {
+    if (this.state.step === "edit") {
+      this.handleTextInput(data, "edit");
+      return;
+    }
+    if (
+      this.config.persistent &&
+      (this.state.step === "decision" ||
+        this.state.step === "persistent-confirm") &&
+      matchesKey(data, "t")
+    ) {
+      this.togglePersistenceSummary();
+      return;
+    }
+    if (this.handleAppAction(data)) return;
+    if (
+      this.state.step === "persistent-confirm" &&
+      matchesKey(data, "enter") &&
+      !this.persistenceSummaryRendered
+    ) {
+      this.requestRender();
       return;
     }
     const event = this.toEvent(data);
-    if (event) {
-      this.apply(event);
-    }
+    if (event) this.apply(event);
   }
 
-  private handleReasonInput(data: string): void {
+  private handleTextInput(data: string, mode: "reason" | "edit"): void {
     if (matchesKey(data, "enter")) {
-      this.apply({ type: "submitReason", draft: this.reasonBuffer });
+      const event: PromptEvent =
+        mode === "reason"
+          ? { type: "submitReason", draft: this.reasonBuffer }
+          : { type: "submitEdit", draft: this.editBuffer };
+      this.apply(event);
       return;
     }
     if (matchesKey(data, "escape")) {
-      this.reasonBuffer = "";
+      this.clearBuffer(mode);
       this.apply({ type: "cancel" });
       return;
     }
     if (matchesKey(data, "backspace")) {
-      this.reasonBuffer = this.reasonBuffer.slice(0, -1);
+      this.setBuffer(mode, this.getBuffer(mode).slice(0, -1));
+      this.requestRender();
+      return;
+    }
+    if (data === "\u0015") {
+      this.setBuffer(mode, "");
       this.requestRender();
       return;
     }
     if (isPrintable(data)) {
-      this.reasonBuffer += data;
+      this.setBuffer(mode, this.getBuffer(mode) + data);
       this.requestRender();
     }
+  }
+
+  private getBuffer(mode: "reason" | "edit"): string {
+    return mode === "reason" ? this.reasonBuffer : this.editBuffer;
+  }
+
+  private setBuffer(mode: "reason" | "edit", value: string): void {
+    if (mode === "reason") this.reasonBuffer = value;
+    else this.editBuffer = value;
+  }
+
+  private clearBuffer(mode: "reason" | "edit"): void {
+    this.setBuffer(mode, "");
   }
 
   private toEvent(data: string): PromptEvent | undefined {
@@ -219,49 +260,81 @@ class PermissionPromptComponent implements Component {
     if (matchesKey(data, "down") || matchesKey(data, "j")) {
       return { type: "nav", direction: "down" };
     }
-    if (matchesKey(data, "enter")) {
-      return { type: "confirm" };
-    }
-    if (matchesKey(data, "escape")) {
-      return { type: "cancel" };
-    }
+    if (matchesKey(data, "enter")) return { type: "confirm" };
+    if (matchesKey(data, "escape")) return { type: "cancel" };
     if (this.state.step === "decision") {
-      const key = OPTION_ORDER.find((option) => matchesKey(data, option));
-      if (key) {
-        return { type: "hotkey", key };
-      }
+      const key = promptKeys(this.config).find((option) =>
+        matchesKey(data, option),
+      );
+      if (key) return { type: "hotkey", key };
     }
     return undefined;
   }
 
   private apply(event: PromptEvent): void {
+    const previous = this.state;
     const outcome = reducePrompt(this.config, this.state, event);
     if (outcome.kind === "decision") {
       this.done(outcome.decision);
       return;
     }
-    if (outcome.state.step === "reason" && this.state.step !== "reason") {
+    this.state = outcome.state;
+    if (
+      this.state.step === "persistent-confirm" &&
+      previous.step !== "persistent-confirm"
+    ) {
+      this.persistenceSummaryRendered = false;
+    }
+    this.syncBuffers(previous);
+    this.requestRender();
+  }
+
+  private syncBuffers(previous: PromptViewState): void {
+    if (this.state.step === "reason" && previous.step !== "reason") {
       this.reasonBuffer = "";
     }
-    this.state = outcome.state;
+    if (
+      this.state.step === "edit" &&
+      (previous.step !== "edit" || previous.editIndex !== this.state.editIndex)
+    ) {
+      this.editBuffer =
+        this.state.editPatterns?.[this.state.editIndex ?? 0] ?? "";
+    }
+  }
+
+  private togglePersistenceSummary(): void {
+    const enabled = !this.config.showPersistenceSummary;
+    if (
+      this.setShowPersistenceSummary &&
+      !this.setShowPersistenceSummary(enabled)
+    ) {
+      return;
+    }
+    this.config = { ...this.config, showPersistenceSummary: enabled };
     this.requestRender();
   }
 
   private renderDecision(): string[] {
     const lines = [this.theme.fg("accent", this.title), this.message, ""];
-    for (const key of OPTION_ORDER) {
+    for (const key of promptKeys(this.config)) {
       const label = key === "s" ? this.config.sessionLabel : OPTION_LABELS[key];
       const selected = this.state.highlightedKey === key;
       const marker = selected ? "▶" : " ";
       const row = `${marker} (${key}) ${label}`;
       lines.push(selected ? this.theme.fg("accent", row) : row);
     }
+    if (this.config.persistent) {
+      lines.push(
+        "",
+        `  (t) ${this.config.showPersistenceSummary ? "[x]" : "[ ]"} Show summary before saving`,
+      );
+    }
     lines.push("");
     lines.push(
       this.state.hint ||
         this.theme.fg(
           "muted",
-          "↑/↓ move · enter confirm · esc deny · press a letter, then again to confirm",
+          "↑/↓ or j/k move · enter confirm · esc deny · press a letter, then again to confirm",
         ),
     );
     return lines;
@@ -277,18 +350,21 @@ class PermissionPromptComponent implements Component {
     if (this.state.reasonError) {
       lines.push(this.theme.fg("error", this.state.reasonError));
     }
-    lines.push("");
-    lines.push(this.theme.fg("muted", "enter submit · esc back"));
+    lines.push(
+      "",
+      this.theme.fg("muted", "enter submit · ctrl+u clear · esc back"),
+    );
     return lines;
   }
 
   private renderScope(): string[] {
     const scope = this.config.sessionScope;
-    const subagentLabel = scope?.subagentLabel ?? "This subagent only";
-    const servingLabel = scope?.servingSessionLabel ?? "The whole session";
     const rows: Array<{ label: string; serving: boolean }> = [
-      { label: subagentLabel, serving: false },
-      { label: servingLabel, serving: true },
+      { label: scope?.subagentLabel ?? "This subagent only", serving: false },
+      {
+        label: scope?.servingSessionLabel ?? "The whole session",
+        serving: true,
+      },
     ];
     const lines = [
       this.theme.fg("accent", this.title),
@@ -297,27 +373,62 @@ class PermissionPromptComponent implements Component {
     ];
     for (const row of rows) {
       const selected = this.state.scopeServing === row.serving;
-      const marker = selected ? "▶" : " ";
-      const text = `${marker} ${row.label}`;
+      const text = `${selected ? "▶" : " "} ${row.label}`;
       lines.push(selected ? this.theme.fg("accent", text) : text);
     }
-    lines.push("");
-    lines.push(this.theme.fg("muted", "↑/↓ move · enter confirm · esc back"));
+    lines.push(
+      "",
+      this.theme.fg("muted", "↑/↓ or j/k move · enter confirm · esc back"),
+    );
+    return lines;
+  }
+
+  private renderEdit(): string[] {
+    const proposal = this.state.proposal;
+    const count = this.state.editPatterns?.length ?? 0;
+    const editIndex = this.state.editIndex ?? 0;
+    const lines = [
+      this.theme.fg("accent", this.title),
+      `Edit ${proposal?.surface ?? "permission"} pattern ${editIndex + 1}/${count}:`,
+      "",
+      `Pattern: ${this.editBuffer}\u2588`,
+    ];
+    if (this.state.editError) {
+      lines.push(this.theme.fg("error", this.state.editError));
+    }
+    lines.push(
+      "",
+      this.theme.fg(
+        "muted",
+        "enter accept · backspace edit · ctrl+u clear · esc back",
+      ),
+    );
+    return lines;
+  }
+
+  private renderPersistenceConfirmation(): string[] {
+    const target = this.state.persistenceTarget;
+    const proposal = this.state.proposal;
+    const lines = [
+      this.theme.fg("accent", this.title),
+      `Scope: ${target?.scope === "project" ? "project-local" : "global"}`,
+      `Surface: ${proposal?.surface ?? "unknown"}`,
+      "Patterns:",
+      ...(proposal?.patterns.map((pattern) => `  - ${pattern}`) ?? []),
+      "Action: allow",
+      `File: ${target?.path ?? "unknown"}`,
+      "",
+      `  (t) ${this.config.showPersistenceSummary ? "[x]" : "[ ]"} Show summary before saving`,
+      "",
+      this.theme.fg("muted", "enter save · t toggle · esc back"),
+    ];
     return lines;
   }
 }
 
-/**
- * Fit rendered lines to the terminal width, satisfying the `ctx.ui.custom`
- * contract that every returned line be a single visual row no wider than
- * `width`. Long lines (e.g. a wide tool-preview message) are wrapped rather
- * than clipped so no content is lost; the final `truncateToWidth` guards the
- * edge cases `wrapTextWithAnsi` cannot split (a lone wide grapheme).
- */
+/** Fit every rendered line to the terminal width. */
 function fitToWidth(lines: string[], width: number): string[] {
-  if (width <= 0) {
-    return [];
-  }
+  if (width <= 0) return [];
   return lines.flatMap((line) =>
     wrapTextWithAnsi(line, width).map((wrapped) =>
       truncateToWidth(wrapped, width),
@@ -326,9 +437,7 @@ function fitToWidth(lines: string[], width: number): string[] {
 }
 
 function isPrintable(data: string): boolean {
-  if (data.length !== 1) {
-    return false;
-  }
+  if (data.length !== 1) return false;
   const code = data.charCodeAt(0);
   return code >= 0x20 && code !== 0x7f;
 }

--- a/packages/pi-permission-system/src/authority/permission-prompt-decision.ts
+++ b/packages/pi-permission-system/src/authority/permission-prompt-decision.ts
@@ -1,31 +1,40 @@
+import type {
+  InteractivePermissionChoice,
+  PermissionRuleProposalData,
+} from "#src/authority/interactive-permission-choice";
 import {
   createDeniedPermissionDecision,
   normalizePermissionDenialReason,
-  type PermissionPromptDecision,
+  type PersistentPromptOptions,
   type RequestPermissionOptions,
 } from "#src/authority/permission-dialog";
+import type { PersistentApprovalTarget } from "#src/persistent-approval-service";
 
 /**
  * Pure decision model for the inline keybind permission dialog.
  *
  * The interaction logic — which hotkey produces which decision, double-press
- * arming, step transitions, and reason validation — lives here with no SDK or
- * TUI imports, so it is unit-testable directly. The `ctx.ui.custom` component
- * ({@link file://./permission-prompt-component.ts}) is a thin adapter that
- * forwards keystrokes to {@link reducePrompt} and renders the returned state.
+ * arming, step transitions, editing, and persistence confirmation — lives here
+ * with no SDK or TUI imports. The component is only a rendering/input adapter.
  */
 
-/** The four decision hotkeys, in display order. */
-export type PromptKey = "y" | "s" | "n" | "r";
+/** Decision hotkeys, in their display order when every choice is available. */
+export type PromptKey = "y" | "s" | "e" | "p" | "g" | "n" | "r";
 
 /** Which sub-view the dialog is showing. */
-export type PromptStep = "decision" | "reason" | "scope";
-
-const OPTION_ORDER: readonly PromptKey[] = ["y", "s", "n", "r"];
+export type PromptStep =
+  | "decision"
+  | "reason"
+  | "scope"
+  | "edit"
+  | "persistent-confirm";
 
 const OPTION_VERBS: Record<PromptKey, string> = {
   y: "approve",
   s: "approve for this session",
+  e: "edit the proposed patterns",
+  p: "persist for this project",
+  g: "persist globally",
   n: "deny",
   r: "deny with a reason",
 };
@@ -36,12 +45,12 @@ export interface PromptModelConfig {
   doublePressToConfirm: boolean;
   /** Label shown beside the approve-for-session option. */
   sessionLabel: string;
-  /**
-   * Forwarded asks only: when set, confirming `s` opens a second step choosing
-   * whether the grant applies to the requesting subagent only (least-privilege
-   * default) or the whole serving session.
-   */
+  /** Show the exact durable rule and destination before saving it. */
+  showPersistenceSummary: boolean;
+  /** Forwarded-ask session-scope choices. */
   sessionScope?: NonNullable<RequestPermissionOptions["sessionScope"]>;
+  /** Local-direct durable choices; absent for forwarded asks. */
+  persistent?: PersistentPromptOptions;
 }
 
 /** The re-render view state the component draws from. */
@@ -50,13 +59,15 @@ export interface PromptViewState {
   highlightedKey: PromptKey;
   /** Set only while awaiting the confirming second press of a hotkey. */
   armedKey?: PromptKey;
-  /** "Press y again to approve." while armed; empty otherwise. */
   hint: string;
   reasonDraft: string;
-  /** Set when an empty reason submit is rejected. */
   reasonError?: string;
-  /** Scope step: false = subagent-only (default), true = whole serving session. */
   scopeServing: boolean;
+  proposal?: PermissionRuleProposalData;
+  editPatterns?: string[];
+  editIndex?: number;
+  editError?: string;
+  persistenceTarget?: PersistentApprovalTarget;
 }
 
 /** An input event the reducer understands. */
@@ -65,16 +76,26 @@ export type PromptEvent =
   | { type: "hotkey"; key: PromptKey }
   | { type: "confirm" }
   | { type: "cancel" }
-  | { type: "submitReason"; draft: string };
+  | { type: "submitReason"; draft: string }
+  | { type: "submitEdit"; draft: string };
 
-/** Either a re-render or a terminal decision. */
+/** Either a re-render or a terminal choice. */
 export type PromptOutcome =
   | { kind: "render"; state: PromptViewState }
-  | { kind: "decision"; decision: PermissionPromptDecision };
+  | { kind: "decision"; decision: InteractivePermissionChoice };
 
-export function initialPromptState(
-  _config: PromptModelConfig,
-): PromptViewState {
+export function promptKeys(config: PromptModelConfig): readonly PromptKey[] {
+  const keys: PromptKey[] = ["y", "s"];
+  if (config.persistent) {
+    keys.push("e");
+    if (config.persistent.projectTarget) keys.push("p");
+    keys.push("g");
+  }
+  keys.push("n", "r");
+  return keys;
+}
+
+export function initialPromptState(config: PromptModelConfig): PromptViewState {
   return {
     step: "decision",
     highlightedKey: "y",
@@ -83,13 +104,17 @@ export function initialPromptState(
     reasonDraft: "",
     reasonError: undefined,
     scopeServing: false,
+    ...(config.persistent
+      ? {
+          proposal: config.persistent.proposal,
+          editPatterns: [],
+          editIndex: 0,
+        }
+      : {}),
   };
 }
 
-/**
- * Advance the dialog by one input event, returning either the next view state
- * to render or the committed {@link PermissionPromptDecision}.
- */
+/** Advance the dialog by one input event. */
 export function reducePrompt(
   config: PromptModelConfig,
   state: PromptViewState,
@@ -102,6 +127,10 @@ export function reducePrompt(
       return reduceReasonStep(state, event);
     case "scope":
       return reduceScopeStep(state, event);
+    case "edit":
+      return reduceEditStep(state, event);
+    case "persistent-confirm":
+      return reducePersistentConfirmStep(state, event);
   }
 }
 
@@ -114,17 +143,18 @@ function reduceDecisionStep(
     case "nav":
       return render({
         ...state,
-        highlightedKey: shiftKey(state.highlightedKey, event.direction),
+        highlightedKey: shiftKey(config, state.highlightedKey, event.direction),
         armedKey: undefined,
         hint: "",
       });
     case "hotkey":
+      if (!promptKeys(config).includes(event.key)) return render(state);
       return pressHotkey(config, state, event.key);
     case "confirm":
       return commit(config, state, state.highlightedKey);
     case "cancel":
       return { kind: "decision", decision: createDeniedPermissionDecision() };
-    case "submitReason":
+    default:
       return render(state);
   }
 }
@@ -134,7 +164,14 @@ function pressHotkey(
   state: PromptViewState,
   key: PromptKey,
 ): PromptOutcome {
-  if (!config.doublePressToConfirm || state.armedKey === key) {
+  const opensNonDestructiveStep =
+    key === "e" ||
+    ((key === "p" || key === "g") && config.showPersistenceSummary);
+  if (
+    opensNonDestructiveStep ||
+    !config.doublePressToConfirm ||
+    state.armedKey === key
+  ) {
     return commit(config, state, key);
   }
   return render({
@@ -156,18 +193,6 @@ function commit(
         kind: "decision",
         decision: { approved: true, state: "approved" },
       };
-    case "n":
-      return { kind: "decision", decision: createDeniedPermissionDecision() };
-    case "r":
-      return render({
-        ...state,
-        step: "reason",
-        highlightedKey: "r",
-        armedKey: undefined,
-        hint: "",
-        reasonDraft: "",
-        reasonError: undefined,
-      });
     case "s":
       if (config.sessionScope) {
         return render({
@@ -181,40 +206,84 @@ function commit(
       }
       return {
         kind: "decision",
-        decision: { approved: true, state: "approved_for_session" },
+        decision: {
+          approved: true,
+          state: "approved_for_session",
+          ...(state.proposal ? { sessionApproval: state.proposal } : {}),
+        },
       };
+    case "e":
+      if (!state.proposal) return render(state);
+      return render({
+        ...state,
+        step: "edit",
+        highlightedKey: "e",
+        armedKey: undefined,
+        hint: "",
+        editPatterns: [...state.proposal.patterns],
+        editIndex: 0,
+        editError: undefined,
+      });
+    case "p": {
+      const target = config.persistent?.projectTarget;
+      return target ? beginPersistence(config, state, target) : render(state);
+    }
+    case "g": {
+      const target = config.persistent?.globalTarget;
+      return target ? beginPersistence(config, state, target) : render(state);
+    }
+    case "n":
+      return { kind: "decision", decision: createDeniedPermissionDecision() };
+    case "r":
+      return render({
+        ...state,
+        step: "reason",
+        highlightedKey: "r",
+        armedKey: undefined,
+        hint: "",
+        reasonDraft: "",
+        reasonError: undefined,
+      });
   }
+}
+
+function beginPersistence(
+  config: PromptModelConfig,
+  state: PromptViewState,
+  target: PersistentApprovalTarget,
+): PromptOutcome {
+  if (!state.proposal) return render(state);
+  if (!config.showPersistenceSummary) {
+    return persistentChoice(state, target, false);
+  }
+  return render({
+    ...state,
+    step: "persistent-confirm",
+    armedKey: undefined,
+    hint: "",
+    persistenceTarget: target,
+  });
 }
 
 function reduceReasonStep(
   state: PromptViewState,
   event: PromptEvent,
 ): PromptOutcome {
-  if (event.type === "cancel") {
+  if (event.type === "cancel") return backToDecision(state);
+  if (event.type !== "submitReason") return render(state);
+
+  const reason = normalizePermissionDenialReason(event.draft);
+  if (reason === undefined) {
     return render({
       ...state,
-      step: "decision",
-      armedKey: undefined,
-      hint: "",
-      reasonDraft: "",
-      reasonError: undefined,
+      reasonDraft: event.draft,
+      reasonError: "A reason is required.",
     });
   }
-  if (event.type === "submitReason") {
-    const reason = normalizePermissionDenialReason(event.draft);
-    if (reason === undefined) {
-      return render({
-        ...state,
-        reasonDraft: event.draft,
-        reasonError: "A reason is required.",
-      });
-    }
-    return {
-      kind: "decision",
-      decision: createDeniedPermissionDecision(reason),
-    };
-  }
-  return render(state);
+  return {
+    kind: "decision",
+    decision: createDeniedPermissionDecision(reason),
+  };
 }
 
 function reduceScopeStep(
@@ -235,22 +304,108 @@ function reduceScopeStep(
         },
       };
     case "cancel":
-      return render({
-        ...state,
-        step: "decision",
-        armedKey: undefined,
-        hint: "",
-      });
+      return backToDecision(state);
     default:
       return render(state);
   }
 }
 
-function shiftKey(current: PromptKey, direction: "up" | "down"): PromptKey {
-  const index = OPTION_ORDER.indexOf(current);
+function reduceEditStep(
+  state: PromptViewState,
+  event: PromptEvent,
+): PromptOutcome {
+  if (event.type === "cancel") return backToDecision(state);
+  if (event.type !== "submitEdit") return render(state);
+
+  const edited = event.draft.trim();
+  if (!edited) {
+    return render({ ...state, editError: "A pattern is required." });
+  }
+  const editIndex = state.editIndex ?? 0;
+  const patterns = [...(state.editPatterns ?? [])];
+  patterns[editIndex] = edited;
+  if (editIndex + 1 < patterns.length) {
+    return render({
+      ...state,
+      editPatterns: patterns,
+      editIndex: editIndex + 1,
+      editError: undefined,
+    });
+  }
+  return render({
+    ...state,
+    step: "decision",
+    highlightedKey: "e",
+    armedKey: undefined,
+    hint: "",
+    proposal: {
+      surface: state.proposal?.surface ?? "*",
+      patterns: [...new Set(patterns)],
+    },
+    editPatterns: [],
+    editIndex: 0,
+    editError: undefined,
+  });
+}
+
+function reducePersistentConfirmStep(
+  state: PromptViewState,
+  event: PromptEvent,
+): PromptOutcome {
+  if (event.type === "cancel") return backToDecision(state);
+  if (event.type !== "confirm") return render(state);
+
+  const target = state.persistenceTarget;
+  return target ? persistentChoice(state, target, true) : backToDecision(state);
+}
+
+function persistentChoice(
+  state: PromptViewState,
+  target: PersistentApprovalTarget,
+  summaryShown: boolean,
+): PromptOutcome {
+  if (!state.proposal) return backToDecision(state);
+  return {
+    kind: "decision",
+    decision: {
+      kind: "persist",
+      scope: target.scope,
+      proposal: state.proposal,
+      target,
+      summaryShown,
+    },
+  };
+}
+
+function backToDecision(state: PromptViewState): PromptOutcome {
+  return render({
+    ...state,
+    step: "decision",
+    armedKey: undefined,
+    hint: "",
+    reasonDraft: "",
+    reasonError: undefined,
+    ...(state.proposal
+      ? {
+          editPatterns: [],
+          editIndex: 0,
+          editError: undefined,
+          persistenceTarget: undefined,
+        }
+      : {}),
+  });
+}
+
+function shiftKey(
+  config: PromptModelConfig,
+  current: PromptKey,
+  direction: "up" | "down",
+): PromptKey {
+  const keys = promptKeys(config);
+  const index = keys.indexOf(current);
   const delta = direction === "down" ? 1 : -1;
-  const next = (index + delta + OPTION_ORDER.length) % OPTION_ORDER.length;
-  return OPTION_ORDER[next] ?? current;
+  const next = (index + delta + keys.length) % keys.length;
+  return keys[next] ?? current;
 }
 
 function render(state: PromptViewState): PromptOutcome {

--- a/packages/pi-permission-system/src/config-loader.ts
+++ b/packages/pi-permission-system/src/config-loader.ts
@@ -7,6 +7,7 @@ import {
   getLegacyGlobalPolicyPath,
   getLegacyProjectPolicyPath,
   getProjectConfigPath,
+  getProjectLocalConfigPath,
 } from "./config-paths";
 import {
   type ShellToolsConfig,
@@ -199,7 +200,7 @@ function formatConfigIssues(error: ZodError): string[] {
  */
 // Scalar knobs merged by override-replaces-base; keep in sync with
 // PermissionSystemExtensionConfig booleans (debugLog, permissionReviewLog,
-// yoloMode, doublePressToConfirm).
+// yoloMode, doublePressToConfirm, showPersistenceSummary).
 export function mergeUnifiedConfigs(
   base: UnifiedPermissionConfig,
   override: UnifiedPermissionConfig,
@@ -212,6 +213,7 @@ export function mergeUnifiedConfigs(
     "permissionReviewLog",
     "yoloMode",
     "doublePressToConfirm",
+    "showPersistenceSummary",
   ] as const) {
     const value = override[key] ?? base[key];
     if (value !== undefined) {
@@ -281,7 +283,8 @@ export interface MergedConfigResult {
  * 2. Legacy extension runtime config (if present and path differs from new global)
  * 3. New global config
  * 4. Legacy project policy (if present)
- * 5. New project config — highest precedence
+ * 5. New shared project config
+ * 6. New project-local config — highest precedence
  *
  * Legacy files are detected and warned about. Their content is parsed with the
  * flat-format parser — legacy-format keys (defaultPolicy, tools, bash, etc.)
@@ -304,6 +307,7 @@ export function loadAndMergeConfigs(
 
   const newGlobalPath = getGlobalConfigPath(agentDir);
   const newProjectPath = getProjectConfigPath(cwd);
+  const newProjectLocalPath = getProjectLocalConfigPath(cwd);
   const legacyGlobalPolicyPath = getLegacyGlobalPolicyPath(agentDir);
   const legacyProjectPolicyPath = getLegacyProjectPolicyPath(cwd);
   const legacyExtConfigPath = getLegacyExtensionConfigPath(extensionRoot);
@@ -359,13 +363,19 @@ export function loadAndMergeConfigs(
     merged = mergeUnifiedConfigs(merged, legacy.config);
   }
 
-  // 5. New project config — skipped when the project scope is withheld, so an
-  // untrusted project contributes nothing and `project` reports empty.
+  // 5–6. Shared and local project config — both are skipped when the project
+  // scope is withheld, so an untrusted project contributes nothing.
   const projectResult = includeProjectScope
     ? loadUnifiedConfig(newProjectPath)
     : { config: {}, issues: [] };
-  allIssues.push(...projectResult.issues);
-  const projectConfig = projectResult.config;
+  const projectLocalResult = includeProjectScope
+    ? loadUnifiedConfig(newProjectLocalPath)
+    : { config: {}, issues: [] };
+  allIssues.push(...projectResult.issues, ...projectLocalResult.issues);
+  const projectConfig = mergeUnifiedConfigs(
+    projectResult.config,
+    projectLocalResult.config,
+  );
   merged = mergeUnifiedConfigs(merged, projectConfig);
 
   const bashFallbackIssue = detectPermissiveBashFallback(merged.permission);

--- a/packages/pi-permission-system/src/config-modal.ts
+++ b/packages/pi-permission-system/src/config-modal.ts
@@ -52,6 +52,7 @@ function cloneDefaultConfig(): PermissionSystemExtensionConfig {
     permissionReviewLog: DEFAULT_EXTENSION_CONFIG.permissionReviewLog,
     yoloMode: DEFAULT_EXTENSION_CONFIG.yoloMode,
     doublePressToConfirm: DEFAULT_EXTENSION_CONFIG.doublePressToConfirm,
+    showPersistenceSummary: DEFAULT_EXTENSION_CONFIG.showPersistenceSummary,
   };
 }
 
@@ -122,6 +123,14 @@ function buildSettingItems(
       currentValue: toOnOff(config.doublePressToConfirm),
       values: ON_OFF,
     },
+    {
+      id: "showPersistenceSummary",
+      label: "Show summary before saving",
+      description:
+        "Show the exact persistent rule and destination before saving it",
+      currentValue: toOnOff(config.showPersistenceSummary),
+      values: ON_OFF,
+    },
   ];
 }
 
@@ -139,6 +148,8 @@ function applySetting(
       return { ...config, debugLog: value === "on" };
     case "doublePressToConfirm":
       return { ...config, doublePressToConfirm: value === "on" };
+    case "showPersistenceSummary":
+      return { ...config, showPersistenceSummary: value === "on" };
     default:
       return config;
   }
@@ -157,6 +168,10 @@ function syncSettingValues(
   settingsList.updateValue(
     "doublePressToConfirm",
     toOnOff(config.doublePressToConfirm),
+  );
+  settingsList.updateValue(
+    "showPersistenceSummary",
+    toOnOff(config.showPersistenceSummary),
   );
 }
 

--- a/packages/pi-permission-system/src/config-paths.ts
+++ b/packages/pi-permission-system/src/config-paths.ts
@@ -21,6 +21,10 @@ export function getProjectConfigPath(cwd: string): string {
   return join(cwd, ".pi", "extensions", EXTENSION_ID, "config.json");
 }
 
+export function getProjectLocalConfigPath(cwd: string): string {
+  return join(cwd, ".pi", "extensions", EXTENSION_ID, "config.local.json");
+}
+
 /**
  * Directory holding project-scoped custom agent definition files.
  *

--- a/packages/pi-permission-system/src/config-reporter.ts
+++ b/packages/pi-permission-system/src/config-reporter.ts
@@ -5,6 +5,8 @@ export interface ResolvedConfigLogEntry {
   globalConfigExists: boolean;
   projectConfigPath: string | null;
   projectConfigExists: boolean;
+  projectLocalConfigPath: string | null;
+  projectLocalConfigExists: boolean;
   agentsDir: string;
   agentsDirExists: boolean;
   projectAgentsDir: string | null;

--- a/packages/pi-permission-system/src/config-schema.ts
+++ b/packages/pi-permission-system/src/config-schema.ts
@@ -187,6 +187,13 @@ export const unifiedConfigSchema = z
         "Require a confirming second press of a decision hotkey (`y`/`s`/`n`/`r`) in the inline permission dialog before it commits — the first press arms the action and shows a `Press y again to approve.` hint.\n\nApplies to interactive **TUI** sessions only; the non-TUI (RPC/frontend) prompt keeps its single-select flow. Set to `false` to commit decisions on the first hotkey press.",
       default: true,
     }),
+    showPersistenceSummary: z.boolean().optional().meta({
+      description:
+        "Show the exact rule and destination before saving a persistent approval.",
+      markdownDescription:
+        "Show a summary of the exact surface, patterns, scope, action, and destination before saving a project-local or global approval. The inline prompt can toggle this sticky preference with `t`.",
+      default: true,
+    }),
     toolInputPreviewMaxLength: z.number().int().min(1).optional().meta({
       description:
         "Maximum character length of the inline-JSON tool-input preview shown in permission prompts. Omit to use the default (200). Set to a large value to disable truncation.",

--- a/packages/pi-permission-system/src/config-store.ts
+++ b/packages/pi-permission-system/src/config-store.ts
@@ -11,7 +11,11 @@ import type {
   ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
 
-import { loadAndMergeConfigs, loadUnifiedConfig } from "./config-loader";
+import {
+  loadAndMergeConfigs,
+  loadUnifiedConfig,
+  type UnifiedPermissionConfig,
+} from "./config-loader";
 import {
   getGlobalConfigPath,
   getLegacyExtensionConfigPath,
@@ -148,33 +152,21 @@ export class ConfigStore implements SessionConfigStore, CommandConfigStore {
   ): void {
     const normalized = normalizePermissionSystemConfig(next);
     const globalPath = getGlobalConfigPath(this.deps.agentDir);
-
     const existing = loadUnifiedConfig(globalPath);
     const merged = {
       ...existing.config,
       debugLog: normalized.debugLog,
       permissionReviewLog: normalized.permissionReviewLog,
       yoloMode: normalized.yoloMode,
+      doublePressToConfirm: normalized.doublePressToConfirm,
+      showPersistenceSummary: normalized.showPersistenceSummary,
     };
 
-    const tmpPath = `${globalPath}.tmp`;
-    try {
-      mkdirSync(dirname(globalPath), { recursive: true });
-      writeFileSync(tmpPath, `${JSON.stringify(merged, null, 2)}\n`, "utf-8");
-      renameSync(tmpPath, globalPath);
-    } catch (error) {
-      try {
-        if (existsSync(tmpPath)) {
-          unlinkSync(tmpPath);
-        }
-      } catch {
-        // Ignore cleanup failures.
-      }
-      const message = error instanceof Error ? error.message : String(error);
-      ctx.ui.notify(
-        `Failed to save permission-system config at '${globalPath}': ${message}`,
-        "error",
-      );
+    if (
+      !this.writeGlobalConfig(globalPath, merged, (message) =>
+        ctx.ui.notify(message, "error"),
+      )
+    ) {
       return;
     }
 
@@ -186,7 +178,51 @@ export class ConfigStore implements SessionConfigStore, CommandConfigStore {
       debugLog: normalized.debugLog,
       permissionReviewLog: normalized.permissionReviewLog,
       yoloMode: normalized.yoloMode,
+      doublePressToConfirm: normalized.doublePressToConfirm,
+      showPersistenceSummary: normalized.showPersistenceSummary,
     });
+  }
+
+  /** Persist the sticky summary preference without copying project overrides globally. */
+  setShowPersistenceSummary(
+    enabled: boolean,
+    notify: (message: string) => void,
+  ): boolean {
+    const globalPath = getGlobalConfigPath(this.deps.agentDir);
+    const existing = loadUnifiedConfig(globalPath);
+    const merged = { ...existing.config, showPersistenceSummary: enabled };
+    if (!this.writeGlobalConfig(globalPath, merged, notify)) return false;
+
+    this.config = { ...this.config, showPersistenceSummary: enabled };
+    this.deps.logger.debug("config.prompt_preference_saved", {
+      showPersistenceSummary: enabled,
+    });
+    return true;
+  }
+
+  private writeGlobalConfig(
+    globalPath: string,
+    config: UnifiedPermissionConfig,
+    notify: (message: string) => void,
+  ): boolean {
+    const tmpPath = `${globalPath}.tmp`;
+    try {
+      mkdirSync(dirname(globalPath), { recursive: true });
+      writeFileSync(tmpPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+      renameSync(tmpPath, globalPath);
+      return true;
+    } catch (error) {
+      try {
+        if (existsSync(tmpPath)) unlinkSync(tmpPath);
+      } catch {
+        // Ignore cleanup failures.
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      notify(
+        `Failed to save permission-system config at '${globalPath}': ${message}`,
+      );
+      return false;
+    }
   }
 
   /**

--- a/packages/pi-permission-system/src/extension-config.ts
+++ b/packages/pi-permission-system/src/extension-config.ts
@@ -18,6 +18,8 @@ export interface PermissionSystemExtensionConfig {
   yoloMode: boolean;
   /** Require a confirming second press of a decision hotkey in the inline TUI dialog. Defaults to true. */
   doublePressToConfirm: boolean;
+  /** Show the exact durable rule and destination before saving. Defaults to true. */
+  showPersistenceSummary: boolean;
   /** Additional directories to auto-allow for reads as Pi infrastructure. */
   piInfrastructureReadPaths?: string[];
   /** Max length of the inline-JSON input preview shown in permission prompts. Defaults to 200. */
@@ -35,6 +37,7 @@ export const DEFAULT_EXTENSION_CONFIG: PermissionSystemExtensionConfig = {
   permissionReviewLog: true,
   yoloMode: false,
   doublePressToConfirm: true,
+  showPersistenceSummary: true,
 };
 
 function resolveExtensionRoot(moduleUrl = import.meta.url): string {
@@ -67,6 +70,7 @@ export function normalizePermissionSystemConfig(
     permissionReviewLog: raw.permissionReviewLog !== false,
     yoloMode: raw.yoloMode === true,
     doublePressToConfirm: raw.doublePressToConfirm !== false,
+    showPersistenceSummary: raw.showPersistenceSummary !== false,
   };
   if (raw.piInfrastructureReadPaths !== undefined) {
     result.piInfrastructureReadPaths = raw.piInfrastructureReadPaths;

--- a/packages/pi-permission-system/src/handlers/gates/runner.ts
+++ b/packages/pi-permission-system/src/handlers/gates/runner.ts
@@ -8,6 +8,7 @@ import {
 } from "#src/denial-messages";
 import { applyPermissionGate } from "#src/permission-gate";
 import type { ScopedPermissionResolver } from "#src/permission-resolver";
+import { SessionApproval } from "#src/session-approval";
 import type { SessionApprovalRecorder } from "#src/session-approval-recorder";
 import type { PermissionCheckResult } from "#src/types";
 import type { GateDescriptor, GateResult } from "./descriptor";
@@ -184,8 +185,13 @@ export class GateRunner {
 
     // 6. Record session approval — tell the store; it owns the per-pattern loop
     // hasSessionApproval already implies gateResult.action === "allow"
-    if (hasSessionApproval && descriptor.sessionApproval) {
-      this.recorder.recordSessionApproval(descriptor.sessionApproval);
+    if (hasSessionApproval && gateResult.sessionApproval) {
+      this.recorder.recordSessionApproval(
+        SessionApproval.multiple(
+          gateResult.sessionApproval.surface,
+          gateResult.sessionApproval.patterns,
+        ),
+      );
     }
 
     if (gateResult.action === "block") {

--- a/packages/pi-permission-system/src/index.ts
+++ b/packages/pi-permission-system/src/index.ts
@@ -9,6 +9,7 @@ import {
   type ServingPolicy,
 } from "./authority/forwarded-request-server";
 import { ForwardingManager } from "./authority/forwarding-manager";
+import { LocalUserAuthorizer } from "./authority/local-user-authorizer";
 import { requestPermissionDecision } from "./authority/permission-prompt-component";
 import { PermissionPrompter } from "./authority/permission-prompter";
 import { SubagentDetection } from "./authority/subagent-detection";
@@ -36,6 +37,11 @@ import { PermissionManager } from "./permission-manager";
 import { PermissionResolver } from "./permission-resolver";
 import { PermissionSession } from "./permission-session";
 import { LocalPermissionsService } from "./permissions-service";
+import {
+  PersistentApprovalService,
+  PersistentApprovalTargetResolver,
+} from "./persistent-approval-service";
+import { PersistentPermissionWriter } from "./persistent-permission-writer";
 import { PermissionServiceLifecycle } from "./service-lifecycle";
 import { PermissionSessionLogger } from "./session-logger";
 import { SessionRules } from "./session-rules";
@@ -104,11 +110,31 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
 
   const authorizerSelection = new AuthorizerSelection({
     detection: subagentDetection,
-    events: pi.events,
-    getPromptPreferences: () => ({
-      doublePressToConfirm: configStore.current().doublePressToConfirm,
-    }),
-    requestPermissionDecision,
+    createLocalAuthorizer: (ctx) =>
+      new LocalUserAuthorizer({
+        ui: ctx.ui,
+        mode: ctx.mode,
+        events: pi.events,
+        getPromptPreferences: () => ({
+          doublePressToConfirm: configStore.current().doublePressToConfirm,
+          showPersistenceSummary: configStore.current().showPersistenceSummary,
+        }),
+        setShowPersistenceSummary: (enabled) =>
+          configStore.setShowPersistenceSummary(enabled, (message) =>
+            ctx.ui.notify(message, "error"),
+          ),
+        requestPermissionDecision,
+        persistentApprovalService: new PersistentApprovalService({
+          targetResolver: new PersistentApprovalTargetResolver({
+            agentDir,
+            cwd: ctx.cwd,
+            isProjectTrusted: () => ctx.isProjectTrusted(),
+          }),
+          writer: new PersistentPermissionWriter(),
+          reload: (cwd) => permissionManager.configureForCwd(cwd),
+          logger,
+        }),
+      }),
     forwardingDir: paths.forwardingDir,
     registry: subagentRegistry,
     logger,

--- a/packages/pi-permission-system/src/permission-gate.ts
+++ b/packages/pi-permission-system/src/permission-gate.ts
@@ -2,7 +2,10 @@ import type { PermissionPromptDecision } from "#src/authority/permission-dialog"
 
 /** Result of applying the permission gate. */
 export type PermissionGateResult =
-  | { action: "allow"; sessionApproval?: { surface: string; pattern: string } }
+  | {
+      action: "allow";
+      sessionApproval?: { surface: string; patterns: readonly string[] };
+    }
   | { action: "block"; reason: string };
 
 /** Everything the gate needs — no direct dependency on ExtensionContext. */
@@ -22,7 +25,7 @@ export interface PermissionGateParams {
    * "for this session". When present and the decision is `approved_for_session`,
    * the result carries the suggestion back to the caller for recording.
    */
-  sessionApproval?: { surface: string; pattern: string };
+  sessionApproval?: { surface: string; patterns: readonly string[] };
 
   /** Write a review-log entry. Called for deny and ask-but-unavailable paths. */
   writeLog: (event: string, extra: Record<string, unknown>) => void;
@@ -70,7 +73,10 @@ export async function applyPermissionGate(
       };
     }
     if (decision.state === "approved_for_session" && params.sessionApproval) {
-      return { action: "allow", sessionApproval: params.sessionApproval };
+      return {
+        action: "allow",
+        sessionApproval: decision.sessionApproval ?? params.sessionApproval,
+      };
     }
   }
 

--- a/packages/pi-permission-system/src/permission-manager.ts
+++ b/packages/pi-permission-system/src/permission-manager.ts
@@ -7,6 +7,7 @@ import {
   getGlobalConfigPath,
   getProjectAgentsDir,
   getProjectConfigPath,
+  getProjectLocalConfigPath,
 } from "./config-paths";
 import { normalizeFlatConfig } from "./normalize";
 import { type PathFlavor, posixPathFlavor } from "./path/path-flavor";
@@ -384,6 +385,7 @@ function derivePolicyLoaderOptions(
     globalConfigPath: getGlobalConfigPath(agentDir),
     agentsDir: join(agentDir, "agents"),
     projectGlobalConfigPath: cwd ? getProjectConfigPath(cwd) : undefined,
+    projectLocalConfigPath: cwd ? getProjectLocalConfigPath(cwd) : undefined,
     projectAgentsDir: cwd ? getProjectAgentsDir(cwd) : undefined,
   };
 }

--- a/packages/pi-permission-system/src/persistent-approval-service.ts
+++ b/packages/pi-permission-system/src/persistent-approval-service.ts
@@ -1,0 +1,148 @@
+import { dirname } from "node:path";
+import {
+  getGlobalConfigDir,
+  getGlobalConfigPath,
+  getProjectLocalConfigPath,
+} from "./config-paths";
+import type {
+  PersistentPermissionWriteRequest,
+  PersistentPermissionWriteResult,
+} from "./persistent-permission-writer";
+import type { ReviewLogger } from "./session-logger";
+
+export type PersistentApprovalScope = "project" | "global";
+
+export interface PersistentApprovalTarget {
+  scope: PersistentApprovalScope;
+  path: string;
+  expectedDir: string;
+  /** Trusted containment root used to reject symlinked directory escapes. */
+  expectedRoot?: string;
+  /** Project scope to retain while reloading, if currently trusted. */
+  reloadCwd?: string;
+}
+
+interface PersistentApprovalTargetResolverDeps {
+  agentDir: string;
+  cwd: string;
+  isProjectTrusted(): boolean;
+}
+
+export class PersistentApprovalTargetResolver {
+  constructor(private readonly deps: PersistentApprovalTargetResolverDeps) {}
+
+  resolve(scope: PersistentApprovalScope): PersistentApprovalTarget {
+    if (scope === "global") {
+      return {
+        scope,
+        path: getGlobalConfigPath(this.deps.agentDir),
+        expectedDir: getGlobalConfigDir(this.deps.agentDir),
+        expectedRoot: this.deps.agentDir,
+        ...(this.deps.isProjectTrusted() ? { reloadCwd: this.deps.cwd } : {}),
+      };
+    }
+
+    if (!this.deps.isProjectTrusted()) {
+      throw new Error("Project approvals require a trusted project.");
+    }
+    const path = getProjectLocalConfigPath(this.deps.cwd);
+    return {
+      scope,
+      path,
+      expectedDir: dirname(path),
+      expectedRoot: this.deps.cwd,
+      reloadCwd: this.deps.cwd,
+    };
+  }
+}
+
+interface PermissionRuleWriter {
+  write(
+    request: PersistentPermissionWriteRequest,
+  ): PersistentPermissionWriteResult;
+}
+
+interface PersistentApprovalServiceDeps {
+  targetResolver: PersistentApprovalTargetResolver;
+  writer: PermissionRuleWriter;
+  reload(cwd: string | undefined): void;
+  logger: ReviewLogger;
+}
+
+export interface PersistApprovalRequest {
+  requestId: string;
+  target: PersistentApprovalTarget;
+  surface: string;
+  patterns: readonly string[];
+}
+
+export interface PersistApprovalResult {
+  path: string;
+}
+
+export interface PersistentApprovalApi {
+  prepare(scope: PersistentApprovalScope): PersistentApprovalTarget;
+  persist(request: PersistApprovalRequest): PersistApprovalResult;
+}
+
+export class PersistentApprovalService implements PersistentApprovalApi {
+  constructor(private readonly deps: PersistentApprovalServiceDeps) {}
+
+  prepare(scope: PersistentApprovalScope): PersistentApprovalTarget {
+    return this.deps.targetResolver.resolve(scope);
+  }
+
+  // fallow-ignore-next-line unused-class-member -- invoked through PersistentApprovalApi
+  persist(request: PersistApprovalRequest): PersistApprovalResult {
+    const details = {
+      requestId: request.requestId,
+      scope: request.target.scope,
+      surface: request.surface,
+      patterns: [...request.patterns],
+      destination: request.target.path,
+    };
+    this.deps.logger.review("permission_rule.persistence_requested", details);
+
+    try {
+      const target = this.revalidateTarget(request);
+      const written = this.deps.writer.write({
+        path: target.path,
+        expectedDir: target.expectedDir,
+        expectedRoot: target.expectedRoot,
+        surface: request.surface,
+        patterns: request.patterns,
+      });
+      try {
+        this.deps.reload(target.reloadCwd);
+      } catch (error) {
+        written.restore();
+        throw error;
+      }
+
+      this.deps.logger.review("permission_rule.persistence_succeeded", details);
+      return { path: written.path };
+    } catch (error) {
+      this.deps.logger.review("permission_rule.persistence_failed", {
+        ...details,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
+  private revalidateTarget(
+    request: PersistApprovalRequest,
+  ): PersistentApprovalTarget {
+    const current = this.deps.targetResolver.resolve(request.target.scope);
+    if (
+      current.path !== request.target.path ||
+      current.expectedDir !== request.target.expectedDir ||
+      current.expectedRoot !== request.target.expectedRoot
+    ) {
+      throw new Error(
+        "Permission approval destination changed before persistence.",
+      );
+    }
+    return current;
+  }
+}

--- a/packages/pi-permission-system/src/persistent-permission-writer.ts
+++ b/packages/pi-permission-system/src/persistent-permission-writer.ts
@@ -1,0 +1,210 @@
+import { randomUUID } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { applyEdits, modify, type ParseError, parse } from "jsonc-parser";
+import { unifiedConfigSchema } from "./config-schema";
+
+export interface PersistentPermissionWriteRequest {
+  path: string;
+  expectedDir: string;
+  /** Trusted containment root; defaults to expectedDir for direct callers. */
+  expectedRoot?: string;
+  surface: string;
+  patterns: readonly string[];
+}
+
+export interface PersistentPermissionWriteResult {
+  path: string;
+  restore(): void;
+}
+
+/** Atomically upsert human-approved allow rules into one JSONC config file. */
+export class PersistentPermissionWriter {
+  write(
+    request: PersistentPermissionWriteRequest,
+  ): PersistentPermissionWriteResult {
+    const path = assertSafeDestination(
+      request.path,
+      request.expectedDir,
+      request.expectedRoot ?? request.expectedDir,
+    );
+    const original = existsSync(path) ? readFileSync(path, "utf8") : null;
+    const source = original ?? "{}\n";
+    validateConfig(source);
+
+    const candidate = addAllowRules(
+      source,
+      request.surface,
+      normalizePatterns(request.patterns),
+    );
+    validateConfig(candidate);
+    atomicReplace(path, candidate);
+
+    let restored = false;
+    return {
+      path,
+      restore: () => {
+        if (restored) return;
+        restored = true;
+        if (original === null) {
+          if (existsSync(path)) unlinkSync(path);
+          return;
+        }
+        atomicReplace(path, original);
+      },
+    };
+  }
+}
+
+function assertSafeDestination(
+  path: string,
+  expectedDir: string,
+  expectedRoot: string,
+): string {
+  const normalizedDir = resolve(expectedDir);
+  const normalizedRoot = resolve(expectedRoot);
+  const normalizedPath = resolve(path);
+  const pathFromDir = relative(normalizedDir, normalizedPath);
+  if (
+    dirname(normalizedPath) !== normalizedDir ||
+    pathFromDir.startsWith("..") ||
+    isAbsolute(pathFromDir)
+  ) {
+    throw new Error(
+      "Permission config destination is outside the expected directory.",
+    );
+  }
+
+  mkdirSync(normalizedDir, { recursive: true, mode: 0o700 });
+  const realRoot = realpathSync(normalizedRoot);
+  const realParent = realpathSync(dirname(normalizedPath));
+  const parentFromRoot = relative(realRoot, realParent);
+  if (
+    parentFromRoot.startsWith("..") ||
+    isAbsolute(parentFromRoot) ||
+    realParent !== realpathSync(normalizedDir)
+  ) {
+    throw new Error(
+      "Permission config destination resolves outside the expected directory.",
+    );
+  }
+  if (
+    existsSync(normalizedPath) &&
+    lstatSync(normalizedPath).isSymbolicLink()
+  ) {
+    throw new Error(
+      "Permission config destination must not be a symbolic link.",
+    );
+  }
+  return normalizedPath;
+}
+
+function normalizePatterns(patterns: readonly string[]): string[] {
+  const normalized = [...new Set(patterns.map((pattern) => pattern.trim()))];
+  if (normalized.length === 0 || normalized.some((pattern) => pattern === "")) {
+    throw new Error("At least one non-empty permission pattern is required.");
+  }
+  return normalized;
+}
+
+function addAllowRules(
+  source: string,
+  surface: string,
+  patterns: readonly string[],
+): string {
+  let text = source;
+  let parsed = parseConfig(text);
+  const permission = asRecord(asRecord(parsed).permission);
+  const existingSurface = permission[surface];
+
+  if (typeof existingSurface === "string") {
+    text = applyModification(text, ["permission", surface], {
+      "*": existingSurface,
+    });
+  }
+
+  for (const pattern of patterns) {
+    parsed = parseConfig(text);
+    const surfaceRules = asRecord(
+      asRecord(asRecord(parsed).permission)[surface],
+    );
+    if (Object.hasOwn(surfaceRules, pattern)) {
+      text = applyModification(
+        text,
+        ["permission", surface, pattern],
+        undefined,
+      );
+    }
+    text = applyModification(text, ["permission", surface, pattern], "allow");
+  }
+
+  return text;
+}
+
+function applyModification(
+  source: string,
+  path: (string | number)[],
+  value: unknown,
+): string {
+  return applyEdits(
+    source,
+    modify(source, path, value, {
+      formattingOptions: { insertSpaces: true, tabSize: 2 },
+    }),
+  );
+}
+
+function parseConfig(source: string): unknown {
+  const errors: ParseError[] = [];
+  const parsed = parse(source, errors, {
+    allowTrailingComma: true,
+    disallowComments: false,
+  }) as unknown;
+  if (errors.length > 0) {
+    throw new Error("Invalid permission config: malformed JSONC.");
+  }
+  return parsed;
+}
+
+function validateConfig(source: string): void {
+  const parsed = parseConfig(source);
+  const result = unifiedConfigSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(`Invalid permission config: ${result.error.message}`);
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function atomicReplace(path: string, content: string): void {
+  const temporaryPath = `${path}.${randomUUID()}.tmp`;
+  let fd: number | null = null;
+  try {
+    fd = openSync(temporaryPath, "wx", 0o600);
+    writeFileSync(fd, content, "utf8");
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = null;
+    renameSync(temporaryPath, path);
+  } catch (error) {
+    if (fd !== null) closeSync(fd);
+    if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+    throw error;
+  }
+}

--- a/packages/pi-permission-system/src/policy-loader.ts
+++ b/packages/pi-permission-system/src/policy-loader.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import {
   loadUnifiedConfig,
+  mergeUnifiedConfigs,
   normalizeFlatPermissionValue,
   stripJsonComments,
 } from "./config-loader";
@@ -69,6 +70,8 @@ export interface ResolvedPolicyPaths {
   globalConfigExists: boolean;
   projectConfigPath: string | null;
   projectConfigExists: boolean;
+  projectLocalConfigPath: string | null;
+  projectLocalConfigExists: boolean;
   agentsDir: string;
   agentsDirExists: boolean;
   projectAgentsDir: string | null;
@@ -131,6 +134,7 @@ export interface PolicyLoaderOptions {
   globalConfigPath?: string;
   agentsDir?: string;
   projectGlobalConfigPath?: string;
+  projectLocalConfigPath?: string;
   projectAgentsDir?: string;
   globalMcpConfigPath?: string;
   mcpServerNames?: readonly string[];
@@ -148,6 +152,7 @@ export class FilePolicyLoader implements PolicyLoader {
   private readonly globalConfigPath: string;
   private readonly agentsDir: string;
   private readonly projectGlobalConfigPath: string | null;
+  private readonly projectLocalConfigPath: string | null;
   private readonly projectAgentsDir: string | null;
   private readonly globalMcpConfigPath: string;
   private readonly configuredMcpServerNamesOverride: readonly string[] | null;
@@ -172,6 +177,7 @@ export class FilePolicyLoader implements PolicyLoader {
       options.globalConfigPath ?? defaultGlobalConfigPath();
     this.agentsDir = options.agentsDir ?? defaultAgentsDir();
     this.projectGlobalConfigPath = options.projectGlobalConfigPath ?? null;
+    this.projectLocalConfigPath = options.projectLocalConfigPath ?? null;
     this.projectAgentsDir = options.projectAgentsDir ?? null;
     this.globalMcpConfigPath =
       options.globalMcpConfigPath ?? defaultGlobalMcpConfigPath();
@@ -220,17 +226,31 @@ export class FilePolicyLoader implements PolicyLoader {
   }
 
   loadProjectConfig(): ScopeConfig {
-    if (!this.projectGlobalConfigPath) {
+    if (!this.projectGlobalConfigPath && !this.projectLocalConfigPath) {
       return {};
     }
 
-    const stamp = getFileStamp(this.projectGlobalConfigPath);
+    const stamp = [
+      this.projectGlobalConfigPath
+        ? getFileStamp(this.projectGlobalConfigPath)
+        : "none",
+      this.projectLocalConfigPath
+        ? getFileStamp(this.projectLocalConfigPath)
+        : "none",
+    ].join("|");
     if (this.projectGlobalConfigCache?.stamp === stamp) {
       return this.projectGlobalConfigCache.value;
     }
 
-    const { config, issues } = loadUnifiedConfig(this.projectGlobalConfigPath);
+    const shared = this.projectGlobalConfigPath
+      ? loadUnifiedConfig(this.projectGlobalConfigPath)
+      : { config: {}, issues: [] };
+    const local = this.projectLocalConfigPath
+      ? loadUnifiedConfig(this.projectLocalConfigPath)
+      : { config: {}, issues: [] };
+    const issues = [...shared.issues, ...local.issues];
     this.accumulateConfigIssues(issues);
+    const config = mergeUnifiedConfigs(shared.config, local.config);
 
     // A present-but-rejected file yields issues (parse error or schema
     // rejection); an absent file yields none. Fail closed on the former.
@@ -338,12 +358,15 @@ export class FilePolicyLoader implements PolicyLoader {
     const projectStamp = this.projectGlobalConfigPath
       ? getFileStamp(this.projectGlobalConfigPath)
       : "none";
+    const projectLocalStamp = this.projectLocalConfigPath
+      ? getFileStamp(this.projectLocalConfigPath)
+      : "none";
     const projectAgentStamp =
       this.projectAgentsDir && agentName
         ? getFileStamp(join(this.projectAgentsDir, `${agentName}.md`))
         : "none";
 
-    return `${getFileStamp(this.globalConfigPath)}|${projectStamp}|${agentStamp}|${projectAgentStamp}`;
+    return `${getFileStamp(this.globalConfigPath)}|${projectStamp}|${projectLocalStamp}|${agentStamp}|${projectAgentStamp}`;
   }
 
   // ── Resolved paths ────────────────────────────────────────────────────
@@ -355,6 +378,10 @@ export class FilePolicyLoader implements PolicyLoader {
       projectConfigPath: this.projectGlobalConfigPath,
       projectConfigExists: this.projectGlobalConfigPath
         ? existsSync(this.projectGlobalConfigPath)
+        : false,
+      projectLocalConfigPath: this.projectLocalConfigPath,
+      projectLocalConfigExists: this.projectLocalConfigPath
+        ? existsSync(this.projectLocalConfigPath)
         : false,
       agentsDir: this.agentsDir,
       agentsDirExists: existsSync(this.agentsDir),

--- a/packages/pi-permission-system/src/session-approval.ts
+++ b/packages/pi-permission-system/src/session-approval.ts
@@ -33,14 +33,12 @@ export class SessionApproval {
     return this.patterns[0];
   }
 
-  /**
-   * Single-pattern shape `applyPermissionGate` echoes back to the caller.
-   * Returns `undefined` when patterns is empty (degenerate case).
-   */
-  toGateApproval(): { surface: string; pattern: string } | undefined {
-    const pattern = this.representativePattern;
-    if (pattern === undefined) return undefined;
-    return { surface: this.surface, pattern };
+  /** Plain proposal data `applyPermissionGate` may echo back after editing. */
+  toGateApproval():
+    | { surface: string; patterns: readonly string[] }
+    | undefined {
+    if (this.patterns.length === 0) return undefined;
+    return { surface: this.surface, patterns: [...this.patterns] };
   }
 
   /**

--- a/packages/pi-permission-system/test/authority/authorizer-selection.test.ts
+++ b/packages/pi-permission-system/test/authority/authorizer-selection.test.ts
@@ -105,16 +105,24 @@ type SelectionDeps = SelectionCtorDeps & {
 function makeDeps(overrides: Partial<SelectionDeps> = {}): SelectionDeps {
   return {
     detection: overrides.detection ?? makeDetection(),
-    events: overrides.events ?? {
-      emit: vi.fn(),
-      on: vi.fn().mockReturnValue(() => undefined),
-    },
-    getPromptPreferences:
-      overrides.getPromptPreferences ??
-      (() => ({ doublePressToConfirm: true })),
-    requestPermissionDecision:
-      overrides.requestPermissionDecision ??
-      vi.fn().mockResolvedValue({ approved: true, state: "approved" }),
+    createLocalAuthorizer:
+      overrides.createLocalAuthorizer ??
+      ((ctx) =>
+        new LocalUserAuthorizer({
+          ui: ctx.ui,
+          mode: ctx.mode,
+          events: {
+            emit: vi.fn(),
+            on: vi.fn().mockReturnValue(() => undefined),
+          },
+          getPromptPreferences: () => ({
+            doublePressToConfirm: true,
+            showPersistenceSummary: true,
+          }),
+          requestPermissionDecision: vi
+            .fn()
+            .mockResolvedValue({ approved: true, state: "approved" }),
+        })),
     forwardingDir: overrides.forwardingDir ?? "/tmp/forwarding",
     registry: overrides.registry,
     logger: overrides.logger ?? makeAuthorizerLog(),

--- a/packages/pi-permission-system/test/authority/authorizer.test.ts
+++ b/packages/pi-permission-system/test/authority/authorizer.test.ts
@@ -33,16 +33,24 @@ function makeDeps(
 ): AuthorizerSelectionDeps {
   return {
     detection: overrides.detection ?? makeDetection(),
-    events: overrides.events ?? {
-      emit: vi.fn(),
-      on: vi.fn().mockReturnValue(() => undefined),
-    },
-    getPromptPreferences:
-      overrides.getPromptPreferences ??
-      (() => ({ doublePressToConfirm: true })),
-    requestPermissionDecision:
-      overrides.requestPermissionDecision ??
-      vi.fn().mockResolvedValue({ approved: true, state: "approved" }),
+    createLocalAuthorizer:
+      overrides.createLocalAuthorizer ??
+      ((ctx) =>
+        new LocalUserAuthorizer({
+          ui: ctx.ui,
+          mode: ctx.mode,
+          events: {
+            emit: vi.fn(),
+            on: vi.fn().mockReturnValue(() => undefined),
+          },
+          getPromptPreferences: () => ({
+            doublePressToConfirm: true,
+            showPersistenceSummary: true,
+          }),
+          requestPermissionDecision: vi
+            .fn()
+            .mockResolvedValue({ approved: true, state: "approved" }),
+        })),
     forwardingDir: overrides.forwardingDir ?? "/tmp/forwarding",
     registry: overrides.registry,
     logger: overrides.logger ?? { review: vi.fn(), debug: vi.fn() },

--- a/packages/pi-permission-system/test/authority/local-user-authorizer.test.ts
+++ b/packages/pi-permission-system/test/authority/local-user-authorizer.test.ts
@@ -3,6 +3,7 @@ import { LocalUserAuthorizer } from "#src/authority/local-user-authorizer";
 import type { PermissionPromptDecision } from "#src/authority/permission-dialog";
 import type { requestPermissionDecision } from "#src/authority/permission-prompt-component";
 import type { PromptPermissionDetails } from "#src/authority/permission-prompter";
+import type { PersistentApprovalApi } from "#src/persistent-approval-service";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -33,6 +34,7 @@ function makePromptUi() {
 function makeDeps(
   overrides: {
     requestPermissionDecision?: typeof requestPermissionDecision;
+    persistentApprovalService?: PersistentApprovalApi;
   } = {},
 ) {
   const events = {
@@ -50,8 +52,12 @@ function makeDeps(
       ui,
       mode: "tui" as const,
       events,
-      getPromptPreferences: () => ({ doublePressToConfirm: true }),
+      getPromptPreferences: () => ({
+        doublePressToConfirm: true,
+        showPersistenceSummary: true,
+      }),
       requestPermissionDecision: decisionFn,
+      persistentApprovalService: overrides.persistentApprovalService,
     },
     events,
     ui,
@@ -115,7 +121,13 @@ describe("LocalUserAuthorizer", () => {
     await authorizer.authorize(makeDetails());
 
     expect(decisionFn).toHaveBeenCalledWith(
-      { mode: "tui", ui, doublePressToConfirm: true },
+      {
+        mode: "tui",
+        ui,
+        doublePressToConfirm: true,
+        showPersistenceSummary: true,
+        setShowPersistenceSummary: undefined,
+      },
       "Permission Required",
       "Allow read?",
       undefined,
@@ -155,7 +167,10 @@ describe("LocalUserAuthorizer", () => {
       ui,
       mode: "tui",
       events,
-      getPromptPreferences: () => ({ doublePressToConfirm: true }),
+      getPromptPreferences: () => ({
+        doublePressToConfirm: true,
+        showPersistenceSummary: true,
+      }),
       requestPermissionDecision: decisionFn,
     });
 
@@ -212,7 +227,13 @@ describe("LocalUserAuthorizer", () => {
       );
 
       expect(decisionFn).toHaveBeenCalledWith(
-        { mode: "tui", ui, doublePressToConfirm: true },
+        {
+          mode: "tui",
+          ui,
+          doublePressToConfirm: true,
+          showPersistenceSummary: true,
+          setShowPersistenceSummary: undefined,
+        },
         "Permission Required (Subagent)",
         "Allow read?",
         undefined,
@@ -269,6 +290,114 @@ describe("LocalUserAuthorizer", () => {
         undefined,
       );
     });
+  });
+
+  it("persists a durable choice before approving the pending request", async () => {
+    const target = {
+      scope: "project" as const,
+      path: "/project/config.local.json",
+      expectedDir: "/project",
+    };
+    const persist = vi.fn(() => ({ path: target.path }));
+    const service: PersistentApprovalApi = {
+      prepare: vi.fn(() => target),
+      persist,
+    };
+    const { deps } = makeDeps({
+      persistentApprovalService: service,
+      requestPermissionDecision: vi
+        .fn<typeof requestPermissionDecision>()
+        .mockResolvedValue({
+          kind: "persist",
+          scope: "project",
+          proposal: { surface: "bash", patterns: ["git status"] },
+          target,
+          summaryShown: true,
+        }),
+    });
+
+    const result = await new LocalUserAuthorizer(deps).authorize(makeDetails());
+
+    expect(persist).toHaveBeenCalledWith({
+      requestId: "req-123",
+      target,
+      surface: "bash",
+      patterns: ["git status"],
+    });
+    expect(result).toEqual({ approved: true, state: "approved" });
+  });
+
+  it("refuses to persist when an enabled summary was bypassed", async () => {
+    const target = {
+      scope: "project" as const,
+      path: "/project/config.local.json",
+      expectedDir: "/project",
+    };
+    const persist = vi.fn(() => ({ path: target.path }));
+    const { deps } = makeDeps({
+      persistentApprovalService: {
+        prepare: vi.fn(() => target),
+        persist,
+      },
+      requestPermissionDecision: vi
+        .fn<typeof requestPermissionDecision>()
+        .mockResolvedValue({
+          kind: "persist",
+          scope: "project",
+          proposal: { surface: "bash", patterns: ["git status"] },
+          target,
+          summaryShown: false,
+        }),
+    });
+
+    const result = await new LocalUserAuthorizer(deps).authorize(makeDetails());
+
+    expect(persist).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      approved: false,
+      state: "denied_with_reason",
+      denialReason: "Persistent approval summary was not shown.",
+    });
+  });
+
+  it("fails closed without exposing filesystem paths from persistence errors", async () => {
+    const target = {
+      scope: "global" as const,
+      path: "/agent/config.json",
+      expectedDir: "/agent",
+    };
+    const service: PersistentApprovalApi = {
+      prepare: vi.fn(() => target),
+      persist: vi.fn(() => {
+        throw Object.assign(
+          new Error(
+            "EACCES: permission denied, open '/private/user/config.json'",
+          ),
+          { code: "EACCES" },
+        );
+      }),
+    };
+    const { deps } = makeDeps({
+      persistentApprovalService: service,
+      requestPermissionDecision: vi
+        .fn<typeof requestPermissionDecision>()
+        .mockResolvedValue({
+          kind: "persist",
+          scope: "global",
+          proposal: { surface: "bash", patterns: ["git status"] },
+          target,
+          summaryShown: true,
+        }),
+    });
+
+    const result = await new LocalUserAuthorizer(deps).authorize(makeDetails());
+
+    expect(result).toEqual({
+      approved: false,
+      state: "denied_with_reason",
+      denialReason: "Persistent approval failed (EACCES).",
+    });
+    expect(result.denialReason).not.toContain("/private/user");
   });
 
   it("returns the decision from requestPermissionDecision", async () => {

--- a/packages/pi-permission-system/test/authority/permission-dialog.test.ts
+++ b/packages/pi-permission-system/test/authority/permission-dialog.test.ts
@@ -267,6 +267,93 @@ describe("requestPermissionDecisionFromUi", () => {
   });
 });
 
+describe("persistent approval choices", () => {
+  const globalTarget = {
+    scope: "global" as const,
+    path: "/agent/extensions/pi-permission-system/config.json",
+    expectedDir: "/agent/extensions/pi-permission-system",
+  };
+  const projectTarget = {
+    scope: "project" as const,
+    path: "/project/.pi/extensions/pi-permission-system/config.local.json",
+    expectedDir: "/project/.pi/extensions/pi-permission-system",
+  };
+  const persistent = {
+    proposal: { surface: "bash", patterns: ["git *"] },
+    projectTarget,
+    globalTarget,
+  };
+
+  it("shows exact rule details without a typed acknowledgement", async () => {
+    const select = vi
+      .fn()
+      .mockResolvedValueOnce("Persist for this project")
+      .mockResolvedValueOnce("Confirm");
+    const input = vi.fn();
+
+    const result = await requestPermissionDecisionFromUi(
+      { select, input },
+      "Title",
+      "Message",
+      { persistent },
+    );
+
+    expect(select.mock.calls[1]?.[0]).toContain("Surface: bash");
+    expect(select.mock.calls[1]?.[0]).toContain("  - git *");
+    expect(select.mock.calls[1]?.[0]).toContain(projectTarget.path);
+    expect(input).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      kind: "persist",
+      scope: "project",
+      proposal: persistent.proposal,
+      target: projectTarget,
+      summaryShown: true,
+    });
+  });
+
+  it("skips exact rule details when the sticky preference is off", async () => {
+    const select = vi.fn().mockResolvedValueOnce("Persist globally");
+
+    const result = await requestPermissionDecisionFromUi(
+      { select, input: vi.fn() },
+      "Title",
+      "Message",
+      { persistent },
+      false,
+    );
+
+    expect(select).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      kind: "persist",
+      scope: "global",
+      proposal: persistent.proposal,
+      target: globalTarget,
+      summaryShown: false,
+    });
+  });
+
+  it("edits the proposal before a session approval", async () => {
+    const select = vi
+      .fn()
+      .mockResolvedValueOnce("Edit proposed pattern(s)")
+      .mockResolvedValueOnce("Yes, for this session");
+    const input = vi.fn().mockResolvedValueOnce("git status");
+
+    const result = await requestPermissionDecisionFromUi(
+      { select, input },
+      "Title",
+      "Message",
+      { persistent },
+    );
+
+    expect(result).toEqual({
+      approved: true,
+      state: "approved_for_session",
+      sessionApproval: { surface: "bash", patterns: ["git status"] },
+    });
+  });
+});
+
 describe("normalizePermissionDenialReason", () => {
   it("returns trimmed string for non-empty input", () => {
     expect(normalizePermissionDenialReason("  reason  ")).toBe("reason");

--- a/packages/pi-permission-system/test/authority/permission-prompt-component.test.ts
+++ b/packages/pi-permission-system/test/authority/permission-prompt-component.test.ts
@@ -1,9 +1,7 @@
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
-import type {
-  PermissionPromptDecision,
-  RequestPermissionOptions,
-} from "#src/authority/permission-dialog";
+import type { InteractivePermissionChoice } from "#src/authority/interactive-permission-choice";
+import type { RequestPermissionOptions } from "#src/authority/permission-dialog";
 import {
   type PermissionPromptView,
   presentInlinePermissionPrompt,
@@ -32,7 +30,7 @@ type PromptFactory = (
   tui: { requestRender: () => void },
   theme: ReturnType<typeof plainTheme>,
   keybindings: { matches(data: string, action: string): boolean },
-  done: (decision: PermissionPromptDecision) => void,
+  done: (decision: InteractivePermissionChoice) => void,
 ) => CapturedComponent;
 
 /** Pi's default binding for the `app.tools.expand` action. */
@@ -51,9 +49,9 @@ function makeFakeView(doublePressToConfirm: boolean, expandKey = CTRL_O) {
   const custom = (
     factory: PromptFactory,
     options: unknown,
-  ): Promise<PermissionPromptDecision> => {
+  ): Promise<InteractivePermissionChoice> => {
     captured.options = options;
-    return new Promise<PermissionPromptDecision>((resolve) => {
+    return new Promise<InteractivePermissionChoice>((resolve) => {
       captured.component = factory(
         { requestRender: vi.fn() },
         plainTheme(),
@@ -68,6 +66,8 @@ function makeFakeView(doublePressToConfirm: boolean, expandKey = CTRL_O) {
   const view = {
     mode: "tui",
     doublePressToConfirm,
+    showPersistenceSummary: true,
+    setShowPersistenceSummary: vi.fn(() => true),
     ui: {
       select: vi.fn(),
       input: vi.fn(),
@@ -82,12 +82,13 @@ function makeFakeView(doublePressToConfirm: boolean, expandKey = CTRL_O) {
 const ARROW_DOWN = "\u001b[B";
 const ENTER = "\r";
 const ESCAPE = "\u001b";
+const CTRL_U = "\u0015";
 
 async function runPrompt(
   doublePressToConfirm: boolean,
   keys: string[],
   options?: RequestPermissionOptions,
-): Promise<PermissionPromptDecision> {
+): Promise<InteractivePermissionChoice> {
   const { view, captured } = makeFakeView(doublePressToConfirm);
   const promise = presentInlinePermissionPrompt(
     view,
@@ -97,6 +98,7 @@ async function runPrompt(
   );
   for (const key of keys) {
     captured.component?.handleInput(key);
+    captured.component?.render(100);
   }
   return promise;
 }
@@ -256,12 +258,35 @@ describe("presentInlinePermissionPrompt", () => {
       expect(await promise).toEqual({ approved: true, state: "approved" });
     });
 
+    it("keeps the inline keybind flow for durable choices in TUI mode", async () => {
+      const { view, captured } = makeFakeView(false);
+      const promise = requestPermissionDecision(view, "Title", "Msg", {
+        persistent: {
+          proposal: { surface: "bash", patterns: ["git status"] },
+          globalTarget: {
+            scope: "global",
+            path: "/agent/config.json",
+            expectedDir: "/agent",
+          },
+        },
+      });
+
+      expect(captured.component).toBeDefined();
+      const text = captured.component?.render(100).join("\n") ?? "";
+      expect(text).toContain("(e) Edit proposed pattern(s)");
+      expect(text).toContain("(g) Persist globally");
+      captured.component?.handleInput("y");
+      expect(await promise).toEqual({ approved: true, state: "approved" });
+      expect(view.ui.select).not.toHaveBeenCalled();
+    });
+
     it("falls back to the select flow outside TUI mode", async () => {
       const custom = vi.fn();
       const select = vi.fn().mockResolvedValue("Yes");
       const view = {
         mode: "rpc",
         doublePressToConfirm: true,
+        showPersistenceSummary: true,
         ui: { select, input: vi.fn(), custom },
       } as unknown as PermissionPromptView;
 
@@ -270,6 +295,163 @@ describe("presentInlinePermissionPrompt", () => {
       expect(custom).not.toHaveBeenCalled();
       expect(select).toHaveBeenCalledTimes(1);
       expect(decision).toEqual({ approved: true, state: "approved" });
+    });
+  });
+
+  describe("durable approval shortcuts and navigation", () => {
+    const projectTarget = {
+      scope: "project" as const,
+      path: "/project/.pi/extensions/pi-permission-system/config.local.json",
+      expectedDir: "/project/.pi/extensions/pi-permission-system",
+    };
+    const globalTarget = {
+      scope: "global" as const,
+      path: "/agent/config.json",
+      expectedDir: "/agent",
+    };
+    const options: RequestPermissionOptions = {
+      persistent: {
+        proposal: { surface: "bash", patterns: ["git status"] },
+        projectTarget,
+        globalTarget,
+      },
+    };
+
+    it("persists project approval with p and a visible summary", async () => {
+      const { view, captured } = makeFakeView(true);
+      const promise = presentInlinePermissionPrompt(
+        view,
+        "Title",
+        "Msg",
+        options,
+      );
+
+      captured.component?.handleInput("p");
+      const summary = captured.component?.render(100).join("\n") ?? "";
+      expect(summary).toContain("Scope: project-local");
+      expect(summary).toContain("git status");
+      expect(summary).toContain(projectTarget.path);
+      captured.component?.handleInput(ENTER);
+
+      expect(await promise).toEqual({
+        kind: "persist",
+        scope: "project",
+        proposal: options.persistent?.proposal,
+        target: projectTarget,
+        summaryShown: true,
+      });
+    });
+
+    it("persists global approval without a typed acknowledgment", async () => {
+      expect(await runPrompt(false, ["g", ENTER], options)).toEqual({
+        kind: "persist",
+        scope: "global",
+        proposal: options.persistent?.proposal,
+        target: globalTarget,
+        summaryShown: true,
+      });
+    });
+
+    it("does not accept summary confirmation before the summary renders", async () => {
+      const { view, captured } = makeFakeView(false);
+      const promise = presentInlinePermissionPrompt(
+        view,
+        "Title",
+        "Msg",
+        options,
+      );
+      let settled = false;
+      void promise.then(() => {
+        settled = true;
+      });
+
+      captured.component?.handleInput("p");
+      captured.component?.handleInput(ENTER);
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      expect(captured.component?.render(100).join("\n")).toContain(
+        "Scope: project-local",
+      );
+      captured.component?.handleInput(ENTER);
+      await expect(promise).resolves.toMatchObject({
+        kind: "persist",
+        summaryShown: true,
+      });
+    });
+
+    it("toggles the sticky summary preference before saving", async () => {
+      const { view, captured } = makeFakeView(false);
+      const promise = presentInlinePermissionPrompt(
+        view,
+        "Title",
+        "Msg",
+        options,
+      );
+
+      expect(captured.component?.render(100)).toContain(
+        "  (t) [x] Show summary before saving",
+      );
+      captured.component?.handleInput("t");
+      expect(view.setShowPersistenceSummary).toHaveBeenCalledWith(false);
+      expect(captured.component?.render(100)).toContain(
+        "  (t) [ ] Show summary before saving",
+      );
+      captured.component?.handleInput("g");
+
+      expect(await promise).toEqual({
+        kind: "persist",
+        scope: "global",
+        proposal: options.persistent?.proposal,
+        target: globalTarget,
+        summaryShown: false,
+      });
+    });
+
+    it("edits the proposal with e before approving it for the session", async () => {
+      expect(
+        await runPrompt(
+          false,
+          [
+            "e",
+            CTRL_U,
+            "g",
+            "i",
+            "t",
+            " ",
+            "d",
+            "i",
+            "f",
+            "f",
+            " ",
+            "*",
+            ENTER,
+            "s",
+          ],
+          options,
+        ),
+      ).toEqual({
+        approved: true,
+        state: "approved_for_session",
+        sessionApproval: { surface: "bash", patterns: ["git diff *"] },
+      });
+    });
+
+    it("navigates through persistent choices with down and enter", async () => {
+      // y -> s -> e -> p, select persistence, then save from the summary.
+      expect(
+        await runPrompt(
+          true,
+          [ARROW_DOWN, ARROW_DOWN, ARROW_DOWN, ENTER, ENTER],
+          options,
+        ),
+      ).toEqual({
+        kind: "persist",
+        scope: "project",
+        proposal: options.persistent?.proposal,
+        target: projectTarget,
+        summaryShown: true,
+      });
     });
   });
 

--- a/packages/pi-permission-system/test/authority/permission-prompt-decision.test.ts
+++ b/packages/pi-permission-system/test/authority/permission-prompt-decision.test.ts
@@ -13,6 +13,7 @@ function makeConfig(
   return {
     doublePressToConfirm: true,
     sessionLabel: "Yes, for this session",
+    showPersistenceSummary: true,
     ...overrides,
   };
 }
@@ -306,6 +307,42 @@ describe("reducePrompt", () => {
           reasonDraft: "",
           reasonError: undefined,
           scopeServing: false,
+        },
+      });
+    });
+  });
+
+  describe("optional persistence summary", () => {
+    const globalTarget = {
+      scope: "global" as const,
+      path: "/agent/config.json",
+      expectedDir: "/agent",
+      expectedRoot: "/agent",
+    };
+
+    it("persists immediately when the sticky summary preference is off", () => {
+      const config = makeConfig({
+        doublePressToConfirm: false,
+        showPersistenceSummary: false,
+        persistent: {
+          proposal: { surface: "bash", patterns: ["git status"] },
+          globalTarget,
+        },
+      });
+
+      expect(
+        reducePrompt(config, initialPromptState(config), {
+          type: "hotkey",
+          key: "g",
+        }),
+      ).toEqual({
+        kind: "decision",
+        decision: {
+          kind: "persist",
+          scope: "global",
+          proposal: config.persistent?.proposal,
+          target: globalTarget,
+          summaryShown: false,
         },
       });
     });

--- a/packages/pi-permission-system/test/config-loader.test.ts
+++ b/packages/pi-permission-system/test/config-loader.test.ts
@@ -488,14 +488,21 @@ describe("mergeUnifiedConfigs", () => {
         permissionReviewLog: true,
         yoloMode: false,
         doublePressToConfirm: true,
+        showPersistenceSummary: true,
       },
-      { debugLog: false, yoloMode: true, doublePressToConfirm: false },
+      {
+        debugLog: false,
+        yoloMode: true,
+        doublePressToConfirm: false,
+        showPersistenceSummary: false,
+      },
     );
 
     expect(merged.debugLog).toBe(false);
     expect(merged.permissionReviewLog).toBe(true);
     expect(merged.yoloMode).toBe(true);
     expect(merged.doublePressToConfirm).toBe(false);
+    expect(merged.showPersistenceSummary).toBe(false);
   });
 
   it("returns base unchanged when override is empty", () => {
@@ -696,6 +703,12 @@ describe("loadAndMergeConfigs", () => {
     writeFileSync(join(dir, "config.json"), JSON.stringify(content));
   }
 
+  function writeProjectLocal(content: Record<string, unknown>): void {
+    const dir = join(cwd, ".pi", "extensions", "pi-permission-system");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "config.local.json"), JSON.stringify(content));
+  }
+
   function writeLegacyGlobalPolicy(content: Record<string, unknown>): void {
     mkdirSync(agentDir, { recursive: true });
     writeFileSync(
@@ -714,6 +727,17 @@ describe("loadAndMergeConfigs", () => {
     mkdirSync(extensionRoot, { recursive: true });
     writeFileSync(join(extensionRoot, "config.json"), JSON.stringify(content));
   }
+
+  it("loads project-local config after shared project config", () => {
+    writeGlobal({ permission: { bash: "deny" } });
+    writeProject({ permission: { bash: "ask", read: "deny" } });
+    writeProjectLocal({ permission: { bash: "allow" } });
+
+    const result = loadAndMergeConfigs(agentDir, cwd, extensionRoot);
+
+    expect(result.project.permission).toEqual({ bash: "allow", read: "deny" });
+    expect(result.merged.permission).toEqual({ bash: "allow", read: "deny" });
+  });
 
   it("merges global and project new-layout configs", () => {
     writeGlobal({
@@ -844,6 +868,18 @@ describe("loadAndMergeConfigs", () => {
 
       // The untrusted project's `bash: allow` must not override global `deny`.
       expect(result.merged.permission).toEqual({ "*": "ask", bash: "deny" });
+      expect(result.project).toEqual({});
+    });
+
+    it("omits project-local config when includeProjectScope is false", () => {
+      writeGlobal({ permission: { bash: "deny" } });
+      writeProjectLocal({ permission: { bash: "allow" } });
+
+      const result = loadAndMergeConfigs(agentDir, cwd, extensionRoot, {
+        includeProjectScope: false,
+      });
+
+      expect(result.merged.permission).toEqual({ bash: "deny" });
       expect(result.project).toEqual({});
     });
 

--- a/packages/pi-permission-system/test/config-modal.test.ts
+++ b/packages/pi-permission-system/test/config-modal.test.ts
@@ -134,6 +134,7 @@ test("permission-system command handlers manage config summary, persistence, and
     permissionReviewLog: false,
     yoloMode: true,
     doublePressToConfirm: true,
+    showPersistenceSummary: true,
   };
 
   try {

--- a/packages/pi-permission-system/test/config-reporter.test.ts
+++ b/packages/pi-permission-system/test/config-reporter.test.ts
@@ -21,6 +21,9 @@ test("buildResolvedConfigLogEntry includes policy paths and legacy detection fla
     projectConfigPath:
       "/projects/my-app/.pi/extensions/pi-permission-system/config.json",
     projectConfigExists: false,
+    projectLocalConfigPath:
+      "/projects/my-app/.pi/extensions/pi-permission-system/config.local.json",
+    projectLocalConfigExists: false,
     agentsDir: "/home/user/.pi/agent/agents",
     agentsDirExists: true,
     projectAgentsDir: "/projects/my-app/.pi/agent/agents",
@@ -37,6 +40,10 @@ test("buildResolvedConfigLogEntry includes policy paths and legacy detection fla
     "/projects/my-app/.pi/extensions/pi-permission-system/config.json",
   );
   expect(result.projectConfigExists).toBe(false);
+  expect(result.projectLocalConfigPath).toBe(
+    "/projects/my-app/.pi/extensions/pi-permission-system/config.local.json",
+  );
+  expect(result.projectLocalConfigExists).toBe(false);
   expect(result.agentsDir).toBe("/home/user/.pi/agent/agents");
   expect(result.agentsDirExists).toBe(true);
   expect(result.projectAgentsDir).toBe("/projects/my-app/.pi/agent/agents");
@@ -53,6 +60,8 @@ test("buildResolvedConfigLogEntry handles null project paths", () => {
     globalConfigExists: false,
     projectConfigPath: null,
     projectConfigExists: false,
+    projectLocalConfigPath: null,
+    projectLocalConfigExists: false,
     agentsDir: "/home/user/.pi/agent/agents",
     agentsDirExists: false,
     projectAgentsDir: null,
@@ -74,6 +83,8 @@ test("buildResolvedConfigLogEntry surfaces legacy detection flags", () => {
     globalConfigExists: true,
     projectConfigPath: null,
     projectConfigExists: false,
+    projectLocalConfigPath: null,
+    projectLocalConfigExists: false,
     agentsDir: "/home/user/.pi/agent/agents",
     agentsDirExists: false,
     projectAgentsDir: null,
@@ -114,6 +125,7 @@ test("config.resolved entry appears in review log via logger", () => {
         permissionReviewLog: true,
         yoloMode: false,
         doublePressToConfirm: true,
+        showPersistenceSummary: true,
       }),
       debugLogPath,
       reviewLogPath,

--- a/packages/pi-permission-system/test/config-schema.test.ts
+++ b/packages/pi-permission-system/test/config-schema.test.ts
@@ -27,6 +27,7 @@ describe("unifiedConfigSchema", () => {
         debugLog: true,
         permissionReviewLog: false,
         yoloMode: true,
+        showPersistenceSummary: false,
         toolInputPreviewMaxLength: 1000,
         toolTextSummaryMaxLength: 120,
         piInfrastructureReadPaths: ["/extra/path"],

--- a/packages/pi-permission-system/test/config-store.test.ts
+++ b/packages/pi-permission-system/test/config-store.test.ts
@@ -78,6 +78,8 @@ function makePolicyPathProvider(
         globalConfigExists: false,
         projectConfigPath: null,
         projectConfigExists: false,
+        projectLocalConfigPath: null,
+        projectLocalConfigExists: false,
         agentsDir: "/agent/agents",
         agentsDirExists: false,
         projectAgentsDir: null,
@@ -422,6 +424,41 @@ describe("ConfigStore", () => {
         expect.stringContaining(".tmp"),
         expect.stringContaining('"piInfrastructureReadPaths"'),
         "utf-8",
+      );
+    });
+  });
+
+  describe("setShowPersistenceSummary()", () => {
+    it("persists only the sticky global preference and updates current config", () => {
+      const { store } = makeStore();
+      mockLoadUnifiedConfig.mockReturnValue({
+        config: { permission: { bash: "ask" }, debugLog: true },
+      });
+
+      expect(store.setShowPersistenceSummary(false, vi.fn())).toBe(true);
+
+      expect(store.current().showPersistenceSummary).toBe(false);
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        expect.stringContaining(".tmp"),
+        expect.stringContaining('"showPersistenceSummary": false'),
+        "utf-8",
+      );
+      const content = mockWriteFileSync.mock.calls.at(-1)?.[1] as string;
+      expect(content).toContain('"debugLog": true');
+      expect(content).not.toContain('"yoloMode"');
+    });
+
+    it("keeps the live preference unchanged when persistence fails", () => {
+      const { store } = makeStore();
+      const notify = vi.fn();
+      mockMkdirSync.mockImplementation(() => {
+        throw new Error("disk full");
+      });
+
+      expect(store.setShowPersistenceSummary(false, notify)).toBe(false);
+      expect(store.current().showPersistenceSummary).toBe(true);
+      expect(notify).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to save"),
       );
     });
   });

--- a/packages/pi-permission-system/test/extension-config.test.ts
+++ b/packages/pi-permission-system/test/extension-config.test.ts
@@ -98,6 +98,7 @@ describe("normalizePermissionSystemConfig", () => {
       permissionReviewLog: false,
       yoloMode: true,
       doublePressToConfirm: true,
+      showPersistenceSummary: true,
     });
   });
 
@@ -126,6 +127,19 @@ describe("normalizePermissionSystemConfig", () => {
       doublePressToConfirm: false,
     });
     expect(result.doublePressToConfirm).toBe(false);
+  });
+
+  it("shows persistence summaries by default", () => {
+    expect(normalizePermissionSystemConfig({}).showPersistenceSummary).toBe(
+      true,
+    );
+  });
+
+  it("disables persistence summaries when explicitly configured", () => {
+    expect(
+      normalizePermissionSystemConfig({ showPersistenceSummary: false })
+        .showPersistenceSummary,
+    ).toBe(false);
   });
 
   it("includes toolInputPreviewMaxLength when a valid positive integer is provided", () => {

--- a/packages/pi-permission-system/test/helpers/manager-harness.ts
+++ b/packages/pi-permission-system/test/helpers/manager-harness.ts
@@ -44,6 +44,8 @@ export function createInMemoryPolicyLoader(
       globalConfigExists: true,
       projectConfigPath: null,
       projectConfigExists: false,
+      projectLocalConfigPath: null,
+      projectLocalConfigExists: false,
       agentsDir: "/in-memory/agents",
       agentsDirExists: false,
       projectAgentsDir: null,

--- a/packages/pi-permission-system/test/permission-gate.test.ts
+++ b/packages/pi-permission-system/test/permission-gate.test.ts
@@ -178,12 +178,32 @@ describe("applyPermissionGate", () => {
       const params = makeParams({
         state: "ask",
         promptForApproval,
-        sessionApproval: { surface: "bash", pattern: "git *" },
+        sessionApproval: { surface: "bash", patterns: ["git *"] },
       });
       const result = await applyPermissionGate(params);
       expect(result).toEqual({
         action: "allow",
-        sessionApproval: { surface: "bash", pattern: "git *" },
+        sessionApproval: { surface: "bash", patterns: ["git *"] },
+      });
+    });
+
+    it("returns the edited session proposal from the decision", async () => {
+      const decision: PermissionPromptDecision = {
+        approved: true,
+        state: "approved_for_session",
+        sessionApproval: { surface: "bash", patterns: ["git status"] },
+      };
+      const result = await applyPermissionGate(
+        makeParams({
+          state: "ask",
+          promptForApproval: vi.fn().mockResolvedValue(decision),
+          sessionApproval: { surface: "bash", patterns: ["git *"] },
+        }),
+      );
+
+      expect(result).toEqual({
+        action: "allow",
+        sessionApproval: { surface: "bash", patterns: ["git status"] },
       });
     });
 
@@ -196,7 +216,7 @@ describe("applyPermissionGate", () => {
       const params = makeParams({
         state: "ask",
         promptForApproval,
-        sessionApproval: { surface: "bash", pattern: "git *" },
+        sessionApproval: { surface: "bash", patterns: ["git *"] },
       });
       const result = await applyPermissionGate(params);
       expect(result).toEqual({ action: "allow" });
@@ -225,7 +245,7 @@ describe("applyPermissionGate", () => {
       const params = makeParams({
         state: "ask",
         promptForApproval,
-        sessionApproval: { surface: "bash", pattern: "git *" },
+        sessionApproval: { surface: "bash", patterns: ["git *"] },
       });
       const result = await applyPermissionGate(params);
       expect(result).toEqual({ action: "block", reason: "User denied." });

--- a/packages/pi-permission-system/test/persistent-approval-service.test.ts
+++ b/packages/pi-permission-system/test/persistent-approval-service.test.ts
@@ -1,0 +1,146 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vi,
+} from "vitest";
+import {
+  PersistentApprovalService,
+  PersistentApprovalTargetResolver,
+} from "#src/persistent-approval-service";
+import { PersistentPermissionWriter } from "#src/persistent-permission-writer";
+
+describe("PersistentApprovalService", () => {
+  let root: string;
+  let agentDir: string;
+  let cwd: string;
+  let trusted: boolean;
+  let review: Mock<(event: string, details?: Record<string, unknown>) => void>;
+  let reload: Mock<(cwd: string | undefined) => void>;
+  let resolver: PersistentApprovalTargetResolver;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "persistent-approval-service-"));
+    agentDir = join(root, "agent");
+    cwd = join(root, "project");
+    mkdirSync(cwd);
+    trusted = true;
+    review =
+      vi.fn<(event: string, details?: Record<string, unknown>) => void>();
+    reload = vi.fn<(cwd: string | undefined) => void>();
+    resolver = new PersistentApprovalTargetResolver({
+      agentDir,
+      cwd,
+      isProjectTrusted: () => trusted,
+    });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function makeService(): PersistentApprovalService {
+    return new PersistentApprovalService({
+      targetResolver: resolver,
+      writer: new PersistentPermissionWriter(),
+      reload,
+      logger: { review },
+    });
+  }
+
+  it("persists project rules, reloads trusted project policy, and logs success", () => {
+    const service = makeService();
+    const target = service.prepare("project");
+
+    const result = service.persist({
+      requestId: "request-1",
+      target,
+      surface: "bash",
+      patterns: ["git status"],
+    });
+
+    expect(result.path).toBe(
+      join(cwd, ".pi/extensions/pi-permission-system/config.local.json"),
+    );
+    expect(reload).toHaveBeenCalledWith(cwd);
+    expect(JSON.parse(readFileSync(result.path, "utf8"))).toEqual({
+      permission: { bash: { "git status": "allow" } },
+    });
+    expect(review).toHaveBeenCalledWith(
+      "permission_rule.persistence_succeeded",
+      expect.objectContaining({ requestId: "request-1", scope: "project" }),
+    );
+  });
+
+  it("withholds project targets and writes when trust is lost", () => {
+    trusted = false;
+    expect(() => makeService().prepare("project")).toThrow("trusted project");
+
+    trusted = true;
+    const service = makeService();
+    const target = service.prepare("project");
+    trusted = false;
+
+    expect(() =>
+      service.persist({
+        requestId: "request-2",
+        target,
+        surface: "bash",
+        patterns: ["git status"],
+      }),
+    ).toThrow("trusted project");
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("reloads global policy without activating the current project", () => {
+    trusted = false;
+    const service = makeService();
+    const target = service.prepare("global");
+
+    service.persist({
+      requestId: "request-5",
+      target,
+      surface: "bash",
+      patterns: ["git status"],
+    });
+
+    expect(reload).toHaveBeenCalledWith(undefined);
+  });
+
+  it("restores the original file and logs failure when reload fails", () => {
+    const service = makeService();
+    const target = service.prepare("project");
+    mkdirSync(target.expectedDir, { recursive: true });
+    const original = `{"permission":{"bash":"ask"}}\n`;
+    writeFileSync(target.path, original);
+    reload.mockImplementation(() => {
+      throw new Error("reload failed");
+    });
+
+    expect(() =>
+      service.persist({
+        requestId: "request-6",
+        target,
+        surface: "bash",
+        patterns: ["git status"],
+      }),
+    ).toThrow("reload failed");
+    expect(readFileSync(target.path, "utf8")).toBe(original);
+    expect(review).toHaveBeenCalledWith(
+      "permission_rule.persistence_failed",
+      expect.objectContaining({ requestId: "request-6" }),
+    );
+  });
+});

--- a/packages/pi-permission-system/test/persistent-permission-writer.test.ts
+++ b/packages/pi-permission-system/test/persistent-permission-writer.test.ts
@@ -1,0 +1,202 @@
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PersistentPermissionWriter } from "#src/persistent-permission-writer";
+
+const ORIGINAL = `{
+  // keep this operator note
+  "debugLog": true,
+  "permission": {
+    "bash": {
+      "git *": "deny",
+      // keep this deny
+      "rm *": "deny"
+    }
+  }
+}
+`;
+
+describe("PersistentPermissionWriter", () => {
+  let root: string;
+  let path: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "persistent-permission-writer-"));
+    path = join(root, "config.local.json");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("appends allow rules while preserving unrelated JSONC", () => {
+    writeFileSync(path, ORIGINAL);
+    const writer = new PersistentPermissionWriter();
+
+    writer.write({
+      path,
+      expectedDir: root,
+      surface: "bash",
+      patterns: ["gh workflow run *"],
+    });
+
+    expect(readFileSync(path, "utf8")).toBe(`{
+  // keep this operator note
+  "debugLog": true,
+  "permission": {
+    "bash": {
+      "git *": "deny",
+      // keep this deny
+      "rm *": "deny",
+      "gh workflow run *": "allow"
+    }
+  }
+}
+`);
+    expect(lstatSync(path).mode & 0o777).toBe(0o600);
+  });
+
+  it("expands a string surface without changing its fallback meaning", () => {
+    writeFileSync(path, `{"permission":{"bash":"deny"}}\n`);
+    const writer = new PersistentPermissionWriter();
+
+    writer.write({
+      path,
+      expectedDir: root,
+      surface: "bash",
+      patterns: ["git status"],
+    });
+
+    expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({
+      permission: { bash: { "*": "deny", "git status": "allow" } },
+    });
+  });
+
+  it("moves an existing pattern to last-match-wins position", () => {
+    writeFileSync(path, `{"permission":{"bash":{"git *":"deny","*":"ask"}}}\n`);
+    const writer = new PersistentPermissionWriter();
+
+    writer.write({
+      path,
+      expectedDir: root,
+      surface: "bash",
+      patterns: ["git *"],
+    });
+
+    expect(
+      Object.keys(JSON.parse(readFileSync(path, "utf8")).permission.bash),
+    ).toEqual(["*", "git *"]);
+  });
+
+  it("rejects invalid existing config without changing it", () => {
+    const invalid = `{"debugLo":true}\n`;
+    writeFileSync(path, invalid);
+    const writer = new PersistentPermissionWriter();
+
+    expect(() =>
+      writer.write({
+        path,
+        expectedDir: root,
+        surface: "bash",
+        patterns: ["git status"],
+      }),
+    ).toThrow("Invalid permission config");
+    expect(readFileSync(path, "utf8")).toBe(invalid);
+  });
+
+  it("rejects a destination outside the expected directory", () => {
+    const writer = new PersistentPermissionWriter();
+
+    expect(() =>
+      writer.write({
+        path: join(root, "..", "escaped.json"),
+        expectedDir: root,
+        surface: "bash",
+        patterns: ["git status"],
+      }),
+    ).toThrow("outside the expected directory");
+  });
+
+  it("rejects a parent directory symlink that escapes the trusted root", () => {
+    const outside = mkdtempSync(
+      join(tmpdir(), "persistent-permission-outside-"),
+    );
+    try {
+      const linkedDir = join(root, "linked");
+      symlinkSync(outside, linkedDir);
+      const writer = new PersistentPermissionWriter();
+
+      expect(() =>
+        writer.write({
+          path: join(linkedDir, "config.json"),
+          expectedDir: linkedDir,
+          expectedRoot: root,
+          surface: "bash",
+          patterns: ["git status"],
+        }),
+      ).toThrow("resolves outside the expected directory");
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a symlink destination", () => {
+    const real = join(root, "real.json");
+    writeFileSync(real, "{}\n");
+    symlinkSync(real, path);
+    const writer = new PersistentPermissionWriter();
+
+    expect(() =>
+      writer.write({
+        path,
+        expectedDir: root,
+        surface: "bash",
+        patterns: ["git status"],
+      }),
+    ).toThrow("symbolic link");
+  });
+
+  it("restores the original bytes after a caller reports reload failure", () => {
+    writeFileSync(path, ORIGINAL);
+    const writer = new PersistentPermissionWriter();
+
+    const result = writer.write({
+      path,
+      expectedDir: root,
+      surface: "bash",
+      patterns: ["git status"],
+    });
+    result.restore();
+
+    expect(readFileSync(path, "utf8")).toBe(ORIGINAL);
+  });
+
+  it("creates the destination directory and writes multiple patterns atomically", () => {
+    const nested = join(root, "nested");
+    const nestedPath = join(nested, "config.json");
+    const writer = new PersistentPermissionWriter();
+
+    writer.write({
+      path: nestedPath,
+      expectedDir: nested,
+      surface: "external_directory",
+      patterns: ["/tmp/a", "/tmp/b"],
+    });
+
+    expect(JSON.parse(readFileSync(nestedPath, "utf8"))).toEqual({
+      permission: {
+        external_directory: { "/tmp/a": "allow", "/tmp/b": "allow" },
+      },
+    });
+    expect(() => mkdirSync(nested)).toThrow();
+  });
+});

--- a/packages/pi-permission-system/test/policy-loader.test.ts
+++ b/packages/pi-permission-system/test/policy-loader.test.ts
@@ -113,6 +113,57 @@ describe("FilePolicyLoader.loadProjectConfig", () => {
     }
   });
 
+  it("merges project-local config after shared project config", () => {
+    const baseDir = makeTempDir();
+    try {
+      const projectConfigPath = join(baseDir, "project-config.json");
+      const projectLocalConfigPath = join(baseDir, "project-config.local.json");
+      writeFileSync(
+        projectConfigPath,
+        JSON.stringify({ permission: { bash: "ask", read: "deny" } }),
+      );
+      writeFileSync(
+        projectLocalConfigPath,
+        JSON.stringify({ permission: { bash: "allow" } }),
+      );
+      const loader = new FilePolicyLoader({
+        globalConfigPath: "/nonexistent/config.json",
+        agentsDir: "/nonexistent/agents",
+        projectGlobalConfigPath: projectConfigPath,
+        projectLocalConfigPath,
+      });
+
+      expect(loader.loadProjectConfig()).toEqual({
+        permission: { bash: "allow", read: "deny" },
+      });
+    } finally {
+      rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it("marks the scope invalid when project-local config is rejected", () => {
+    const baseDir = makeTempDir();
+    try {
+      const projectConfigPath = join(baseDir, "project-config.json");
+      const projectLocalConfigPath = join(baseDir, "project-config.local.json");
+      writeFileSync(
+        projectConfigPath,
+        JSON.stringify({ permission: { bash: "allow" } }),
+      );
+      writeFileSync(projectLocalConfigPath, JSON.stringify({ debugLo: true }));
+      const loader = new FilePolicyLoader({
+        globalConfigPath: "/nonexistent/config.json",
+        agentsDir: "/nonexistent/agents",
+        projectGlobalConfigPath: projectConfigPath,
+        projectLocalConfigPath,
+      });
+
+      expect(loader.loadProjectConfig().invalid).toBe(true);
+    } finally {
+      rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+
   it("marks the scope invalid when the project config file is rejected", () => {
     const baseDir = makeTempDir();
     try {

--- a/packages/pi-permission-system/test/session-approval.test.ts
+++ b/packages/pi-permission-system/test/session-approval.test.ts
@@ -15,11 +15,11 @@ describe("SessionApproval", () => {
       expect(approval.representativePattern).toBe("git *");
     });
 
-    it("toGateApproval returns { surface, pattern }", () => {
+    it("toGateApproval returns the complete proposal", () => {
       const approval = SessionApproval.single("bash", "git *");
       expect(approval.toGateApproval()).toEqual({
         surface: "bash",
-        pattern: "git *",
+        patterns: ["git *"],
       });
     });
   });
@@ -42,15 +42,26 @@ describe("SessionApproval", () => {
       expect(approval.representativePattern).toBe("/outside/a/*");
     });
 
-    it("toGateApproval returns { surface, pattern } using the first pattern", () => {
+    it("toGateApproval returns every pattern", () => {
       const approval = SessionApproval.multiple("external_directory", [
         "/outside/a/*",
         "/outside/b/*",
       ]);
       expect(approval.toGateApproval()).toEqual({
         surface: "external_directory",
-        pattern: "/outside/a/*",
+        patterns: ["/outside/a/*", "/outside/b/*"],
       });
+    });
+
+    it("toGateApproval returns a defensive copy", () => {
+      const approval = SessionApproval.multiple("external_directory", [
+        "/outside/a/*",
+        "/outside/b/*",
+      ]);
+      const gateApproval = approval.toGateApproval();
+      (gateApproval?.patterns as string[]).push("/outside/c/*");
+
+      expect(approval.patterns).toEqual(["/outside/a/*", "/outside/b/*"]);
     });
 
     it("defensive copy — mutating the source array does not affect patterns", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
 
   packages/pi-permission-system:
     dependencies:
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       tree-sitter-bash:
         specifier: ^0.25.1
         version: 0.25.1
@@ -1530,6 +1533,9 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
@@ -3365,6 +3371,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  jsonc-parser@3.3.1: {}
 
   jwa@2.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

- add editable session, trusted project-local, and global approval choices to direct permission prompts
- load `.pi/extensions/pi-permission-system/config.local.json` after shared project policy
- preserve JSONC while validating and atomically writing `allow` rules, with containment checks and rollback on reload failure
- keep forwarded asks and authorizer-chain decisions live-only
- log persistence requests, successes, and failures and document precedence, confirmation, rollback, and Git guidance

## Security properties

- project persistence is offered and revalidated only for trusted projects
- generated project rules never modify shared `config.json`
- tracked or indeterminate project-local files and all global writes require stronger typed confirmation
- failed validation, write, or reload denies the pending request and restores the original config
- existing cross-surface deny and most-restrictive composition remain authoritative

## Prior work

This credited reimplementation builds on the persistence, editable-pattern, atomic-write, test, and documentation concepts from #73 by @rienkim, while adapting them to current trust, JSONC, authorizer-chain, and project-local policy architecture. No source was copied from that closed branch.

## Validation

- `pnpm run check`
- `pnpm run lint`
- `pnpm run test` — 2,698 `pi-permission-system` tests
- `pnpm fallow dead-code`

Refs #691.
Also subsumes the project-only request in #603 and remains compatible with the policy-source work in #675.
