### PR TITLE
fix(pi-subagents): capture widget UI context at session_start and widen SubagentRecord

### DIFF
--- a/packages/pi-subagents/src/index.ts
+++ b/packages/pi-subagents/src/index.ts
@@ -157,14 +157,23 @@ export default function (pi: ExtensionAPI) {
     unpublishSubagentsService,
   );
 
-  pi.on("session_start", (event, ctx) => lifecycle.handleSessionStart(event, ctx));
-  pi.on("session_before_switch", () => lifecycle.handleSessionBeforeSwitch());
-  pi.on("session_shutdown", () => lifecycle.handleSessionShutdown());
-
   // Live widget: constructed after the manager (it polls listAgents()) and
   // registered as a lifecycle observer so it self-drives its update timer.
   const widget = new AgentWidget(manager, registry);
   observer.add(widget);
+
+  pi.on("session_start", (event, ctx) => {
+    // Capture the UI context here too, not just on the first tool call
+    // (ToolStartHandler below): a spawn path that never triggers a tool
+    // call from the parent agent loop otherwise leaves the widget with no
+    // UI context for its entire run. Same setUICtx() method, same ctx.ui
+    // reference; setUICtx()'s existing `ctx !== this.uiCtx` guard makes the
+    // later ToolStartHandler call a no-op once this has already fired.
+    widget.setUICtx(ctx.ui);
+    return lifecycle.handleSessionStart(event, ctx);
+  });
+  pi.on("session_before_switch", () => lifecycle.handleSessionBeforeSwitch());
+  pi.on("session_shutdown", () => lifecycle.handleSessionShutdown());
 
   // Grab UI context from first tool execution + clear lingering widget on new turn
   const toolStart = new ToolStartHandler(widget);

--- a/packages/pi-subagents/src/service/service-adapter.ts
+++ b/packages/pi-subagents/src/service/service-adapter.ts
@@ -124,11 +124,16 @@ export function toSubagentRecord(record: Subagent): SubagentRecord {
     startedAt: record.startedAt,
     lifetimeUsage: record.lifetimeUsage,
     compactionCount: record.compactionCount,
+    turnCount: record.turnCount,
+    // activeTools is a ReadonlyMap<key, toolName> on the live record — not
+    // JSON-safe. Serialize to the tool-name values only.
+    activeTools: Array.from(record.activeTools.values()),
   };
 
   if (record.result !== undefined) out.result = record.result;
   if (record.error !== undefined) out.error = record.error;
   if (record.completedAt !== undefined) out.completedAt = record.completedAt;
+  if (record.outputFile !== undefined) out.outputFile = record.outputFile;
 
   return out;
 }

--- a/packages/pi-subagents/src/service/service.ts
+++ b/packages/pi-subagents/src/service/service.ts
@@ -49,6 +49,10 @@ export interface SubagentRecord {
   completedAt?: number;
   lifetimeUsage: LifetimeUsage;
   compactionCount: number;
+  turnCount: number;
+  /** Serialized active-tool names (the live field is a ReadonlyMap, not JSON-safe). */
+  activeTools: string[];
+  outputFile?: string;
 }
 
 /** Options for spawning an agent via the service. */

--- a/packages/pi-subagents/test/service/service-adapter.test.ts
+++ b/packages/pi-subagents/test/service/service-adapter.test.ts
@@ -37,6 +37,10 @@ describe("toSubagentRecord", () => {
       completedAt: 2000,
       lifetimeUsage: { input: 100, output: 200, cacheWrite: 50 },
       compactionCount: 1,
+      // turnCount/activeTools are now required fields on SubagentRecord,
+      // unconditionally populated by toSubagentRecord().
+      turnCount: 1,
+      activeTools: [],
     });
   });
 
@@ -97,6 +101,9 @@ describe("toSubagentRecord", () => {
       startedAt: 500,
       lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
       compactionCount: 0,
+      // turnCount/activeTools are now required fields; see note above.
+      turnCount: 1,
+      activeTools: [],
     });
     expect(result).not.toHaveProperty("result");
     expect(result).not.toHaveProperty("error");

