### PR TITLE
feat(pi-subagents): exclude package extensions from children

### DIFF
--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -304,6 +304,25 @@ Individual projects can still override via `/subagents:settings`.
 
 **Failure behavior:** missing file is silent; malformed JSON logs a `[pi-subagents] Ignoring malformed settings at …` warning to stderr; invalid/out-of-range field values are dropped per-field; write failures downgrade the `/subagents:settings` toast to a warning with `(session only; failed to persist)`.
 
+### Excluding package extensions from children
+
+Some session-oriented extensions must run only in the parent.
+Add their exact Pi package sources to `excludedExtensionPackages`:
+
+```json
+{
+  "excludedExtensionPackages": [
+    "npm:@cortexkit/pi-magic-context"
+  ]
+}
+```
+
+The setting disables only the matched package's extensions in child resource loaders, before extension factories run.
+Other resources from that package and all resources from other packages remain available.
+The parent session is unchanged.
+
+This setting is edited directly in the global or project `subagents.json`; it is not exposed in `/subagents:settings`.
+
 ### Abort on interrupt
 
 By default, pressing ESC to interrupt the parent agent also aborts every subagent.
@@ -343,7 +362,8 @@ The earlier `isolation: "worktree"` spawn flag and `isolation:` frontmatter key 
 ## Removed: agent memory and skill preloading
 
 Persistent agent memory (the `memory:` frontmatter key) and skill preloading (the `skills:` frontmatter key) were removed when the core was slimmed down.
-Children now always inherit the parent's skills and extensions, so the `isolated`, `extensions`, and `skills` frontmatter keys no longer exist.
+Children inherit the parent's skills and extensions by default, so the `isolated`, `extensions`, and `skills` frontmatter keys no longer exist.
+Package-level extension opt-outs belong in `excludedExtensionPackages` settings instead of agent frontmatter.
 
 ## Migrating from `disallowed_tools`
 

--- a/packages/pi-subagents/docs/architecture/architecture.md
+++ b/packages/pi-subagents/docs/architecture/architecture.md
@@ -547,7 +547,8 @@ The observational surface then carries only fire-and-forget broadcasts of immuta
 - **Session lifecycle** — create child sessions, bind extensions, run conversation loop, track results.
 - **Concurrency management** — queue, abort, resume, max concurrency.
 - **Recursion guard** — remove pi-subagents' own three tools from child sessions (prevent infinite nesting).
