### PR TITLE
fix(pi-permission-system): export child detector and duplicate-author…

### DIFF
--- a/packages/pi-permission-system/docs/cross-extension-api.md
+++ b/packages/pi-permission-system/docs/cross-extension-api.md
@@ -78,6 +78,16 @@ interface PermissionsService {
     toolName: string,
     extractor: (input: Record<string, unknown>) => string | undefined,
   ): () => void;
+
+  /**
+   * Register a named live-authority link consulted by `authorizerChain`.
+   * Returns a disposer.
+   * Throws a duplicate-registration error when the name is already present.
+   */
+  registerAuthorizer(
+    name: string,
+    authorize: Authorizer["authorize"],
+  ): () => void;
 }
 ```
 
@@ -262,6 +272,49 @@ const dispose = permissions.registerToolAccessExtractor("ffgrep", (input) =>
 
 Registration rules mirror `registerToolInputFormatter`: one extractor per tool name (a second `register` for the same name throws), and the returned disposer is identity-guarded.
 The extractor must not throw — guard your parsing and return `undefined` on anything unexpected.
+
+#### `isRegisteredSubagentChild` and `isAuthorizerAlreadyRegisteredError`
+
+`registerAuthorizer` callbacks receive the current ask details, the narrow `PermissionQuery`, the shared `AuthorizerLog`, and an optional `signal` (`ctx.signal`) as the fourth argument.
+Use `signal` to cancel long-running review work (for example, a model call) promptly when the user interrupts the session.
+
+When an extension registers authorizers from a `permissions:ready` listener, in-process subagent children reuse the parent service instance.
+A child can therefore hit duplicate registration if it calls `registerAuthorizer` for a link name the parent already owns.
+
+Use the public child detector to skip duplicate registration in children:
+
+```typescript
+import { isRegisteredSubagentChild } from "@gotgenes/pi-permission-system";
+
+pi.events.on(PERMISSIONS_READY_CHANNEL, (_event, ctx) => {
+  if (isRegisteredSubagentChild(ctx)) {
+    return;
+  }
+  registerAuthorizer();
+});
+```
+
+And/or use the exported type guard when a duplicate slips through:
+
+```typescript
+import {
+  getPermissionsService,
+  isAuthorizerAlreadyRegisteredError,
+} from "@gotgenes/pi-permission-system";
+
+try {
+  getPermissionsService()?.registerAuthorizer("model-judge", authorize);
+} catch (error) {
+  if (isAuthorizerAlreadyRegisteredError(error)) {
+    // Benign duplicate in child context.
+  } else {
+    throw error;
+  }
+}
+```
+
+Duplicate-registration errors carry a stable `code` (`"AUTHORIZER_ALREADY_REGISTERED"`) and the duplicate `linkName`.
+`isAuthorizerAlreadyRegisteredError` checks that shape directly, so handling stays reliable across per-extension module isolation.
 
 #### Subagent session registration
 

--- a/packages/pi-permission-system/scripts/verify-public-types.sh
+++ b/packages/pi-permission-system/scripts/verify-public-types.sh
@@ -28,7 +28,8 @@ for sym in getPermissionsService publishPermissionsService unpublishPermissionsS
   PermissionsService PermissionCheckResult PermissionState ToolInputFormatter \
   PERMISSIONS_UI_PROMPT_CHANNEL PERMISSIONS_READY_CHANNEL PERMISSIONS_DECISION_CHANNEL \
   PermissionUiPromptEvent registerAuthorizer PermissionQuery Authorizer \
-  AuthorizerVerdict PromptPermissionDetails; do
+  AuthorizerVerdict PromptPermissionDetails isRegisteredSubagentChild \
+  isAuthorizerAlreadyRegisteredError; do
   grep -q "$sym" "$DTS" || { echo "FAIL: '$sym' missing from dist/public.d.ts" >&2; exit 1; }
 done
 echo "OK: dist/public.d.ts is self-contained and exports the public surface"

--- a/packages/pi-permission-system/src/authority/authorizer-registry.ts
+++ b/packages/pi-permission-system/src/authority/authorizer-registry.ts
@@ -15,6 +15,41 @@
 import type { Authorizer } from "./authorizer";
 
 /**
+ * Thrown when a second authorizer attempts to register the same link name.
+ *
+ * Exported so downstream extensions can reliably catch duplicate-registration
+ * in child sessions without string-matching the error message.
+ */
+export class AuthorizerAlreadyRegisteredError extends Error {
+  readonly code = "AUTHORIZER_ALREADY_REGISTERED" as const;
+
+  constructor(readonly linkName: string) {
+    super(`An authorizer is already registered for '${linkName}'.`);
+    this.name = "AuthorizerAlreadyRegisteredError";
+  }
+}
+
+/**
+ * Return true when `value` matches the duplicate-registration error shape.
+ *
+ * Consumers should prefer this guard over `instanceof` across extension
+ * boundaries, where each extension may import a different module instance.
+ */
+export function isAuthorizerAlreadyRegisteredError(
+  value: unknown,
+): value is AuthorizerAlreadyRegisteredError {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    candidate.name === "AuthorizerAlreadyRegisteredError" &&
+    candidate.code === "AUTHORIZER_ALREADY_REGISTERED" &&
+    typeof candidate.linkName === "string"
+  );
+}
+
+/**
  * Read-only lookup used by chain composition (ISP — exposes only the read side,
  * not the registration surface).
  */
@@ -53,7 +88,7 @@ export class AuthorizerRegistry
    */
   register(name: string, authorize: Authorizer["authorize"]): () => void {
     if (this.links.has(name)) {
-      throw new Error(`An authorizer is already registered for '${name}'.`);
+      throw new AuthorizerAlreadyRegisteredError(name);
     }
     this.links.set(name, authorize);
     return () => {

--- a/packages/pi-permission-system/src/authority/subagent-context.ts
+++ b/packages/pi-permission-system/src/authority/subagent-context.ts
@@ -1,5 +1,6 @@
 import { SUBAGENT_ENV_HINT_KEYS } from "#src/authority/permission-forwarding";
 import type { SubagentSessionRegistry } from "#src/authority/subagent-registry";
+import { getSubagentSessionRegistry } from "#src/authority/subagent-registry";
 import type { PathFlavor } from "#src/path/path-flavor";
 
 /**
@@ -33,14 +34,22 @@ export function normalizeFilesystemPath(
  */
 export function isRegisteredSubagentChild(
   ctx: SubagentDetectionContext,
+): boolean;
+export function isRegisteredSubagentChild(
+  ctx: SubagentDetectionContext,
   registry: SubagentSessionRegistry,
+): boolean;
+export function isRegisteredSubagentChild(
+  ctx: SubagentDetectionContext,
+  registry?: SubagentSessionRegistry,
 ): boolean {
+  const activeRegistry = registry ?? getSubagentSessionRegistry();
   try {
     const sessionId = ctx.sessionManager.getSessionId();
     if (!sessionId) {
       return false;
     }
-    return registry.has(sessionId);
+    return activeRegistry.has(sessionId);
   } catch {
     // getSessionId() unavailable — treat as not-a-registered-child.
     return false;

--- a/packages/pi-permission-system/src/service.ts
+++ b/packages/pi-permission-system/src/service.ts
@@ -20,6 +20,8 @@ export type {
   Authorizer,
   AuthorizerVerdict,
 } from "./authority/authorizer";
+export { isAuthorizerAlreadyRegisteredError } from "./authority/authorizer-registry";
+export { isRegisteredSubagentChild } from "./authority/subagent-context";
 
 /**
  * The narrow review-log seam handed to a chain link at `authorize` time
@@ -160,9 +162,11 @@ export interface PermissionsService extends PermissionQuery {
    *
    * @param name      - Operator-facing link name referenced from `authorizerChain`.
    * @param authorize - The link's decision callback
-   *                    (`(details, query, log) => verdict`); `log` is an
-   *                    {@link AuthorizerLog} for recording a decision trail to
-   *                    the shared permission review log.
+   *                    (`(details, query, log, signal?) => verdict`); `log` is
+   *                    an {@link AuthorizerLog} for recording a decision trail
+   *                    to the shared permission review log, and `signal` is the
+   *                    active session's `ctx.signal` so long-running link work
+   *                    can cancel promptly when the session is interrupted.
    */
   registerAuthorizer(
     name: string,

--- a/packages/pi-permission-system/test/authority/authorizer-registry.test.ts
+++ b/packages/pi-permission-system/test/authority/authorizer-registry.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "vitest";
 
 import type { Authorizer } from "#src/authority/authorizer";
-import { AuthorizerRegistry } from "#src/authority/authorizer-registry";
+import {
+  AuthorizerAlreadyRegisteredError,
+  AuthorizerRegistry,
+  isAuthorizerAlreadyRegisteredError,
+} from "#src/authority/authorizer-registry";
 
 const noopLink: Authorizer["authorize"] = () =>
   Promise.resolve({ kind: "defer" });
@@ -28,7 +32,18 @@ describe("AuthorizerRegistry", () => {
         registry.register("model-judge", () =>
           Promise.resolve({ kind: "defer" }),
         ),
-      ).toThrow("model-judge");
+      ).toThrow(AuthorizerAlreadyRegisteredError);
+      try {
+        registry.register("model-judge", () =>
+          Promise.resolve({ kind: "defer" }),
+        );
+      } catch (error) {
+        expect(error).toBeInstanceOf(AuthorizerAlreadyRegisteredError);
+        if (error instanceof AuthorizerAlreadyRegisteredError) {
+          expect(error.code).toBe("AUTHORIZER_ALREADY_REGISTERED");
+          expect(error.linkName).toBe("model-judge");
+        }
+      }
     });
 
     test("allows registering different names independently", () => {
@@ -67,5 +82,38 @@ describe("AuthorizerRegistry", () => {
       const registry = new AuthorizerRegistry();
       expect(registry.get("unknown")).toBeUndefined();
     });
+  });
+});
+
+describe("isAuthorizerAlreadyRegisteredError", () => {
+  test("returns true for the registry's duplicate-registration error", () => {
+    const registry = new AuthorizerRegistry();
+    registry.register("model-judge", noopLink);
+    try {
+      registry.register("model-judge", noopLink);
+    } catch (error) {
+      expect(isAuthorizerAlreadyRegisteredError(error)).toBe(true);
+      return;
+    }
+    throw new Error("expected duplicate registration to throw");
+  });
+
+  test("returns true for a structural error shape from another module instance", () => {
+    const foreignError = {
+      name: "AuthorizerAlreadyRegisteredError",
+      code: "AUTHORIZER_ALREADY_REGISTERED",
+      linkName: "model-judge",
+    };
+    expect(isAuthorizerAlreadyRegisteredError(foreignError)).toBe(true);
+  });
+
+  test("returns false for unrelated errors", () => {
+    expect(isAuthorizerAlreadyRegisteredError(new Error("nope"))).toBe(false);
+    expect(
+      isAuthorizerAlreadyRegisteredError({
+        name: "AuthorizerAlreadyRegisteredError",
+        code: "AUTHORIZER_ALREADY_REGISTERED",
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/pi-permission-system/test/authority/subagent-context.test.ts
+++ b/packages/pi-permission-system/test/authority/subagent-context.test.ts
@@ -6,7 +6,10 @@ import {
   normalizeFilesystemPath,
   type SubagentDetectionContext,
 } from "#src/authority/subagent-context";
-import { SubagentSessionRegistry } from "#src/authority/subagent-registry";
+import {
+  getSubagentSessionRegistry,
+  SubagentSessionRegistry,
+} from "#src/authority/subagent-registry";
 import { posixPathFlavor, win32PathFlavor } from "#src/path/path-flavor";
 
 afterEach(() => {
@@ -62,6 +65,20 @@ describe("isRegisteredSubagentChild", () => {
       },
     };
     expect(isRegisteredSubagentChild(ctx, registry)).toBe(false);
+  });
+});
+
+describe("isRegisteredSubagentChild (public one-arg form)", () => {
+  test("reads from the process-global subagent session registry", () => {
+    const sessionId = "global-child-session";
+    const registry = getSubagentSessionRegistry();
+    registry.register(sessionId, {});
+
+    try {
+      expect(isRegisteredSubagentChild(makeCtx(null, sessionId))).toBe(true);
+    } finally {
+      registry.unregister(sessionId);
+    }
   });
 });
 

--- a/packages/pi-permission-system/test/service.test.ts
+++ b/packages/pi-permission-system/test/service.test.ts
@@ -1,12 +1,18 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AccessIntent } from "#src/access-intent/access-intent";
-import { AuthorizerRegistry } from "#src/authority/authorizer-registry";
+import {
+  AuthorizerRegistry,
+  isAuthorizerAlreadyRegisteredError,
+} from "#src/authority/authorizer-registry";
+import { getSubagentSessionRegistry } from "#src/authority/subagent-registry";
 import { posixPathFlavor } from "#src/path/path-flavor";
 import { PathNormalizer } from "#src/path-normalizer";
 import { LocalPermissionsService } from "#src/permissions-service";
 import type { PermissionsService } from "#src/service";
 import {
   getPermissionsService,
+  isAuthorizerAlreadyRegisteredError as isAuthorizerAlreadyRegisteredErrorPublic,
+  isRegisteredSubagentChild,
   publishPermissionsService,
   unpublishPermissionsService,
 } from "#src/service";
@@ -77,6 +83,38 @@ describe("globalThis accessor", () => {
   it("unpublish is safe to call when nothing was published", () => {
     expect(() => unpublishPermissionsService(makeService())).not.toThrow();
     expect(getPermissionsService()).toBeUndefined();
+  });
+});
+
+describe("additional public exports", () => {
+  it("exports isRegisteredSubagentChild with process-global registry lookup", () => {
+    const sessionId = "service-export-child";
+    const ctx = {
+      sessionManager: {
+        getSessionDir: () => "",
+        getSessionId: () => sessionId,
+      },
+    };
+    const registry = getSubagentSessionRegistry();
+    registry.register(sessionId, {});
+    try {
+      expect(isRegisteredSubagentChild(ctx)).toBe(true);
+    } finally {
+      registry.unregister(sessionId);
+    }
+  });
+
+  it("exports isAuthorizerAlreadyRegisteredError for cross-module-safe duplicate detection", () => {
+    const foreignError = {
+      name: "AuthorizerAlreadyRegisteredError",
+      code: "AUTHORIZER_ALREADY_REGISTERED",
+      linkName: "model-judge",
+    };
+    expect(isAuthorizerAlreadyRegisteredErrorPublic(foreignError)).toBe(true);
+    // Keep source and public exports aligned.
+    expect(isAuthorizerAlreadyRegisteredErrorPublic(foreignError)).toBe(
+      isAuthorizerAlreadyRegisteredError(foreignError),
+    );
   });
 });
 


### PR DESCRIPTION
…izer guard

Expose isRegisteredSubagentChild as a public API and add cross-extension-safe duplicate-registration handling via isAuthorizerAlreadyRegisteredError.

Keep duplicate registration typed internally while avoiding public instanceof coupling across isolated extension module instances.

Closes #699