--- a/packages/pi-subagents/test/subagent-record-allowlist.test.ts
+++ b/packages/pi-subagents/test/subagent-record-allowlist.test.ts
@@ -1,0 +1,66 @@
+/**
+ * toSubagentRecord() widens to carry turnCount/activeTools/outputFile — all
+ * three already live on Subagent/SubagentState but previously dropped by
+ * toSubagentRecord()'s allowlist.
+ */
+import { describe, expect, it } from "vitest";
+import { toSubagentRecord } from "#src/service/service-adapter";
+import { createTestSubagent } from "#test/helpers/make-subagent";
+import { createSubagentSessionStub, toSubagentSession } from "#test/helpers/mock-session";
+
+describe("toSubagentRecord — widened fields", () => {
+  it("carries turnCount and serialized activeTools", () => {
+    const record = createTestSubagent({
+      id: "abc-123",
+      turnCount: 4,
+      activeTools: ["read_file", "grep"],
+    });
+
+    const out = toSubagentRecord(record);
+
+    expect(out.turnCount).toBe(4);
+    // activeTools is a ReadonlyMap<key, toolName> on the live object; the
+    // record must serialize to a plain array of tool names.
+    expect(out.activeTools).toEqual(["read_file", "grep"]);
+  });
+
+  it("defaults to turnCount 1 and an empty activeTools array when unset", () => {
+    const record = createTestSubagent({ id: "def-456" });
+
+    const out = toSubagentRecord(record);
+
+    expect(out.turnCount).toBe(1);
+    expect(out.activeTools).toEqual([]);
+  });
+
+  it("includes outputFile when the record has an active session with one", () => {
+    const record = createTestSubagent({ id: "with-output" });
+    record.subagentSession = toSubagentSession(createSubagentSessionStub(undefined, "/tmp/agent-out.txt"));
+
+    const out = toSubagentRecord(record);
+
+    expect(out.outputFile).toBe("/tmp/agent-out.txt");
+  });
+
+  it("omits outputFile when the record never had a session", () => {
+    const record = createTestSubagent({ id: "no-output" });
+
+    const out = toSubagentRecord(record);
+
+    expect(out).not.toHaveProperty("outputFile");
+  });
+
+  it("stays JSON-round-trippable", () => {
+    const record = createTestSubagent({
+      id: "roundtrip",
+      turnCount: 2,
+      activeTools: ["bash"],
+    });
+    record.subagentSession = toSubagentSession(createSubagentSessionStub(undefined, "/tmp/out.txt"));
+
+    const out = toSubagentRecord(record);
+    const roundTripped = JSON.parse(JSON.stringify(out));
+
+    expect(roundTripped).toEqual(out);
+  });
+});


### PR DESCRIPTION
A command-driven SDK spawn path in a downstream consumer (dispatch through `SubagentsService.spawn()` with no model tool call in the loop) can run an entire session with the widget dark. In one recorded run, a slash-command dispatch produced 35 transcript entries over 31 minutes with zero user messages and zero tool-call-triggered UI context, so `AgentWidget` never received a `UICtx` and never rendered anything for the whole run, even after the record became eligible for the widget's roster filter.

That eligibility half is #724 (this repo's other open item from us, not part of this PR). This PR is the other half: getting `UICtx` into the widget at all when nothing ever triggers `tool_execution_start`.

#423 deliberately kept `UICtx` capture in `ToolStartHandler`, and the linked ADR (0004-reconsider-ui-direction.md) pins that as an invariant Phase 19 has to preserve: "the runtime holds zero UI state (#422), the widget is a reactive consumer with no inbound calls from core spawn tools (#423), ..." I think this change keeps both invariants rather than breaking them: `session_start` isn't a call from a spawn tool into the widget, it's the composition root (`index.ts`) wiring the widget as a lifecycle observer, the same role it already plays via `observer.add(widget)`. The runtime doesn't hold any UI state either way; `ctx.ui` still comes from the event, same as it does in `ToolStartHandler`. So the question I'd actually ask: is the tool-call gate protecting something specific about when a UICtx is safe to capture, or was `ToolStartHandler` just where a `ctx` happened to already be in hand at the time?

The mechanism isn't new. It's the same `setUICtx` method, called with the same `ctx.ui` object, the session's UI context singleton. `ToolStartHandler` is unmodified and still the only place `onTurnStart()` gets called, so turn-aging is unaffected. `setUICtx`'s existing `ctx !== this.uiCtx` guard makes the later `ToolStartHandler` call a no-op once `session_start` has already run, so there's no double-capture or reset. The diff is small and additive: `AgentWidget` construction moves a few lines earlier in the same file so the `session_start` handler can reference it, and one line calls `widget.setUICtx(ctx.ui)`.

One thing worth flagging rather than hiding: `finishedTurnAge` only increments through `onTurnStart()`, and `onTurnStart()` only fires from `tool_execution_start`. In a session where a dispatch runs to completion and no parent turn ever happens, a completed agent's row is seeded at age 0 and never ages out of the widget until the user's next tool-calling turn. This PR doesn't touch that. If you'd rather not carry that as a loose end, I can pair this with either a non-turn-based aging signal or a timer-based sweep, whichever fits the widget's existing self-driving model better.

If a push-at-`session_start` model isn't what you want, the same fix works as a lazily-pulled supplier instead: something like `getUICtx: () => UICtx | undefined` that the widget reads from when it needs it, rather than being handed the value at `session_start`. Happy to send that version instead if you'd prefer it over the push model in this diff. (I did consider capturing `UICtx` inside `service-adapter.ts`'s `spawn()` itself, so the SDK path would self-sufficiently carry its own UI context, but that pulls UI concerns into the spawn path and runs against the same invariants above, so I left that out.)

Separately from the UICtx question: this PR also widens `SubagentRecord` with `turnCount: number` and `activeTools: string[]` as required fields, plus an optional `outputFile?: string`. All three already exist on the live `Subagent`/`SubagentState` but were dropped by `toSubagentRecord()`'s allowlist. Making `turnCount`/`activeTools` required (not optional) is a breaking change for anyone outside this repo implementing `SubagentRecord` themselves, since existing implementations won't have those fields. If you'd rather they stay optional, or be shaped some other way, I can rework that part before this merges as is; wanted to call it out explicitly rather than bury it in the diff.

Two commits:
- widen `SubagentRecord` with `turnCount`/`activeTools` (the breaking change above)
- capture widget UI context at `session_start`
