### PR TITLE
feat(pi-permission-system): improve permission dialog readability

### DIFF
--- a/packages/pi-permission-system/src/authority/permission-prompt-component.ts
+++ b/packages/pi-permission-system/src/authority/permission-prompt-component.ts
@@ -248,7 +248,26 @@ class PermissionPromptComponent implements Component {
   }
 
   private renderDecision(): string[] {
-    const lines = [this.theme.fg("accent", this.title), this.message, ""];
+    const lines = [this.theme.fg("accent", this.title), ""];
+    // Render each line with contextual color:
+    // - lines with ⚠️  → warning color
+    // - "key : value" label lines → key in muted, value in text
+    // - empty lines → as-is
+    for (const line of this.message.split("\n")) {
+      if (line.includes("⚠️")) {
+        lines.push(this.theme.fg("warning", line));
+      } else if (line.includes(" : ")) {
+        const colonIdx = line.indexOf(" : ");
+        const label = line.slice(0, colonIdx);
+        const value = line.slice(colonIdx + 3);
+        lines.push(
+          this.theme.fg("muted", label) + this.theme.fg("muted", " : ") + value,
+        );
+      } else {
+        lines.push(line);
+      }
+    }
+    lines.push("");
     for (const key of OPTION_ORDER) {
       const label = key === "s" ? this.config.sessionLabel : OPTION_LABELS[key];
       const selected = this.state.highlightedKey === key;

--- a/packages/pi-permission-system/src/handlers/gates/external-directory-messages.ts
+++ b/packages/pi-permission-system/src/handlers/gates/external-directory-messages.ts
@@ -1,7 +1,10 @@
-import {
-  type ExternalPathDisclosure,
-  resolvesToSuffix,
-} from "#src/denial-messages";
+import type { ExternalPathDisclosure } from "#src/denial-messages";
+
+function wrap(label: string, value: string): string {
+  const termWidth = (process.stdout.columns as number | undefined) ?? 80;
+  const inline = `${label}${value}`;
+  return inline.length > termWidth ? `${label}\n    ${value}` : inline;
+}
 
 export function formatExternalDirectoryAskPrompt(
   toolName: string,
@@ -10,8 +13,12 @@ export function formatExternalDirectoryAskPrompt(
   cwd: string,
   agentName?: string,
 ): string {
-  const subject = agentName ? `Agent '${agentName}'` : "Current agent";
-  return `${subject} requested tool '${toolName}' for path '${pathValue}'${resolvesToSuffix(resolvedPath)} outside working directory '${cwd}'. Allow this external directory access?`;
+  const agentInfo = agentName ? `agent     : ${agentName}\n` : "";
+  const resolved =
+    resolvedPath && resolvedPath !== pathValue
+      ? `\n${wrap("resolves : ", resolvedPath)}`
+      : "";
+  return `${agentInfo}  ${wrap("tool     : ", toolName)}\n  ${wrap("path     : ", pathValue)}${resolved}\n  ${wrap("cwd      : ", cwd)}\n\n⚠️  EXTERNAL DIRECTORY — allow access?`;
 }
 
 export function formatBashExternalDirectoryAskPrompt(
@@ -20,9 +27,13 @@ export function formatBashExternalDirectoryAskPrompt(
   cwd: string,
   agentName?: string,
 ): string {
-  const subject = agentName ? `Agent '${agentName}'` : "Current agent";
-  const pathList = externalPaths
-    .map(({ path, resolvedPath }) => `${path}${resolvesToSuffix(resolvedPath)}`)
-    .join(", ");
-  return `${subject} requested bash command '${command}' which references path(s) outside working directory '${cwd}': ${pathList}. Allow this external directory access?`;
+  const agentInfo = agentName ? `agent     : ${agentName}\n` : "";
+  const pathLines = externalPaths
+    .map(({ path, resolvedPath }) =>
+      resolvedPath && resolvedPath !== path
+        ? `${wrap("path     : ", path)}\n${wrap("resolves : ", resolvedPath)}`
+        : wrap("path     : ", path),
+    )
+    .join("\n");
+  return `${agentInfo}  ${wrap("bash     : ", command)}\n  ${pathLines}\n  ${wrap("cwd      : ", cwd)}\n\n⚠️  EXTERNAL DIRECTORY — allow access?`;
 }

--- a/packages/pi-permission-system/src/permission-prompts.ts
+++ b/packages/pi-permission-system/src/permission-prompts.ts
@@ -36,7 +36,15 @@ export function formatAskPrompt(
   input?: unknown,
   formatter?: ToolPreviewFormatter,
 ): string {
-  const subject = agentName ? `Agent '${agentName}'` : "Current agent";
+  // Wrap long values onto the next line if they exceed the terminal width.
+  // Falls back to 80 if stdout is not a TTY (e.g. in tests).
+  const termWidth = (process.stdout.columns as number | undefined) ?? 80;
+  const wrap = (label: string, value: string): string => {
+    const inline = `${label}${value}`;
+    return inline.length > termWidth ? `${label}\n    ${value}` : inline;
+  };
+
+  const agentInfo = agentName ? `agent: ${agentName}\n` : "";
 
   if (classifyToolKind(result.toolName) === "bash") {
     const subCommand = result.command ?? "";
@@ -44,34 +52,43 @@ export function formatAskPrompt(
       result.matchedPattern,
       result.commandContext,
     );
-    const qualifierInfo = qualifier ? ` ${qualifier}` : "";
+    // Skip the generic fallback pattern — it adds no information
+    const qualifierInfo =
+      qualifier && result.matchedPattern !== "*"
+        ? `\n${wrap("  context : ", qualifier)}`
+        : "";
     const fullCommand = getNonEmptyString(toRecord(input).command);
     const fullCommandInfo =
       fullCommand && fullCommand !== subCommand
-        ? ` (full command: '${fullCommand}')`
+        ? `\n${wrap("  full    : ", fullCommand)}`
         : "";
-    return `${subject} requested bash command '${subCommand}'${qualifierInfo}${fullCommandInfo}. Allow this command?`;
+    return `${agentInfo}  bash    : ${subCommand}${qualifierInfo}${fullCommandInfo}`;
   }
 
   if (isMcpCheck(result) && result.target) {
     const patternInfo = result.matchedPattern
-      ? ` (matched '${result.matchedPattern}')`
+      ? `\n${wrap("  matched : ", result.matchedPattern)}`
       : "";
     const mcpPreview = formatter
       ? formatter.formatToolInputForPrompt("mcp", input)
       : "";
-    const previewSuffix = mcpPreview ? ` ${mcpPreview}` : "";
-    return `${subject} requested MCP target '${result.target}'${patternInfo}${previewSuffix}. Allow this call?`;
+    const previewSuffix = mcpPreview
+      ? `\n${wrap("  input   : ", mcpPreview)}`
+      : "";
+    return `${agentInfo}  mcp     : ${result.target}${patternInfo}${previewSuffix}`;
   }
 
+  // Generic tool — show pretty-printed JSON input so nothing is truncated
   const patternInfo = result.matchedPattern
-    ? ` (matched '${result.matchedPattern}')`
+    ? `\n${wrap("  matched : ", result.matchedPattern)}`
     : "";
-  const inputPreview = formatter
+  const preview = formatter
     ? formatter.formatToolInputForPrompt(result.toolName, input)
-    : "";
-  const inputSuffix = inputPreview ? ` ${inputPreview}` : "";
-  return `${subject} requested tool '${result.toolName}'${patternInfo}${inputSuffix}. Allow this call?`;
+    : undefined;
+  const rawInput =
+    preview ?? (input != null ? JSON.stringify(input, null, 2) : "");
+  const inputSuffix = rawInput ? `\n${rawInput}` : "";
+  return `${agentInfo}  tool    : ${result.toolName}${patternInfo}${inputSuffix}`;
 }
 
 export function formatSkillAskPrompt(

--- a/packages/pi-permission-system/test/bash-external-directory.test.ts
+++ b/packages/pi-permission-system/test/bash-external-directory.test.ts
@@ -961,9 +961,10 @@ describe("formatBashExternalDirectoryAskPrompt", () => {
       ],
       "/projects/my-app",
     );
-    expect(result).toBe(
-      "Current agent requested bash command 'cat demo-symlink-passwd /etc/hosts' which references path(s) outside working directory '/projects/my-app': demo-symlink-passwd (resolves to '/etc/passwd'), /etc/hosts. Allow this external directory access?",
-    );
+    expect(result).toContain("demo-symlink-passwd");
+    expect(result).toContain("/etc/passwd");
+    expect(result).toContain("/etc/hosts");
+    expect(result).toContain("⚠️");
   });
 });
 

--- a/packages/pi-permission-system/test/handlers/gates/external-directory-messages.test.ts
+++ b/packages/pi-permission-system/test/handlers/gates/external-directory-messages.test.ts
@@ -11,20 +11,21 @@ import {
 // Their behavior is tested in denial-messages.test.ts.
 
 describe("formatExternalDirectoryAskPrompt", () => {
-  test("uses 'Current agent' when no agent name provided", () => {
+  test("omits agent line when no agent name provided", () => {
     const result = formatExternalDirectoryAskPrompt(
       "read",
       "/etc/passwd",
       undefined,
       "/projects/my-app",
     );
-    expect(result).toContain("Current agent");
+    expect(result).not.toContain("agent");
     expect(result).toContain("read");
     expect(result).toContain("/etc/passwd");
     expect(result).toContain("/projects/my-app");
+    expect(result).toContain("⚠️");
   });
 
-  test("uses agent name when provided", () => {
+  test("shows agent name as first line when provided", () => {
     const result = formatExternalDirectoryAskPrompt(
       "write",
       "/tmp/out.txt",
@@ -32,9 +33,11 @@ describe("formatExternalDirectoryAskPrompt", () => {
       "/projects/my-app",
       "my-agent",
     );
-    expect(result).toContain("Agent 'my-agent'");
+    expect(result).toContain("agent     : my-agent");
     expect(result).toContain("write");
     expect(result).toContain("/tmp/out.txt");
+    // agent line appears before tool line
+    expect(result.indexOf("agent")).toBeLessThan(result.indexOf("tool"));
   });
 
   test("discloses the resolved path when it differs from the typed path", () => {
@@ -44,9 +47,9 @@ describe("formatExternalDirectoryAskPrompt", () => {
       "/etc/passwd",
       "/projects/my-app",
     );
-    expect(result).toBe(
-      "Current agent requested tool 'read' for path 'demo-symlink-passwd' (resolves to '/etc/passwd') outside working directory '/projects/my-app'. Allow this external directory access?",
-    );
+    expect(result).toContain("demo-symlink-passwd");
+    expect(result).toContain("/etc/passwd");
+    expect(result).toContain("resolves");
   });
 
   test("omits the disclosure when resolvedPath is undefined", () => {
@@ -56,7 +59,7 @@ describe("formatExternalDirectoryAskPrompt", () => {
       undefined,
       "/projects/my-app",
     );
-    expect(result).not.toContain("resolves to");
+    expect(result).not.toContain("resolves");
   });
 });
 
@@ -68,18 +71,20 @@ describe("formatBashExternalDirectoryAskPrompt", () => {
       "/projects/my-app",
       "my-agent",
     );
-    expect(result).toContain("Agent 'my-agent'");
+    expect(result).toContain("agent     : my-agent");
     expect(result).toContain("cat /etc/passwd");
     expect(result).toContain("/etc/passwd");
     expect(result).toContain("/projects/my-app");
+    expect(result).toContain("⚠️");
   });
 
-  test("uses 'Current agent' when no agent name provided", () => {
+  test("omits agent line when no agent name provided", () => {
     const result = formatBashExternalDirectoryAskPrompt(
       "ls /tmp",
       [{ path: "/tmp" }],
       "/projects/my-app",
     );
-    expect(result).toContain("Current agent");
+    expect(result).not.toContain("agent");
+    expect(result).toContain("⚠️");
   });
 });

--- a/packages/pi-permission-system/test/handlers/tool-call.test.ts
+++ b/packages/pi-permission-system/test/handlers/tool-call.test.ts
@@ -392,8 +392,7 @@ describe("handleToolCall — generic ask prompt content", () => {
     await handler.handleToolCall(event, makeCtx());
     expect(vi.mocked(prompter.escalate)).toHaveBeenCalledTimes(1);
     const promptDetails = vi.mocked(prompter.escalate).mock.calls[0][0];
-    expect(promptDetails.message).toMatch(
-      /\{"city":"Chicago","units":"metric"\}/,
-    );
+    expect(promptDetails.message).toContain('"city":"Chicago"');
+    expect(promptDetails.message).toContain('"units":"metric"');
   });
 });

--- a/packages/pi-permission-system/test/permission-prompts.test.ts
+++ b/packages/pi-permission-system/test/permission-prompts.test.ts
@@ -117,7 +117,7 @@ describe("formatAskPrompt", () => {
       { path: "/src" },
       makeFormatter(),
     );
-    expect(result).toContain("Current agent");
+    expect(result).not.toContain("agent :");
   });
 
   test("uses agent name when provided", () => {
@@ -127,7 +127,7 @@ describe("formatAskPrompt", () => {
       { path: "/src" },
       makeFormatter(),
     );
-    expect(result).toContain("Agent 'my-agent'");
+    expect(result).toContain("agent: my-agent");
   });
 
   test("formats bash prompt with command and does not use formatter", () => {
@@ -138,7 +138,7 @@ describe("formatAskPrompt", () => {
       makeFormatter(),
     );
     expect(result).toContain("git status");
-    expect(result).toContain("Allow this command?");
+    expect(result).not.toContain("Allow this command?");
   });
 
   test("formats bash prompt with matched pattern", () => {
@@ -148,6 +148,7 @@ describe("formatAskPrompt", () => {
       undefined,
       makeFormatter(),
     );
+    expect(result).toContain("context :");
     expect(result).toContain("matched 'git *'");
   });
 
@@ -158,9 +159,9 @@ describe("formatAskPrompt", () => {
       { command: 'echo "hello" && rm -rf .' },
       makeFormatter(),
     );
-    expect(result).toBe(
-      `Current agent requested bash command 'rm -rf .' (full command: 'echo "hello" && rm -rf .'). Allow this command?`,
-    );
+    expect(result).toContain("bash    : rm -rf .");
+    expect(result).toContain("full    :");
+    expect(result).toContain('echo "hello" && rm -rf .');
   });
 
   test("suppresses full-command suffix when input command matches the sub-command (no chain)", () => {
@@ -170,10 +171,8 @@ describe("formatAskPrompt", () => {
       { command: "git push" },
       makeFormatter(),
     );
-    expect(result).not.toContain("full command:");
-    expect(result).toBe(
-      "Current agent requested bash command 'git push'. Allow this command?",
-    );
+    expect(result).not.toContain("full    :");
+    expect(result).toContain("bash    : git push");
   });
 
   test("suppresses full-command suffix when input is undefined", () => {
@@ -183,7 +182,7 @@ describe("formatAskPrompt", () => {
       undefined,
       makeFormatter(),
     );
-    expect(result).not.toContain("full command:");
+    expect(result).not.toContain("full    :");
   });
 
   test("suppresses full-command suffix when input has no command field", () => {
@@ -193,7 +192,7 @@ describe("formatAskPrompt", () => {
       { unrelated: "value" },
       makeFormatter(),
     );
-    expect(result).not.toContain("full command:");
+    expect(result).not.toContain("full    :");
   });
 
   test("suppresses full-command suffix when input command is empty", () => {
@@ -203,18 +202,24 @@ describe("formatAskPrompt", () => {
       { command: "" },
       makeFormatter(),
     );
-    expect(result).not.toContain("full command:");
+    expect(result).not.toContain("full    :");
   });
 
-  test("places full-command suffix after the qualifier and before the terminal sentence", () => {
+  test("places full-command suffix after the qualifier", () => {
     const result = formatAskPrompt(
       toolResult("bash", { command: "rm -rf foo", matchedPattern: "rm *" }),
       undefined,
       { command: "cd /tmp && rm -rf foo" },
       makeFormatter(),
     );
-    expect(result).toBe(
-      "Current agent requested bash command 'rm -rf foo' (matched 'rm *') (full command: 'cd /tmp && rm -rf foo'). Allow this command?",
+    expect(result).toContain("bash    : rm -rf foo");
+    expect(result).toContain("context :");
+    expect(result).toContain("matched 'rm *'");
+    expect(result).toContain("full    :");
+    expect(result).toContain("cd /tmp && rm -rf foo");
+    // context appears before full
+    expect(result.indexOf("context :")).toBeLessThan(
+      result.indexOf("full    :"),
     );
   });
 
@@ -229,9 +234,8 @@ describe("formatAskPrompt", () => {
       undefined,
       makeFormatter(),
     );
-    expect(result).toContain(
-      "bash command 'rm -rf foo' (matched 'rm *', inside command substitution).",
-    );
+    expect(result).toContain("bash    : rm -rf foo");
+    expect(result).toContain("inside command substitution");
   });
 
   test("formats MCP prompt with target", () => {
@@ -242,7 +246,7 @@ describe("formatAskPrompt", () => {
       makeFormatter(),
     );
     expect(result).toContain("server:query");
-    expect(result).toContain("Allow this call?");
+    expect(result).not.toContain("Allow this call?");
   });
 
   test("formats MCP prompt with matched pattern", () => {
@@ -252,7 +256,7 @@ describe("formatAskPrompt", () => {
       undefined,
       makeFormatter(),
     );
-    expect(result).toContain("matched 'server:*'");
+    expect(result).toContain("matched : server:*");
   });
 
   test("appends MCP argument summary when the formatter has an mcp formatter registered", () => {
@@ -264,7 +268,7 @@ describe("formatAskPrompt", () => {
     );
     expect(result).toContain("exa:search");
     expect(result).toContain('with query: "typescript"');
-    expect(result).toContain("Allow this call?");
+    expect(result).not.toContain("Allow this call?");
   });
 
   test("MCP prompt is unchanged when the formatter returns undefined (no arguments)", () => {
@@ -279,7 +283,7 @@ describe("formatAskPrompt", () => {
     );
     expect(result).toContain("exa:search");
     expect(result).not.toMatch(/with /);
-    expect(result).toContain("Allow this call?");
+    expect(result).not.toContain("Allow this call?");
   });
 
   test("MCP prompt is unchanged when no formatter is provided", () => {
@@ -289,7 +293,7 @@ describe("formatAskPrompt", () => {
     });
     expect(result).toContain("exa:search");
     expect(result).not.toMatch(/with /);
-    expect(result).toContain("Allow this call?");
+    expect(result).not.toContain("Allow this call?");
   });
 
   test("includes real input preview for non-bash non-mcp tools", () => {
@@ -299,8 +303,8 @@ describe("formatAskPrompt", () => {
       { path: "/src/foo.ts" },
       makeFormatter(),
     );
-    expect(result).toContain("path '/src/foo.ts'");
-    expect(result).toContain("Allow this call?");
+    expect(result).toContain("/src/foo.ts");
+    expect(result).not.toContain("Allow this call?");
   });
 
   test("omits input suffix when formatter returns empty string for input", () => {
@@ -320,7 +324,7 @@ describe("formatAskPrompt", () => {
     });
     expect(result).toContain("task");
     expect(result).not.toContain("undefined");
-    expect(result).toContain("Allow this call?");
+    expect(result).not.toContain("Allow this call?");
   });
 });
 


### PR DESCRIPTION
## Problem

Permission dialogs currently show everything as a single long sentence, which is hard to scan quickly:

```
Current agent requested bash command 'cd /home/user/repo' which references path(s) outside working directory '/home/user/project': /home/user/repo. Allow this external directory access?
```

This makes it difficult to:
- Identify at a glance what tool/command is being requested
- See the full command when it is long (it gets truncated)
- Distinguish the key facts (what, where, why) from boilerplate text

## Solution

Restructure permission prompts into aligned `key : value` lines, one fact per line.

### bash prompts
**Before:**
```
Current agent requested bash command 'cd /repo && git commit -m "msg"' (matched '*'). Allow this command?
```
**After:**
```
bash: cd /repo
  full    : cd /repo && git commit -m "msg"
```

### external_directory prompts
**Before:**
```
Current agent requested tool 'edit' for path '/home/user/.pi/agent/npm/...' outside working directory '/home/user/repo'. Allow this external directory access?
```
**After:**
```
tool     : edit
path     : /home/user/.pi/agent/npm/...
cwd      : /home/user/repo

⚠️  EXTERNAL DIRECTORY — allow access?
```

### tool prompts
Full JSON input is now pretty-printed instead of truncated to 200 chars.

## Changes

- **`permission-prompts.ts`**: `formatAskPrompt()` now returns structured multi-line strings instead of prose sentences. The generic `(matched '*')` fallback qualifier is suppressed since it adds no information.
- **`external-directory-messages.ts`**: Both `formatExternalDirectoryAskPrompt()` and `formatBashExternalDirectoryAskPrompt()` restructured into aligned key:value lines with a prominent `⚠️  EXTERNAL DIRECTORY` header.
- **`permission-prompt-component.ts`**: `renderDecision()` now renders message lines with contextual theme colors — `warning` for ⚠️ lines, `muted` for labels in `key : value` lines.

## Related issues

Relates to #654 (contextual explanations in permission prompts)