-  With `isolated` removed (#264), children always load the parent's resources, so the guard is unconditional rather than gated on `cfg.extensions`.
+  With `isolated` removed (#264), children load the parent's resources by default, so the guard is unconditional rather than gated on per-agent policy.
+  Child settings may disable extensions from exact package sources before resource loading.
   This is the core defending its own invariant, keyed off its own tool names — not policy.
 - **Lifecycle events** — emit awaited, ordered events when child sessions spawn, are created, complete, and are disposed.
 - **Workspace provider seam** — accept a registered `WorkspaceProvider` and consult it for the child's cwd; default to the parent's cwd when none is registered.
@@ -559,7 +560,8 @@ These policy and environment concerns were removed so the core stays narrow; eac
 
 - **Tool policy** (`disallowed_tools`) and **extension filtering** (`extensions: string[]`) — access control and tool visibility belong in pi-permission-system's `permission:` frontmatter (Phase 14, #237/#238).
 - **Worktree isolation** (`GitWorktreeManager`, the `isolation: "worktree"` mode) — one _strategy_ for choosing the child's cwd, evicted to `@gotgenes/pi-subagents-worktrees` (#263), the first consumer of the workspace provider seam.
-- **Extension lifecycle control** (`extensions: false`, `isolated`, `noSkills`) — removed in #264; deny-at-use covers what `isolated` pretended to do for tools, and prevent-load is left as a _latent_ (un-built) provider seam, added only if a real consumer needs it.
+- **Per-agent extension lifecycle control** (`extensions: false`, `isolated`, `noSkills`) — removed in #264; deny-at-use covers tool policy.
+  The global/project `excludedExtensionPackages` setting provides the narrower prevent-load seam needed for session-oriented extensions that are unsafe in child runtimes.
 
 ### Composition model
 

--- a/packages/pi-subagents/docs/decisions/0002-extensions-on-a-minimal-core.md
+++ b/packages/pi-subagents/docs/decisions/0002-extensions-on-a-minimal-core.md
@@ -96,3 +96,9 @@ Permissions depend only on the core's events; workspaces depend only on the core
   Confirming Pi's event model supports awaited pre-bind emission is the first investigation of the reclaimed phase.
 - Once the cwd is resolved through the provider seam rather than relayed by `Agent`, child-session creation can construct a born-complete execution and the "runner" concept dissolves — recovering the structural goal of the abandoned collaborator steps by a cleaner route.
 - The reclaimed Phase 16 roadmap and step issues live in [`docs/architecture/architecture.md`](../architecture/architecture.md).
+
+## Amendment: concrete prevent-load consumer
+
+Magic Context exposed a concrete integration failure: in-process children reloaded its session-wide extension runtime and multiplied global session discovery in the shared V8 heap.
+The core therefore admits a narrow package-level prevent-load setting, `excludedExtensionPackages`.
+It applies globally or per project before child resource loading, preserves default inheritance, and does not restore per-agent policy or tool permission semantics.

--- a/packages/pi-subagents/src/index.ts
+++ b/packages/pi-subagents/src/index.ts
@@ -108,6 +108,7 @@ export default function (pi: ExtensionAPI) {
     },
     exec: (cmd, args, opts) => pi.exec(cmd, args, opts),
     registry,
+    getExcludedExtensionPackages: () => settings.excludedExtensionPackages,
     lifecycle: createChildLifecyclePublisher((channel, data) => pi.events.emit(channel, data)),
   };
 

--- a/packages/pi-subagents/src/lifecycle/create-subagent-session.ts
+++ b/packages/pi-subagents/src/lifecycle/create-subagent-session.ts
@@ -29,10 +29,49 @@ import type { ParentSessionInfo, ShellExec, SubagentType, ThinkingLevel } from "
 /** Names of tools registered by this extension that subagents must NOT inherit. */
 const EXCLUDED_TOOL_NAMES = ["subagent", "get_subagent_result", "steer_subagent"];
 
+type PiSettings = ReturnType<SettingsManager["getGlobalSettings"]>;
+
+function disableExcludedPackageExtensions(settings: PiSettings, excludedSources: ReadonlySet<string>): PiSettings {
+  if (!settings.packages || excludedSources.size === 0) return settings;
+
+  return {
+    ...settings,
+    packages: settings.packages.map((pkg) => {
+      const source = typeof pkg === "string" ? pkg : pkg.source;
+      if (!excludedSources.has(source)) return pkg;
+      return typeof pkg === "string" ? { source, extensions: [] } : { ...pkg, extensions: [] };
+    }),
+  };
+}
+
+/** Child-local view of Pi settings that disables selected package extensions before resource loading. */
+function createChildSettingsManager(
+  settingsManager: SettingsManager,
+  excludedSources: readonly string[],
+): SettingsManager {
+  const excluded = new Set(excludedSources);
+  if (excluded.size === 0) return settingsManager;
+
+  return new Proxy(settingsManager, {
+    get(target, property) {
+      if (property === "getGlobalSettings") {
+        return () => disableExcludedPackageExtensions(target.getGlobalSettings(), excluded);
+      }
+      if (property === "getProjectSettings") {
+        return () => disableExcludedPackageExtensions(target.getProjectSettings(), excluded);
+      }
+      const value = (target as unknown as Record<PropertyKey, unknown>)[property];
+      return typeof value === "function"
+        ? (...args: unknown[]): unknown => Reflect.apply(value, target, args) as unknown
+        : value;
+    },
+  });
+}
+
 /**
  * Apply the recursion guard: remove this extension's dispatch tools from the
  * child's active set. Runs after `bindExtensions` so extension-registered tools
- * are also covered. Unconditional: children always load the parent's extensions.
+ * are also covered. The guard is unconditional for every child that reaches binding.
  */
 function applyRecursionGuard(session: AgentSession): void {
   const filtered = session
@@ -59,6 +98,7 @@ export interface SessionManagerLike {
 export interface ResourceLoaderOptions {
   cwd: string;
   agentDir: string;
+  settingsManager?: SettingsManager;
   noPromptTemplates?: boolean;
   noThemes?: boolean;
   noContextFiles?: boolean;
@@ -122,6 +162,7 @@ export interface SubagentSessionDeps {
   io: SubagentSessionIO;
   exec: ShellExec;
   registry: AgentConfigLookup;
+  getExcludedExtensionPackages: () => readonly string[];
   /** Publishes the child-execution lifecycle so consumers can observe it. */
   lifecycle: ChildLifecyclePublisher;
 }
@@ -174,8 +215,12 @@ export async function createSubagentSession(
   );
 
   const agentDir = deps.io.getAgentDir();
+  const settingsManager = createChildSettingsManager(
+    deps.io.createSettingsManager(effectiveCwd, agentDir),
+    deps.getExcludedExtensionPackages(),
+  );
 
-  // Children always load the parent's extensions and skills.
+  // Children load the parent's skills and all extensions not explicitly excluded.
   // Suppress AGENTS.md/CLAUDE.md and APPEND_SYSTEM.md - upstream's
   // buildSystemPrompt() re-appends both AFTER systemPromptOverride, which
   // would defeat prompt_mode: replace. Parent context, if wanted, reaches the
@@ -184,6 +229,7 @@ export async function createSubagentSession(
   const loader = deps.io.createResourceLoader({
     cwd: cfg.effectiveCwd,
     agentDir,
+    settingsManager,
     noPromptTemplates: true,
     noThemes: true,
     noContextFiles: true,
@@ -204,7 +250,7 @@ export async function createSubagentSession(
     cwd: cfg.effectiveCwd,
     agentDir,
     sessionManager,
-    settingsManager: deps.io.createSettingsManager(cfg.effectiveCwd, agentDir),
+    settingsManager,
     modelRegistry: snapshot.modelRegistry,
     model: cfg.model,
     tools: cfg.toolNames,

--- a/packages/pi-subagents/src/settings.ts
+++ b/packages/pi-subagents/src/settings.ts
@@ -24,6 +24,8 @@ export interface SubagentsSettings {
    * abort on ESC either way.
    */
   abortAllOnInterrupt?: boolean;
+  /** Pi package sources whose extensions children must not load. */
+  excludedExtensionPackages?: string[];
 }
 
 
@@ -47,6 +49,7 @@ export class SettingsManager {
   private _consumedSessionRetentionMinutes: number = DEFAULT_CONSUMED_RETENTION_MINUTES;
   private _unconsumedSessionRetentionMinutes: number = DEFAULT_UNCONSUMED_RETENTION_MINUTES;
   private _abortAllOnInterrupt: boolean = DEFAULT_ABORT_ALL_ON_INTERRUPT;
+  private _excludedExtensionPackages: string[] = [];
 
   private readonly emit: SettingsEmit;
   private readonly cwd: string;
@@ -118,6 +121,10 @@ export class SettingsManager {
     return this._abortAllOnInterrupt;
   }
 
+  get excludedExtensionPackages(): readonly string[] {
+    return this._excludedExtensionPackages;
+  }
+
   // ── Lifecycle methods ──
 
   /**
@@ -136,6 +143,7 @@ export class SettingsManager {
       this.unconsumedSessionRetentionMinutes = settings.unconsumedSessionRetentionMinutes;
     if (typeof settings.abortAllOnInterrupt === "boolean")
       this._abortAllOnInterrupt = settings.abortAllOnInterrupt;
+    this._excludedExtensionPackages = [...(settings.excludedExtensionPackages ?? [])];
     this.emit("subagents:settings_loaded", { settings });
     return settings;
   }
@@ -151,8 +159,9 @@ export class SettingsManager {
     consumedSessionRetentionMinutes: number;
     unconsumedSessionRetentionMinutes: number;
     abortAllOnInterrupt: boolean;
+    excludedExtensionPackages?: string[];
   } {
-    return {
+    const snapshot = {
       maxConcurrent: this._maxConcurrent,
       defaultMaxTurns: this._defaultMaxTurns ?? 0,
       graceTurns: this._graceTurns,
@@ -160,6 +169,9 @@ export class SettingsManager {
       unconsumedSessionRetentionMinutes: this._unconsumedSessionRetentionMinutes,
       abortAllOnInterrupt: this._abortAllOnInterrupt,
     };
+    return this._excludedExtensionPackages.length > 0
+      ? { ...snapshot, excludedExtensionPackages: [...this._excludedExtensionPackages] }
+      : snapshot;
   }
 
   /**
@@ -278,6 +290,13 @@ function sanitize(raw: unknown): SubagentsSettings {
   }
   if (typeof r.abortAllOnInterrupt === "boolean") {
     out.abortAllOnInterrupt = r.abortAllOnInterrupt;
+  }
+  if (Array.isArray(r.excludedExtensionPackages)) {
+    const packages = r.excludedExtensionPackages
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => value.trim())
+      .filter(Boolean);
+    out.excludedExtensionPackages = [...new Set(packages)];
   }
   return out;
 }

--- a/packages/pi-subagents/test/helpers/subagent-session-io.ts
+++ b/packages/pi-subagents/test/helpers/subagent-session-io.ts
@@ -81,12 +81,14 @@ export function createSubagentSessionDeps(overrides?: {
 	io?: ReturnType<typeof createSubagentSessionIO>;
 	exec?: ShellExec;
 	registry?: AgentConfigLookup;
+	getExcludedExtensionPackages?: () => readonly string[];
 	lifecycle?: ReturnType<typeof createChildLifecycleMock>;
 }) {
 	return {
 		io: overrides?.io ?? createSubagentSessionIO(),
 		exec: overrides?.exec ?? vi.fn(),
 		registry: overrides?.registry ?? createAgentLookup(),
+		getExcludedExtensionPackages: overrides?.getExcludedExtensionPackages ?? (() => []),
 		lifecycle: overrides?.lifecycle ?? createChildLifecycleMock(),
 	};
 }

--- a/packages/pi-subagents/test/lifecycle/create-subagent-session.test.ts
+++ b/packages/pi-subagents/test/lifecycle/create-subagent-session.test.ts
@@ -87,6 +87,48 @@ describe("createSubagentSession — assembly", () => {
     );
   });
 
+  it("disables excluded package extensions in the child settings view before loader reload", async () => {
+    const baseSettings = {
+      getGlobalSettings: vi.fn(() => ({
+        packages: ["npm:@cortexkit/pi-magic-context", "npm:keep-me"],
+      })),
+      getProjectSettings: vi.fn(() => ({
+        packages: [{ source: "npm:@cortexkit/pi-magic-context", skills: ["skills/**"] }],
+      })),
+    };
+    io.createSettingsManager.mockReturnValue(baseSettings);
+
+    await createSubagentSession(
+      { snapshot: STUB_SNAPSHOT, type: "Explore" },
+      createSubagentSessionDeps({
+        io,
+        exec,
+        registry: mockAgentLookup,
+        getExcludedExtensionPackages: () => ["npm:@cortexkit/pi-magic-context"],
+      }),
+    );
+
+    const loaderOpts = io.createResourceLoader.mock.calls[0][0];
+    expect(loaderOpts.settingsManager.getGlobalSettings().packages).toEqual([
+      { source: "npm:@cortexkit/pi-magic-context", extensions: [] },
+      "npm:keep-me",
+    ]);
+    expect(loaderOpts.settingsManager.getProjectSettings().packages).toEqual([
+      {
+        source: "npm:@cortexkit/pi-magic-context",
+        skills: ["skills/**"],
+        extensions: [],
+      },
+    ]);
+    expect(io.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ settingsManager: loaderOpts.settingsManager }),
+    );
+    expect(baseSettings.getGlobalSettings().packages).toEqual([
+      "npm:@cortexkit/pi-magic-context",
+      "npm:keep-me",
+    ]);
+  });
+
   it("suppresses AGENTS.md/CLAUDE.md/APPEND_SYSTEM.md for subagents", async () => {
     await createSubagentSession(
       { snapshot: STUB_SNAPSHOT, type: "Explore" },

--- a/packages/pi-subagents/test/settings.test.ts
+++ b/packages/pi-subagents/test/settings.test.ts
@@ -220,6 +220,26 @@ describe("settings persistence", () => {
       writeProject({ abortAllOnInterrupt: null });
       expect(loadSettings(globalDir, projectDir)).toEqual({});
     });
+
+    it("sanitizes and deduplicates excludedExtensionPackages", () => {
+      writeProject({
+        excludedExtensionPackages: [
+          " npm:@cortexkit/pi-magic-context ",
+          "npm:@cortexkit/pi-magic-context",
+          "npm:keep",
+          "",
+          42,
+        ],
+      });
+      expect(loadSettings(globalDir, projectDir)).toEqual({
+        excludedExtensionPackages: ["npm:@cortexkit/pi-magic-context", "npm:keep"],
+      });
+    });
+
+    it("drops excludedExtensionPackages when it is not an array", () => {
+      writeProject({ excludedExtensionPackages: "npm:@cortexkit/pi-magic-context" });
+      expect(loadSettings(globalDir, projectDir)).toEqual({});
+    });
   });
 
   describe("save result + corrupt-file warning", () => {
@@ -307,6 +327,11 @@ describe("SettingsManager", () => {
     it("defaults to abortAllOnInterrupt: true (ESC keeps its current blast radius)", () => {
       const sm = new SettingsManager({ emit: vi.fn(), cwd: "/tmp", agentDir: "/nonexistent" });
       expect(sm.abortAllOnInterrupt).toBe(true);
+    });
+
+    it("defaults to no excluded extension packages", () => {
+      const sm = new SettingsManager({ emit: vi.fn(), cwd: "/tmp", agentDir: "/nonexistent" });
+      expect(sm.excludedExtensionPackages).toEqual([]);
     });
   });
 
@@ -464,6 +489,22 @@ describe("SettingsManager", () => {
       expect(sm.abortAllOnInterrupt).toBe(true);
     });
 
+    it("loads excluded extension package sources", () => {
+      mkdirSync(join(projectDir, ".pi"), { recursive: true });
+      const settingsPath = join(projectDir, ".pi", "subagents.json");
+      writeFileSync(
+        settingsPath,
+        JSON.stringify({ excludedExtensionPackages: ["npm:@cortexkit/pi-magic-context"] }),
+      );
+      const sm = new SettingsManager({ emit: vi.fn(), cwd: projectDir, agentDir: globalDir });
+      sm.load();
+      expect(sm.excludedExtensionPackages).toEqual(["npm:@cortexkit/pi-magic-context"]);
+
+      writeFileSync(settingsPath, JSON.stringify({}));
+      sm.load();
+      expect(sm.excludedExtensionPackages).toEqual([]);
+    });
+
     it("emits subagents:settings_loaded with merged settings", () => {
       mkdirSync(join(projectDir, ".pi"), { recursive: true });
       writeFileSync(join(projectDir, ".pi", "subagents.json"), JSON.stringify({ graceTurns: 7 }));
@@ -521,6 +562,26 @@ describe("SettingsManager", () => {
       const sm = new SettingsManager({ emit: vi.fn(), cwd: "/tmp", agentDir: "/nonexistent" });
       sm.toggleAbortAllOnInterrupt();
       expect(sm.snapshot()).toEqual({ maxConcurrent: 4, defaultMaxTurns: 0, graceTurns: 5, consumedSessionRetentionMinutes: 10, unconsumedSessionRetentionMinutes: 720, abortAllOnInterrupt: false });
+    });
+
+    it("preserves excluded extension packages loaded from disk", () => {
+      const projectDir = mkdtempSync(join(tmpdir(), "pi-sm-excluded-"));
+      try {
+        mkdirSync(join(projectDir, ".pi"), { recursive: true });
+        writeFileSync(
+          join(projectDir, ".pi", "subagents.json"),
+          JSON.stringify({ excludedExtensionPackages: ["npm:@cortexkit/pi-magic-context"] }),
+        );
+        const sm = new SettingsManager({ emit: vi.fn(), cwd: projectDir, agentDir: "/nonexistent" });
+        sm.load();
+        expect(sm.snapshot()).toEqual(
+          expect.objectContaining({
+            excludedExtensionPackages: ["npm:@cortexkit/pi-magic-context"],
+          }),
+        );
+      } finally {
+        rmSync(projectDir, { recursive: true, force: true });
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- add `excludedExtensionPackages` to layered `subagents.json` settings
- pass a child-local filtered `SettingsManager` into `ResourceLoader` before package discovery
- disable only matching package extensions; keep package skills and other resources available
- document exact Pi package-source matching and the parent/child behavior

Closes #696.

## Why

In-process child sessions currently reload every parent package extension. Extensions that are parent-scoped or expensive per session can initialize repeatedly in the shared V8 heap. A concrete reproducer is cortexkit/magic-context#247: four concurrent children load Magic Context five times total (parent + four children) and abort near the V8 heap limit while scanning a large Pi session store.

This change adds a narrow, opt-in prevent-load seam without restoring the old broad `extensions`/`isolated` agent frontmatter policy.

Example:

```json
{
  "excludedExtensionPackages": [
    "npm:@cortexkit/pi-magic-context"
  ]
}
```

## Validation

- `pnpm run check`
- `pnpm run lint`
- `pnpm test` — 64 files, 1,141 tests passed
- regression run with four concurrent children: all four returned; process remained around 60 MB RSS after five minutes instead of reproducing the previous ~4.14 GB V8 OOM / exit 134
