### PR TITLE
feat(pi-permission-system): pass authorizer invocation context throug…

### DIFF
--- a/packages/pi-permission-system/README.md
+++ b/packages/pi-permission-system/README.md
@@ -116,6 +116,7 @@ The optional `shellTools` field records which non-`bash` tools carry shell seman
 
 The optional `authorizerChain` field names registered case-by-case decision links (e.g. a light model judge) to consult when a request lands on `ask`, ahead of the interactive prompt.
 A downstream extension registers a link via `getPermissionsService().registerAuthorizer(name, authorize)`; it decides nothing until you name it here (opt-in), config order fixes the chain order, and the chain owner caps any link's `allow` on `external_directory`/`path` to keep it within your policy — see [docs/configuration.md](docs/configuration.md#authorizer-chain--case-by-case-decision-links).
+The callback also receives an aggregate invocation context whose `signal` field exposes `ctx.signal` for canceling long-running link work when the session is interrupted.
 [`@gotgenes/pi-permission-model-judge`](https://github.com/gotgenes/pi-packages/tree/main/packages/pi-permission-model-judge) is a first-party reference implementation of such a link — a deny-first reviewer that auto-denies mistyped out-of-directory paths.
 
 For the full reference — all surfaces, runtime knobs, per-agent overrides, merge semantics, and common recipes — see [docs/configuration.md](docs/configuration.md).

--- a/packages/pi-permission-system/docs/configuration.md
+++ b/packages/pi-permission-system/docs/configuration.md
@@ -213,7 +213,7 @@ The excluded surface is the **gate** surface the rule fired on, not the tool nam
 This holds for an ask forwarded up from a subagent exactly as it does for a local one.
 See [migration/0635-forwarded-ask-delegation-envelope.md](migration/0635-forwarded-ask-delegation-envelope.md).
 
-Extension authors: register a link from a `permissions:ready` handler via `getPermissionsService().registerAuthorizer(name, authorize)`; the callback receives the ask details and a narrow, session-scoped `PermissionQuery` (`checkPermission` / `getToolPermission`) so it can consult the deterministic engine at gate parity.
+Extension authors: register a link from a `permissions:ready` handler via `getPermissionsService().registerAuthorizer(name, authorize)`; the callback receives the ask details, a narrow session-scoped `PermissionQuery` (`checkPermission` / `getToolPermission`), a shared `AuthorizerLog`, and an aggregate invocation context whose `signal` field exposes `ctx.signal` so long-running link work can cancel promptly on session interruption.
 Registration returns a disposer, and only one link may hold a given name.
 For a complete working example, see [`@gotgenes/pi-permission-model-judge`](https://github.com/gotgenes/pi-packages/tree/main/packages/pi-permission-model-judge): it registers a `model-judge` link on `permissions:ready` that reviews `external_directory` asks and auto-denies mistyped paths with a corrective reason.
 

--- a/packages/pi-permission-system/src/authority/authorizer-chain.ts
+++ b/packages/pi-permission-system/src/authority/authorizer-chain.ts
@@ -1,6 +1,7 @@
 import type { AuthorizerLog, PermissionQuery } from "#src/service";
 import type {
   Authorizer,
+  AuthorizerInvocationContext,
   AuthorizerVerdict,
   TerminalAuthorizer,
 } from "./authorizer";
@@ -16,18 +17,20 @@ import { createDeniedPermissionDecision } from "./permission-dialog";
  * (returns a full decision), so a deferring link cannot occupy the terminal
  * slot.
  *
- * Each link is handed the session-scoped `query` and the review-log `log` at
- * `authorize` time (ADR 0007 §3) so it queries the deterministic engine at gate
- * parity and records its decision trail; the terminal receives neither. With
- * zero links the composed chain **is** the terminal instance (identity), so
- * behavior is byte-identical to the pre-chain spine — the empty-links case that
- * ships until a link registers.
+ * Each link is handed the session-scoped `query`, the review-log `log`, and
+ * the optional aggregate runtime `context` at `authorize` time (ADR 0007 §3)
+ * so it queries the deterministic engine at gate parity and records its
+ * decision trail; the terminal receives neither. With zero links the composed
+ * chain **is** the terminal instance (identity), so behavior is byte-identical
+ * to the pre-chain spine — the empty-links case that ships until a link
+ * registers.
  */
 export function composeAuthorizerChain(
   links: readonly Authorizer[],
   terminal: TerminalAuthorizer,
   query: PermissionQuery,
   log: AuthorizerLog,
+  context: AuthorizerInvocationContext,
 ): TerminalAuthorizer {
   if (links.length === 0) {
     return terminal;
@@ -35,7 +38,7 @@ export function composeAuthorizerChain(
   return {
     async authorize(details) {
       for (const link of links) {
-        const verdict = await link.authorize(details, query, log);
+        const verdict = await link.authorize(details, query, log, context);
         const decision = decideFromVerdict(verdict);
         if (decision) {
           return decision;

--- a/packages/pi-permission-system/src/authority/authorizer-selection.ts
+++ b/packages/pi-permission-system/src/authority/authorizer-selection.ts
@@ -3,6 +3,7 @@ import type { PermissionPromptDecision } from "#src/authority/permission-dialog"
 import type { PermissionQuery } from "#src/service";
 import {
   type Authorizer,
+  type AuthorizerInvocationContext,
   type AuthorizerSelectionDeps,
   selectAuthorizer,
   type TerminalAuthorizer,
@@ -55,6 +56,7 @@ export class AuthorizerSelection
   implements AskEscalator, AuthorizerSelectionLifecycle
 {
   private terminal: TerminalAuthorizer | null = null;
+  private context: AuthorizerInvocationContext | null = null;
 
   constructor(
     private readonly deps: AuthorizerSelectionDeps & {
@@ -76,6 +78,7 @@ export class AuthorizerSelection
    */
   activate(ctx: ExtensionContext): void {
     this.terminal = selectAuthorizer(ctx, this.deps);
+    this.context = { signal: ctx.signal };
   }
 
   /**
@@ -101,6 +104,7 @@ export class AuthorizerSelection
   /** Clear the stored selection. */
   deactivate(): void {
     this.terminal = null;
+    this.context = null;
   }
 
   /**
@@ -117,7 +121,7 @@ export class AuthorizerSelection
   escalate(
     details: PromptPermissionDetails,
   ): Promise<PermissionPromptDecision> {
-    if (this.terminal === null) {
+    if (this.terminal === null || this.context === null) {
       return Promise.reject(
         new Error("escalate called before the session was activated"),
       );
@@ -127,6 +131,7 @@ export class AuthorizerSelection
       this.terminal,
       this.deps.getPermissionQuery(),
       this.deps.logger,
+      this.context,
     );
     return this.deps.prompter.prompt(chain, details);
   }

--- a/packages/pi-permission-system/src/authority/authorizer.ts
+++ b/packages/pi-permission-system/src/authority/authorizer.ts
@@ -24,6 +24,12 @@ export type AuthorizerVerdict =
   | { kind: "deny"; reason?: string }
   | { kind: "defer" };
 
+/** The aggregate runtime context passed to an `Authorizer`. */
+export interface AuthorizerInvocationContext {
+  /** The active session abort signal, or undefined when no signal exists. */
+  signal: AbortSignal | undefined;
+}
+
 /**
  * A non-terminal link in the live-authority chain: reviews an `ask` and may
  * decide it or defer to the next link (ADR 0007). The chain injects a narrow,
@@ -38,6 +44,7 @@ export interface Authorizer {
     details: PromptPermissionDetails,
     query: PermissionQuery,
     log: AuthorizerLog,
+    context: AuthorizerInvocationContext,
   ): Promise<AuthorizerVerdict>;
 }
 

--- a/packages/pi-permission-system/src/authority/delegation-envelope.ts
+++ b/packages/pi-permission-system/src/authority/delegation-envelope.ts
@@ -32,8 +32,8 @@ export const DELEGATION_EXCLUDED_SURFACES: ReadonlySet<string> = new Set([
 export function encloseInDelegationEnvelope(
   authorize: Authorizer["authorize"],
 ): Authorizer["authorize"] {
-  return async (details, query, log) => {
-    const verdict = await authorize(details, query, log);
+  return async (details, query, log, context) => {
+    const verdict = await authorize(details, query, log, context);
     if (verdict.kind === "allow" && isExcludedSurface(details)) {
       return { kind: "defer" };
     }

--- a/packages/pi-permission-system/src/service.ts
+++ b/packages/pi-permission-system/src/service.ts
@@ -18,6 +18,7 @@ import type { PermissionCheckResult, PermissionState } from "./types";
 
 export type {
   Authorizer,
+  AuthorizerInvocationContext,
   AuthorizerVerdict,
 } from "./authority/authorizer";
 
@@ -147,9 +148,11 @@ export interface PermissionsService extends PermissionQuery {
    *
    * A link reviews an `ask` and returns `allow` / `deny` (with an optional
    * teaching `reason`) / `defer`. It is handed a narrow, session-scoped
-   * {@link PermissionQuery} at `authorize` time so it can query the
-   * deterministic engine at gate parity. Register from a `permissions:ready`
-   * handler so registration is robust to load order and survives `/reload`.
+   * {@link PermissionQuery} and an aggregate invocation context at `authorize`
+   * time so it can query the deterministic engine at gate parity and read the
+   * active session abort signal from `context.signal`. Register from a
+   * `permissions:ready` handler so registration is robust to load order and
+   * survives `/reload`.
    *
    * Registration alone grants **no authority**: the link decides nothing until
    * the operator names it in the `authorizerChain` config (opt-in activation),
@@ -160,9 +163,11 @@ export interface PermissionsService extends PermissionQuery {
    *
    * @param name      - Operator-facing link name referenced from `authorizerChain`.
    * @param authorize - The link's decision callback
-   *                    (`(details, query, log) => verdict`); `log` is an
-   *                    {@link AuthorizerLog} for recording a decision trail to
-   *                    the shared permission review log.
+   *                    (`(details, query, log, context) => verdict`); `log` is
+   *                    an {@link AuthorizerLog} for recording a decision trail
+   *                    to the shared permission review log, and `context` is a
+   *                    plain object whose optional `signal` field exposes the
+   *                    active session abort signal.
    */
   registerAuthorizer(
     name: string,

--- a/packages/pi-permission-system/test/authority/authorizer-chain.test.ts
+++ b/packages/pi-permission-system/test/authority/authorizer-chain.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import type { AuthorizerVerdict } from "#src/authority/authorizer";
+import type {
+  AuthorizerInvocationContext,
+  AuthorizerVerdict,
+} from "#src/authority/authorizer";
 import { composeAuthorizerChain } from "#src/authority/authorizer-chain";
 import type { PermissionPromptDecision } from "#src/authority/permission-dialog";
 import type { PromptPermissionDetails } from "#src/authority/permission-prompter";
@@ -39,6 +42,10 @@ function makeTerminal(decision: PermissionPromptDecision) {
   };
 }
 
+function makeContext(signal?: AbortSignal): AuthorizerInvocationContext {
+  return { signal };
+}
+
 /** A non-terminal link stub returning a fixed verdict. */
 function makeLink(verdict: AuthorizerVerdict) {
   return {
@@ -48,6 +55,7 @@ function makeLink(verdict: AuthorizerVerdict) {
           details: PromptPermissionDetails,
           query: PermissionQuery,
           log: AuthorizerLog,
+          context: AuthorizerInvocationContext,
         ) => Promise<AuthorizerVerdict>
       >()
       .mockResolvedValue(verdict),
@@ -60,7 +68,13 @@ describe("composeAuthorizerChain", () => {
   it("returns the terminal instance itself when there are no links", () => {
     const terminal = makeTerminal({ approved: true, state: "approved" });
 
-    const composed = composeAuthorizerChain([], terminal, makeQuery(), log);
+    const composed = composeAuthorizerChain(
+      [],
+      terminal,
+      makeQuery(),
+      log,
+      makeContext(),
+    );
 
     // Identity is a behavioral invariant: escalate hands the real terminal to
     // the prompter, so `expect.any(LocalUserAuthorizer)` still holds.
@@ -73,13 +87,24 @@ describe("composeAuthorizerChain", () => {
     const query = makeQuery();
     const details = makeDetails();
 
-    const composed = composeAuthorizerChain([link], terminal, query, log);
+    const composed = composeAuthorizerChain(
+      [link],
+      terminal,
+      query,
+      log,
+      makeContext(),
+    );
     const decision = await composed.authorize(details);
 
     expect(decision).toEqual({ approved: true, state: "approved" });
     // The chain injects the session-scoped query and the review-log seam into
     // each link (ADR 0007 §3).
-    expect(link.authorize).toHaveBeenCalledWith(details, query, log);
+    expect(link.authorize).toHaveBeenCalledWith(
+      details,
+      query,
+      log,
+      makeContext(),
+    );
     expect(terminal.authorize).not.toHaveBeenCalled();
   });
 
@@ -90,7 +115,13 @@ describe("composeAuthorizerChain", () => {
       reason: "wrong path; use pi-packages",
     });
 
-    const composed = composeAuthorizerChain([link], terminal, makeQuery(), log);
+    const composed = composeAuthorizerChain(
+      [link],
+      terminal,
+      makeQuery(),
+      log,
+      makeContext(),
+    );
     const decision = await composed.authorize(makeDetails());
 
     expect(decision).toEqual({
@@ -105,7 +136,13 @@ describe("composeAuthorizerChain", () => {
     const terminal = makeTerminal({ approved: true, state: "approved" });
     const link = makeLink({ kind: "deny" });
 
-    const composed = composeAuthorizerChain([link], terminal, makeQuery(), log);
+    const composed = composeAuthorizerChain(
+      [link],
+      terminal,
+      makeQuery(),
+      log,
+      makeContext(),
+    );
     const decision = await composed.authorize(makeDetails());
 
     expect(decision).toEqual({ approved: false, state: "denied" });
@@ -122,12 +159,70 @@ describe("composeAuthorizerChain", () => {
     const query = makeQuery();
     const details = makeDetails();
 
-    const composed = composeAuthorizerChain([link], terminal, query, log);
+    const composed = composeAuthorizerChain(
+      [link],
+      terminal,
+      query,
+      log,
+      makeContext(),
+    );
     const decision = await composed.authorize(details);
 
     expect(decision).toEqual(terminalDecision);
-    expect(link.authorize).toHaveBeenCalledWith(details, query, log);
+    expect(link.authorize).toHaveBeenCalledWith(
+      details,
+      query,
+      log,
+      makeContext(),
+    );
     expect(terminal.authorize).toHaveBeenCalledWith(details);
+  });
+
+  it("forwards a provided abort signal to each link", async () => {
+    const terminal = makeTerminal({ approved: true, state: "approved" });
+    const link = makeLink({ kind: "defer" });
+    const signal = new AbortController().signal;
+    const context: AuthorizerInvocationContext = { signal };
+
+    const composed = composeAuthorizerChain(
+      [link],
+      terminal,
+      makeQuery(),
+      log,
+      context,
+    );
+    await composed.authorize(makeDetails());
+
+    expect(link.authorize).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      log,
+      context,
+    );
+  });
+
+  it("supports a fourth-argument runtime context", async () => {
+    const terminal = makeTerminal({ approved: true, state: "approved" });
+    const link = makeLink({ kind: "defer" });
+    const query = makeQuery();
+    const signal = new AbortController().signal;
+    const context: AuthorizerInvocationContext = { signal };
+
+    const composed = composeAuthorizerChain(
+      [link],
+      terminal,
+      query,
+      log,
+      context,
+    );
+    await composed.authorize(makeDetails());
+
+    expect(link.authorize).toHaveBeenCalledWith(
+      expect.anything(),
+      query,
+      log,
+      context,
+    );
   });
 
   it("tries links in order and the first non-defer verdict wins", async () => {
@@ -141,6 +236,7 @@ describe("composeAuthorizerChain", () => {
       terminal,
       makeQuery(),
       log,
+      makeContext(),
     );
     const decision = await composed.authorize(makeDetails());
 
@@ -163,6 +259,7 @@ describe("composeAuthorizerChain", () => {
       terminal,
       makeQuery(),
       log,
+      makeContext(),
     );
     const decision = await composed.authorize(makeDetails());
 

--- a/packages/pi-permission-system/test/authority/authorizer-selection.test.ts
+++ b/packages/pi-permission-system/test/authority/authorizer-selection.test.ts
@@ -31,6 +31,7 @@ function makeCtx(overrides: Partial<ExtensionContext> = {}): ExtensionContext {
   return {
     cwd: "/test/project",
     hasUI: true,
+    signal: new AbortController().signal,
     ui: {
       setStatus: vi.fn(),
       notify: vi.fn(),
@@ -273,6 +274,33 @@ describe("AuthorizerSelection", () => {
         expect.anything(),
         expect.anything(),
         logger,
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+
+    it("injects the active context abort signal into each link", async () => {
+      const controller = new AbortController();
+      const link = vi
+        .fn<Authorizer["authorize"]>()
+        .mockResolvedValue({ kind: "defer" });
+      const registry = new AuthorizerRegistry();
+      registry.register("judge", link);
+      const selection = new AuthorizerSelection(
+        makeDeps({
+          prompter: makeInvokingPrompter(),
+          authorizerRegistry: registry,
+          getAuthorizerChain: () => ["judge"],
+        }),
+      );
+
+      selection.activate(makeCtx({ hasUI: true, signal: controller.signal }));
+      await selection.escalate(makeDetailsOn("bash"));
+
+      expect(link).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        { signal: controller.signal },
       );
     });
 

--- a/packages/pi-permission-system/test/authority/delegation-envelope.test.ts
+++ b/packages/pi-permission-system/test/authority/delegation-envelope.test.ts
@@ -39,6 +39,7 @@ function makeLink(verdict: AuthorizerVerdict): Authorizer["authorize"] {
 describe("encloseInDelegationEnvelope", () => {
   const query = makeQuery();
   const log = makeAuthorizerLog();
+  const context = { signal: undefined };
 
   describe("caps an allow verdict on an excluded surface to defer", () => {
     it("downgrades an allow on external_directory", async () => {
@@ -47,19 +48,25 @@ describe("encloseInDelegationEnvelope", () => {
         makeDetails("external_directory"),
         query,
         log,
+        context,
       );
       expect(verdict).toEqual({ kind: "defer" });
     });
 
     it("downgrades an allow on the path surface", async () => {
       const enclosed = encloseInDelegationEnvelope(makeLink({ kind: "allow" }));
-      const verdict = await enclosed(makeDetails("path"), query, log);
+      const verdict = await enclosed(makeDetails("path"), query, log, context);
       expect(verdict).toEqual({ kind: "defer" });
     });
 
     it("downgrades an allow when the surface is undetermined (fail-safe)", async () => {
       const enclosed = encloseInDelegationEnvelope(makeLink({ kind: "allow" }));
-      const verdict = await enclosed(makeDetails(undefined, null), query, log);
+      const verdict = await enclosed(
+        makeDetails(undefined, null),
+        query,
+        log,
+        context,
+      );
       expect(verdict).toEqual({ kind: "defer" });
     });
   });
@@ -67,13 +74,13 @@ describe("encloseInDelegationEnvelope", () => {
   describe("passes verdicts through unchanged", () => {
     it("keeps an allow on a non-excluded surface (bash)", async () => {
       const enclosed = encloseInDelegationEnvelope(makeLink({ kind: "allow" }));
-      const verdict = await enclosed(makeDetails("bash"), query, log);
+      const verdict = await enclosed(makeDetails("bash"), query, log, context);
       expect(verdict).toEqual({ kind: "allow" });
     });
 
     it("keeps an allow on a per-tool surface (read)", async () => {
       const enclosed = encloseInDelegationEnvelope(makeLink({ kind: "allow" }));
-      const verdict = await enclosed(makeDetails("read"), query, log);
+      const verdict = await enclosed(makeDetails("read"), query, log, context);
       expect(verdict).toEqual({ kind: "allow" });
     });
 
@@ -85,13 +92,14 @@ describe("encloseInDelegationEnvelope", () => {
         makeDetails("external_directory"),
         query,
         log,
+        context,
       );
       expect(verdict).toEqual({ kind: "deny", reason: "wrong path" });
     });
 
     it("never caps a defer", async () => {
       const enclosed = encloseInDelegationEnvelope(makeLink({ kind: "defer" }));
-      const verdict = await enclosed(makeDetails("path"), query, log);
+      const verdict = await enclosed(makeDetails("path"), query, log, context);
       expect(verdict).toEqual({ kind: "defer" });
     });
   });
@@ -104,6 +112,7 @@ describe("encloseInDelegationEnvelope", () => {
       makeDetails("external_directory", "bash"),
       query,
       log,
+      context,
     );
     expect(verdict).toEqual({ kind: "defer" });
   });
@@ -112,7 +121,7 @@ describe("encloseInDelegationEnvelope", () => {
     const link = makeLink({ kind: "defer" });
     const enclosed = encloseInDelegationEnvelope(link);
     const details = makeDetails("bash");
-    await enclosed(details, query, log);
-    expect(link).toHaveBeenCalledWith(details, query, log);
+    await enclosed(details, query, log, context);
+    expect(link).toHaveBeenCalledWith(details, query, log, context);
   });
 });

--- a/packages/pi-permission-system/test/authority/forwarded-request-server.test.ts
+++ b/packages/pi-permission-system/test/authority/forwarded-request-server.test.ts
@@ -398,6 +398,7 @@ describe("processInbox — bounded delegation over forwarded asks", () => {
     getToolPermission: vi.fn(),
   };
   const log = makeAuthorizerLog();
+  const context = { signal: undefined };
   const allowingLink: Authorizer["authorize"] = () =>
     Promise.resolve({ kind: "allow" });
 
@@ -418,7 +419,9 @@ describe("processInbox — bounded delegation over forwarded asks", () => {
 
     // The gate surface, not the displayed tool name, decides exclusion — so a
     // forwarded path ask is capped exactly like the same ask made locally.
-    expect(await enclosed(details, query, log)).toEqual({ kind: "defer" });
+    expect(await enclosed(details, query, log, context)).toEqual({
+      kind: "defer",
+    });
   });
 
   test("passes a link's allow on a forwarded bash ask through", async () => {
@@ -432,7 +435,9 @@ describe("processInbox — bounded delegation over forwarded asks", () => {
 
     const enclosed = encloseInDelegationEnvelope(allowingLink);
 
-    expect(await enclosed(details, query, log)).toEqual({ kind: "allow" });
+    expect(await enclosed(details, query, log, context)).toEqual({
+      kind: "allow",
+    });
   });
 });
 


### PR DESCRIPTION
…h chain

Thread the session runtime context into authorizer links via composeAuthorizerChain and delegation envelope, and align selection lifecycle with a nullable stored context.

Docs and tests now describe and assert the required fourth authorize arg as a plain context object carrying signal.

Close #688