### PR TITLE
fix(pi-subagents): pass parentSession and invocation through SDK spawn path

### DIFF
--- a/packages/pi-subagents/src/service/service-adapter.ts
+++ b/packages/pi-subagents/src/service/service-adapter.ts
@@ -41,7 +41,8 @@ export class SubagentsServiceAdapter implements SubagentsService {
   ) {}
 
   spawn(type: string, prompt: string, options?: SpawnOptions): string {
-    if (!this.runtime.currentCtx) {
+    const ctx = this.runtime.currentCtx;
+    if (!ctx) {
       throw new Error("No active session — cannot spawn agents outside a session.");
     }
 
@@ -58,6 +59,12 @@ export class SubagentsServiceAdapter implements SubagentsService {
       inheritContext: options?.inheritContext,
       bypassQueue: options?.bypassQueue,
       isBackground,
+      // Parity with the tool path (background-spawner.ts:34) so
+      // create-subagent-session.ts:241 publishes a resolvable parentSessionId.
+      parentSession: {
+        parentSessionId: ctx.sessionManager.getSessionId(),
+        parentSessionFile: ctx.sessionManager.getSessionFile(),
+      },
     });
   }
 

--- a/packages/pi-subagents/src/service/service-adapter.ts
+++ b/packages/pi-subagents/src/service/service-adapter.ts
@@ -59,6 +59,9 @@ export class SubagentsServiceAdapter implements SubagentsService {
       inheritContext: options?.inheritContext,
       bypassQueue: options?.bypassQueue,
       isBackground,
+      // Parity with the tool path (background-spawner.ts:34) so the native
+      // widget's roster filter (agent-widget.ts:168) picks up SDK spawns too.
+      invocation: { runInBackground: isBackground },
       // Parity with the tool path (background-spawner.ts:34) so
       // create-subagent-session.ts:241 publishes a resolvable parentSessionId.
       parentSession: {

--- a/packages/pi-subagents/test/service-adapter-invocation.test.ts
+++ b/packages/pi-subagents/test/service-adapter-invocation.test.ts
@@ -1,0 +1,77 @@
+/**
+ * SubagentsServiceAdapter.spawn() must pass an `invocation` object to
+ * manager.spawn(), mirroring the tool path (background-spawner.ts:34), so
+ * the native widget's roster filter
+ * (record.invocation?.runInBackground === true, agent-widget.ts:168) admits
+ * SDK-spawned agents instead of treating them as permanently ineligible.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { ParentSnapshot } from "#src/lifecycle/parent-snapshot";
+import type { ServiceRuntimeLike, SubagentManagerLike } from "#src/service/service-adapter";
+import { SubagentsServiceAdapter } from "#src/service/service-adapter";
+import type { SessionContext } from "#src/types";
+import { STUB_SNAPSHOT } from "#test/helpers/stub-ctx";
+
+function makeStubCtx(): SessionContext {
+  return {
+    cwd: "/tmp",
+    model: undefined,
+    modelRegistry: { find: () => undefined, getAll: () => [] },
+    getSystemPrompt: () => "test prompt",
+    sessionManager: {
+      getSessionFile: () => "/tmp/session.jsonl",
+      getSessionId: () => "stub-session-id",
+      getBranch: () => [],
+    },
+  };
+}
+
+function makeRuntimeStub(override: Partial<ServiceRuntimeLike> = {}): ServiceRuntimeLike {
+  return {
+    currentCtx: makeStubCtx(),
+    buildSnapshot: vi.fn((_: boolean): ParentSnapshot => STUB_SNAPSHOT),
+    ...override,
+  };
+}
+
+function createManagerStub() {
+  return {
+    spawn: vi.fn<SubagentManagerLike["spawn"]>(() => "spawned-id"),
+    getRecord: vi.fn<SubagentManagerLike["getRecord"]>(),
+    listAgents: vi.fn<SubagentManagerLike["listAgents"]>(() => []),
+    abort: vi.fn<SubagentManagerLike["abort"]>(() => true),
+    waitForAll: vi.fn<SubagentManagerLike["waitForAll"]>(async () => {}),
+    hasRunning: vi.fn<SubagentManagerLike["hasRunning"]>(() => false),
+    registerWorkspaceProvider: vi.fn<SubagentManagerLike["registerWorkspaceProvider"]>(() => () => {}),
+  };
+}
+
+describe("SubagentsServiceAdapter.spawn — invocation", () => {
+  it("passes invocation: { runInBackground: true } for a background spawn (default)", () => {
+    const mgr = createManagerStub();
+    const svc = new SubagentsServiceAdapter(mgr, vi.fn(), makeRuntimeStub());
+
+    svc.spawn("Explore", "check TODOs");
+
+    expect(mgr.spawn).toHaveBeenCalledWith(
+      expect.anything(),
+      "Explore",
+      "check TODOs",
+      expect.objectContaining({ invocation: { runInBackground: true } }),
+    );
+  });
+
+  it("passes invocation: { runInBackground: false } for a foreground spawn", () => {
+    const mgr = createManagerStub();
+    const svc = new SubagentsServiceAdapter(mgr, vi.fn(), makeRuntimeStub());
+
+    svc.spawn("Plan", "plan work", { foreground: true });
+
+    expect(mgr.spawn).toHaveBeenCalledWith(
+      expect.anything(),
+      "Plan",
+      "plan work",
+      expect.objectContaining({ invocation: { runInBackground: false } }),
+    );
+  });
+});

--- a/packages/pi-subagents/test/service-adapter-parent-session.test.ts
+++ b/packages/pi-subagents/test/service-adapter-parent-session.test.ts
@@ -1,0 +1,113 @@
+/**
+ * SubagentsServiceAdapter.spawn() must forward parentSession to
+ * manager.spawn(), mirroring the tool path (background-spawner.ts:34), so
+ * that a parent/child permission-forwarding consumer can resolve `ask`-level
+ * rules for SDK-spawned children.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { ParentSnapshot } from "#src/lifecycle/parent-snapshot";
+import type { ServiceRuntimeLike, SubagentManagerLike } from "#src/service/service-adapter";
+import { SubagentsServiceAdapter } from "#src/service/service-adapter";
+import type { SessionContext } from "#src/types";
+import { STUB_SNAPSHOT } from "#test/helpers/stub-ctx";
+
+function makeStubCtx(overrides: Partial<SessionContext["sessionManager"]> = {}): SessionContext {
+  return {
+    cwd: "/tmp",
+    model: undefined,
+    modelRegistry: { find: () => undefined, getAll: () => [] },
+    getSystemPrompt: () => "test prompt",
+    sessionManager: {
+      getSessionFile: () => "/tmp/session.jsonl",
+      getSessionId: () => "stub-session-id",
+      getBranch: () => [],
+      ...overrides,
+    },
+  };
+}
+
+function makeRuntimeStub(override: Partial<ServiceRuntimeLike> = {}): ServiceRuntimeLike {
+  return {
+    currentCtx: makeStubCtx(),
+    buildSnapshot: vi.fn((_: boolean): ParentSnapshot => STUB_SNAPSHOT),
+    ...override,
+  };
+}
+
+function createManagerStub() {
+  return {
+    spawn: vi.fn<SubagentManagerLike["spawn"]>(() => "spawned-id"),
+    getRecord: vi.fn<SubagentManagerLike["getRecord"]>(),
+    listAgents: vi.fn<SubagentManagerLike["listAgents"]>(() => []),
+    abort: vi.fn<SubagentManagerLike["abort"]>(() => true),
+    waitForAll: vi.fn<SubagentManagerLike["waitForAll"]>(async () => {}),
+    hasRunning: vi.fn<SubagentManagerLike["hasRunning"]>(() => false),
+    registerWorkspaceProvider: vi.fn<SubagentManagerLike["registerWorkspaceProvider"]>(() => () => {}),
+  };
+}
+
+describe("SubagentsServiceAdapter.spawn — parentSession forwarding", () => {
+  it("passes parentSession built from currentCtx.sessionManager", () => {
+    const mgr = createManagerStub();
+    const svc = new SubagentsServiceAdapter(
+      mgr,
+      vi.fn(),
+      makeRuntimeStub({
+        currentCtx: makeStubCtx({
+          getSessionId: () => "parent-session-42",
+          getSessionFile: () => "/sessions/parent-42.jsonl",
+        }),
+      }),
+    );
+
+    svc.spawn("Explore", "check TODOs");
+
+    expect(mgr.spawn).toHaveBeenCalledWith(
+      expect.anything(),
+      "Explore",
+      "check TODOs",
+      expect.objectContaining({
+        parentSession: {
+          parentSessionId: "parent-session-42",
+          parentSessionFile: "/sessions/parent-42.jsonl",
+        },
+      }),
+    );
+  });
+
+  it("forwards an undefined session file as undefined (no coercion)", () => {
+    const mgr = createManagerStub();
+    const svc = new SubagentsServiceAdapter(
+      mgr,
+      vi.fn(),
+      makeRuntimeStub({
+        currentCtx: makeStubCtx({
+          getSessionId: () => "no-file-session",
+          getSessionFile: () => undefined,
+        }),
+      }),
+    );
+
+    svc.spawn("Explore", "check TODOs");
+
+    expect(mgr.spawn).toHaveBeenCalledWith(
+      expect.anything(),
+      "Explore",
+      "check TODOs",
+      expect.objectContaining({
+        parentSession: {
+          parentSessionId: "no-file-session",
+          parentSessionFile: undefined,
+        },
+      }),
+    );
+  });
+
+  it("still throws the existing error when currentCtx is undefined", () => {
+    const mgr = createManagerStub();
+    const svc = new SubagentsServiceAdapter(mgr, vi.fn(), makeRuntimeStub({ currentCtx: undefined }));
+
+    expect(() => svc.spawn("Explore", "do something")).toThrow(/no active session/i);
+    expect(mgr.spawn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #724.

`SubagentsServiceAdapter.spawn()`, the SDK path used when a consumer calls `getSubagentsService().spawn()` directly instead of going through the model's `subagent` tool (for example from a slash-command handler), never set `invocation` on the config it passes to `manager.spawn()`. The widget's roster filter checks `record.invocation?.runInBackground === true` (`agent-widget.ts:168`), so every agent spawned through the SDK path was filtered out of the background widget permanently, not just until some later event.

The same method also never set `parentSession`, unlike the tool path (`background-spawner.ts:34`), so a consumer relying on the parent/child session link had no resolvable parent session id or file for SDK-spawned children.

Both fixes bring the SDK path to parity with what `background-spawner.ts` already does for tool-invoked spawns: pass `invocation: { runInBackground: isBackground }`, and pass `parentSession: { parentSessionId: ctx.sessionManager.getSessionId(), parentSessionFile: ctx.sessionManager.getSessionFile() }`.

#724 proposed this exact shape: "would you take a small patch that has spawn() in service-adapter.ts build a minimal invocation snapshot (something like { runInBackground: isBackground }) and pass it through, mirroring what the tool path already does?" This PR is that patch, plus the parentSession gap found while touching the same function.

Two commits, each with its own test:
- pass parentSession through the SDK spawn path
- populate invocation for SDK-spawned agents
