### PR TITLE
feat(pi-permission-system): configurable log destination (file/stdout…

### DIFF
--- a/packages/pi-permission-system/config/config.example.json
+++ b/packages/pi-permission-system/config/config.example.json
@@ -15,6 +15,8 @@
 
   "authorizerChain": [],
 
+  "logging": { "destination": "file" },
+
   "shellTools": {
     "exec_command": { "commandArgument": "cmd", "workdirArgument": "workdir" }
   },

--- a/packages/pi-permission-system/docs/configuration.md
+++ b/packages/pi-permission-system/docs/configuration.md
@@ -70,6 +70,9 @@ This clamp is deny-preserving and, like `yoloMode`, applied at composition; when
   // Ordered names of registered live-authority chain links (empty = none)
   "authorizerChain": [],
 
+  // Where the logs are written (file | stdout | stderr; file is the default)
+  "logging": { "destination": "file" },
+
   // Flat permission policy
   "permission": {
     "*": "ask",                              // universal fallback
@@ -110,9 +113,48 @@ This clamp is deny-preserving and, like `yoloMode`, applied at composition; when
 | `toolTextSummaryMaxLength`  | `80`     | Max characters of inline pattern/path summaries (grep patterns, find globs, ls paths) in permission prompts. Omit to use the default.                                                              |
 | `piInfrastructureReadPaths` | `[]`     | Extra directories to auto-allow for reads, bypassing the `external_directory` gate. Supports `~`/`$HOME`/`${HOME}` expansion and wildcard patterns (`*`, `?`).                                     |
 | `authorizerChain`           | `[]`     | Ordered names of registered live-authority chain links to consult before the terminal authorizer (see [Authorizer chain](#authorizer-chain--case-by-case-decision-links)).                         |
+| `logging`                   | file     | Where the debug and review logs are written — a file (optionally in a custom `directory`), or `stdout`/`stderr` (see [Log destination](#logging--log-destination)).                                 |
 
-Both logs write to `~/.pi/agent/extensions/pi-permission-system/logs/`.
-No debug output is printed to the terminal.
+By default both logs write to `~/.pi/agent/extensions/pi-permission-system/logs/`, and no output is printed to the terminal.
+Set `logging.destination` to `stdout` or `stderr` to stream the logs instead — the fix for a read-only filesystem where that directory cannot be created (see [Log destination](#logging--log-destination)).
+
+### `logging` — log destination
+
+`logging` controls **where** the debug and review logs are written; `debugLog` and `permissionReviewLog` still control **whether** each stream emits at all.
+
+```jsonc
+{
+  "logging": {
+    "destination": "stderr" // "file" (default) | "stdout" | "stderr"
+    // "directory": "~/pi-logs"  // file destination only; defaults to the extension logs dir
+  }
+}
+```
+
+| Field         | Default | Description                                                                                                                                    |
+| ------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `destination` | `file`  | `file` writes JSONL log files; `stdout` / `stderr` write each JSONL line to that process stream and **create no directory**.                    |
+| `directory`   | —       | Directory for the log files when `destination` is `file`. Defaults to the extension logs directory. Supports `~`/`$HOME`. Ignored for streams. |
+
+**Read-only filesystem / sandboxes.**
+When Pi runs where the default `logs/` directory cannot be created, the file destination fails on every write with a repeated warning like:
+
+```text
+Failed to create permission-system log directory '/home/pi/.pi/agent/extensions/pi-permission-system/logs': EACCES: permission denied, mkdir '…/logs'
+```
+
+Set `"logging": { "destination": "stderr" }` (or `stdout`) and no directory is ever created — the logs stream to the process instead, which a container can collect.
+Alternatively, keep the file destination and point `directory` at a writable path.
+
+**stderr vs stdout.**
+Prefer `stderr`. In a TUI session stdout is the terminal, and in an RPC/frontend session it may carry the protocol — writing logs there can corrupt the display or transport. `stderr` is the safe stream for interleaved logging.
+
+Both the debug and review streams share one destination; every line carries a `stream` field (`"debug"` / `"review"`), so a consumer tailing stdout/stderr can still separate them.
+Redaction of sensitive-keyed values (see [Log file sensitivity](#log-file-sensitivity)) applies to every destination; the owner-only file mode only applies to the file destination.
+
+**Merge semantics.**
+`logging` shallow-merges by field across global → project: a project scope that sets only `directory` still inherits the global `destination` (and vice versa).
+Like the other runtime knobs, a project scope's `logging` is loaded only when the project is trusted.
 
 ### Inline permission dialog (TUI)
 

--- a/packages/pi-permission-system/docs/troubleshooting.md
+++ b/packages/pi-permission-system/docs/troubleshooting.md
@@ -11,10 +11,14 @@
 | External file path blocked                                        | `external_directory` is `ask` without UI or `deny`                | Allow/ask the permission or keep file tools inside the active working directory.                                                                  |
 | Spurious external-path prompt for `cd <subdir> && grep … ../path` | Relative path was resolved against cwd instead of the `cd` target | Fixed in current version — paths after a leading `cd <subdir> &&` are resolved against the cd target, matching actual shell behavior.             |
 | Permission prompt is too verbose                                  | Generic extension tool input is large                             | Built-in file tools are summarized automatically; third-party tools are capped to a bounded one-line JSON preview.                                |
+| Repeated `Failed to create permission-system log directory … EACCES` | Read-only filesystem / sandbox where the default `logs/` dir cannot be created | Set `"logging": { "destination": "stderr" }` (or `stdout`) to stream logs and create no directory, or point `"logging": { "directory": "…" }` at a writable path (see [Log destination](configuration.md#logging--log-destination)). |
 
 ## Diagnostic Logging
 
 Enable `"debugLog": true` in your config to write verbose diagnostics to `logs/pi-permission-system-debug.jsonl`.
+
+By default the logs are written to files under the extension logs directory.
+On a read-only filesystem, or to collect logs from a container, set `"logging": { "destination": "stderr" }` (or `stdout`) to stream them instead — no directory is created (see [Log destination](configuration.md#logging--log-destination)).
 
 On every session start, the extension emits a `config.resolved` entry to both logs listing the resolved config paths and whether each exists.
 This makes it easy to verify which files the extension actually loaded:

--- a/packages/pi-permission-system/schemas/permissions.schema.json
+++ b/packages/pi-permission-system/schemas/permissions.schema.json
@@ -73,6 +73,34 @@
         "minLength": 1
       }
     },
+    "logging": {
+      "type": "object",
+      "properties": {
+        "destination": {
+          "description": "Where log lines go. 'file' (default) writes JSONL files under the logs directory; 'stdout' / 'stderr' write each JSONL line to that stream and create no directory (use these on a read-only filesystem or to collect logs from a container).",
+          "default": "file",
+          "type": "string",
+          "enum": ["file", "stdout", "stderr"]
+        },
+        "directory": {
+          "description": "Directory for the log files when destination is 'file'. Defaults to the extension logs directory (logs/ under the extension config dir). Supports ~ / $HOME expansion. Ignored for the stdout/stderr destinations.",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false,
+      "description": "Controls where the debug and permission-review logs are written. Both the debug and review streams share one destination; each line is tagged with its stream so they stay distinguishable when interleaved on stdout/stderr.",
+      "markdownDescription": "Controls where the permission-system logs are written.\n\nBy default both logs are JSONL files under `logs/` in the extension config directory. Set `destination` to redirect them:\n\n- `\"file\"` (default) — write to log files. Set `directory` to place them somewhere other than the default `logs/` directory (supports `~`/`$HOME`).\n- `\"stdout\"` / `\"stderr\"` — write each JSONL line to that process stream and create **no** directory. Use this when Pi runs on a read-only filesystem (where the default `logs/` directory cannot be created) or inside a container that collects stdout/stderr.\n\nThe `debugLog` and `permissionReviewLog` toggles still decide whether each stream emits at all; `logging` only decides *where*. Both streams share one destination, and every line carries a `stream` field (`\"debug\"` / `\"review\"`) so a consumer tailing stdout/stderr can separate them.\n\n> **Prefer `stderr` over `stdout`.** In a TUI session stdout is the terminal, and in an RPC/frontend session it may carry the protocol — writing logs there can corrupt the display or transport. `stderr` is the safe stream for interleaved logging.",
+      "examples": [
+        {
+          "destination": "stderr"
+        },
+        {
+          "destination": "file",
+          "directory": "~/pi-logs"
+        }
+      ]
+    },
     "permission": {
       "type": "object",
       "propertyNames": {

--- a/packages/pi-permission-system/src/config-loader.ts
+++ b/packages/pi-permission-system/src/config-loader.ts
@@ -252,6 +252,19 @@ export function mergeUnifiedConfigs(
     merged.shellTools = overrideShell;
   }
 
+  // logging: shallow-merge by field so a project scope that sets only
+  // `directory` still inherits the global `destination` (and vice versa),
+  // rather than a project `logging` block wiping unrelated global fields.
+  const baseLogging = base.logging;
+  const overrideLogging = override.logging;
+  if (baseLogging && overrideLogging) {
+    merged.logging = { ...baseLogging, ...overrideLogging };
+  } else if (baseLogging) {
+    merged.logging = baseLogging;
+  } else if (overrideLogging) {
+    merged.logging = overrideLogging;
+  }
+
   // Permission: deep-shallow merge
   const basePerm = base.permission;
   const overridePerm = override.permission;

--- a/packages/pi-permission-system/src/config-schema.ts
+++ b/packages/pi-permission-system/src/config-schema.ts
@@ -145,6 +145,39 @@ const shellToolsSchema = z
     ],
   });
 
+// No `id` — this enum is referenced once (by `loggingSchema.destination`), so
+// it inlines rather than becoming a shared `$def` like the reused sub-schemas.
+const logDestinationSchema = z.enum(["file", "stdout", "stderr"]).meta({
+  description:
+    "Where the permission-system logs are written: 'file' (the extension logs directory, or a custom 'directory'), 'stdout', or 'stderr'.",
+});
+
+/** A permission-system log destination: file, stdout, or stderr. */
+export type LogDestination = z.infer<typeof logDestinationSchema>;
+
+const loggingSchema = z
+  .strictObject({
+    destination: logDestinationSchema.optional().meta({
+      description:
+        "Where log lines go. 'file' (default) writes JSONL files under the logs directory; 'stdout' / 'stderr' write each JSONL line to that stream and create no directory (use these on a read-only filesystem or to collect logs from a container).",
+      default: "file",
+    }),
+    directory: z.string().min(1).optional().meta({
+      description:
+        "Directory for the log files when destination is 'file'. Defaults to the extension logs directory (logs/ under the extension config dir). Supports ~ / $HOME expansion. Ignored for the stdout/stderr destinations.",
+    }),
+  })
+  .meta({
+    description:
+      "Controls where the debug and permission-review logs are written. Both the debug and review streams share one destination; each line is tagged with its stream so they stay distinguishable when interleaved on stdout/stderr.",
+    markdownDescription:
+      'Controls where the permission-system logs are written.\n\nBy default both logs are JSONL files under `logs/` in the extension config directory. Set `destination` to redirect them:\n\n- `"file"` (default) — write to log files. Set `directory` to place them somewhere other than the default `logs/` directory (supports `~`/`$HOME`).\n- `"stdout"` / `"stderr"` — write each JSONL line to that process stream and create **no** directory. Use this when Pi runs on a read-only filesystem (where the default `logs/` directory cannot be created) or inside a container that collects stdout/stderr.\n\nThe `debugLog` and `permissionReviewLog` toggles still decide whether each stream emits at all; `logging` only decides *where*. Both streams share one destination, and every line carries a `stream` field (`"debug"` / `"review"`) so a consumer tailing stdout/stderr can separate them.\n\n> **Prefer `stderr` over `stdout`.** In a TUI session stdout is the terminal, and in an RPC/frontend session it may carry the protocol — writing logs there can corrupt the display or transport. `stderr` is the safe stream for interleaved logging.',
+    examples: [
+      { destination: "stderr" },
+      { destination: "file", directory: "~/pi-logs" },
+    ],
+  });
+
 /**
  * The on-disk config file shape.
  *
@@ -220,6 +253,7 @@ export const unifiedConfigSchema = z
         "Ordered names of registered **live-authority chain links** (e.g. a model judge) to consult before the terminal authorizer (the human, or the subagent-forwarding / headless-deny fallback).\n\nA link reviews an `ask` and returns `allow` / `deny` (with an optional teaching reason) / `defer` to the next link. Three invariants govern the chain:\n\n- **Config order wins.** The order here \u2014 not the order extensions register in \u2014 fixes the security-relevant chain order.\n- **Fail-safe skip.** A name with no registered link is skipped with a warning; the `ask` still reaches the terminal (more prompting, never less).\n- **Opt-in activation.** Installing a judge extension grants it no authority; a link decides nothing until you name it here.\n\nThe chain owner caps every verdict with a bounded-delegation checkpoint: a link's `allow` on an excluded surface (`external_directory` or `path`) is downgraded to `defer`, so a link cannot exceed your policy.\n\nDefaults to an empty list (no links).",
       default: [],
     }),
+    logging: loggingSchema.optional(),
     permission: permissionSchema.optional(),
     shellTools: shellToolsSchema.optional(),
   })

--- a/packages/pi-permission-system/src/extension-config.ts
+++ b/packages/pi-permission-system/src/extension-config.ts
@@ -5,12 +5,26 @@ import type {
   ShellToolsConfig,
   UnifiedPermissionConfig,
 } from "./config-loader";
+import type { LogDestination } from "./config-schema";
 import {
   OWNER_ONLY_DIRECTORY_MODE,
   restrictExistingPathToOwner,
 } from "./log-file-permissions";
 
 export const EXTENSION_ID = "pi-permission-system";
+
+/**
+ * Where the permission logs are written, after normalization.
+ *
+ * `destination` is always present here (defaulted to `"file"` by
+ * {@link normalizePermissionSystemConfig}); `directory` is only meaningful for
+ * the file destination and defaults to the extension logs directory downstream.
+ */
+export interface LoggingConfig {
+  destination: LogDestination;
+  /** Custom logs directory for the `file` destination. Supports `~`/`$HOME`. */
+  directory?: string;
+}
 
 export interface PermissionSystemExtensionConfig {
   debugLog: boolean;
@@ -30,6 +44,8 @@ export interface PermissionSystemExtensionConfig {
   shellTools?: ShellToolsConfig;
   /** Ordered names of registered live-authority chain links to consult before the terminal authorizer. */
   authorizerChain?: string[];
+  /** Where the debug and permission-review logs are written. Absent means the default file destination. */
+  logging?: LoggingConfig;
 }
 
 export const DEFAULT_EXTENSION_CONFIG: PermissionSystemExtensionConfig = {
@@ -87,6 +103,16 @@ export function normalizePermissionSystemConfig(
   }
   if (raw.authorizerChain !== undefined) {
     result.authorizerChain = raw.authorizerChain;
+  }
+  if (raw.logging !== undefined) {
+    // Default the destination to "file" here so downstream consumers read one
+    // fully-resolved shape; a bare `{ "directory": "…" }` still means file.
+    result.logging = {
+      destination: raw.logging.destination ?? "file",
+      ...(raw.logging.directory !== undefined
+        ? { directory: raw.logging.directory }
+        : {}),
+    };
   }
   return result;
 }

--- a/packages/pi-permission-system/src/logging.ts
+++ b/packages/pi-permission-system/src/logging.ts
@@ -1,14 +1,11 @@
-import { appendFileSync } from "node:fs";
-
 import {
   EXTENSION_ID,
   type PermissionSystemExtensionConfig,
 } from "./extension-config";
-import {
-  OWNER_ONLY_FILE_MODE,
-  restrictExistingPathToOwner,
-} from "./log-file-permissions";
 import { redactedJsonStringify } from "./log-redaction";
+
+/** The two log streams the extension emits. Each line is tagged with its value. */
+export type LogStream = "debug" | "review";
 
 export interface PermissionSystemLogger {
   debug: (
@@ -23,55 +20,35 @@ export interface PermissionSystemLogger {
 
 interface PermissionSystemLoggerOptions {
   getConfig: () => PermissionSystemExtensionConfig;
-  debugLogPath: string;
-  reviewLogPath: string;
-  ensureLogsDirectory: () => string | undefined;
+  /**
+   * Write one already-serialized, newline-free line to its destination.
+   *
+   * Owns everything destination-specific (file vs stdout/stderr) and returns a
+   * human-readable error message on failure, or `undefined` on success. Called
+   * per line so a mid-session config reload can redirect the destination.
+   */
+  emit: (stream: LogStream, line: string) => string | undefined;
 }
 
 export function createPermissionSystemLogger(
   options: PermissionSystemLoggerOptions,
 ): PermissionSystemLogger {
-  const { debugLogPath, reviewLogPath, ensureLogsDirectory } = options;
-  // Per-session, so a log inherited from an earlier version is tightened once
-  // rather than on every line. Lives in the closure because the factory is
-  // re-invoked per session, unlike module scope, which now outlives one.
-  const hardened = new Set<string>();
-
   const writeLine = (
-    stream: "debug" | "review",
-    path: string,
+    stream: LogStream,
     event: string,
     details: Record<string, unknown>,
   ): string | undefined => {
-    const directoryError = ensureLogsDirectory();
-    if (directoryError) {
-      return directoryError;
+    const line = redactedJsonStringify({
+      timestamp: new Date().toISOString(),
+      extension: EXTENSION_ID,
+      stream,
+      event,
+      ...details,
+    });
+    if (!line) {
+      return `Failed to write permission-system ${stream} log: event could not be serialized.`;
     }
-
-    try {
-      const line = redactedJsonStringify({
-        timestamp: new Date().toISOString(),
-        extension: EXTENSION_ID,
-        stream,
-        event,
-        ...details,
-      });
-      if (!line) {
-        return `Failed to write permission-system ${stream} log '${path}': event could not be serialized.`;
-      }
-      appendFileSync(path, `${line}\n`, {
-        encoding: "utf-8",
-        mode: OWNER_ONLY_FILE_MODE,
-      });
-      if (!hardened.has(path)) {
-        hardened.add(path);
-        restrictExistingPathToOwner(path, OWNER_ONLY_FILE_MODE);
-      }
-      return undefined;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      return `Failed to write permission-system ${stream} log '${path}': ${message}`;
-    }
+    return options.emit(stream, line);
   };
 
   const debug = (
@@ -82,7 +59,7 @@ export function createPermissionSystemLogger(
       return undefined;
     }
 
-    return writeLine("debug", debugLogPath, event, details);
+    return writeLine("debug", event, details);
   };
 
   const review = (
@@ -93,7 +70,7 @@ export function createPermissionSystemLogger(
       return undefined;
     }
 
-    return writeLine("review", reviewLogPath, event, details);
+    return writeLine("review", event, details);
   };
 
   return { debug, review };

--- a/packages/pi-permission-system/src/session-logger.ts
+++ b/packages/pi-permission-system/src/session-logger.ts
@@ -1,11 +1,18 @@
+import { appendFileSync } from "node:fs";
 import { join } from "node:path";
 import { DEBUG_LOG_FILENAME, REVIEW_LOG_FILENAME } from "./config-paths";
+import { expandHomePath } from "./expand-home";
 import {
   ensurePermissionSystemLogsDirectory,
   type PermissionSystemExtensionConfig,
 } from "./extension-config";
 import {
+  OWNER_ONLY_FILE_MODE,
+  restrictExistingPathToOwner,
+} from "./log-file-permissions";
+import {
   createPermissionSystemLogger,
+  type LogStream,
   type PermissionSystemLogger,
 } from "./logging";
 
@@ -38,9 +45,15 @@ export interface SessionLogger extends DebugReviewLogger {
 
 /** Narrow dependencies for constructing a {@link SessionLogger}. */
 export interface SessionLoggerDeps {
-  /** Root logs directory; the debug + review log file paths derive from it. */
+  /**
+   * Default logs directory for the `file` destination; the debug + review log
+   * file paths derive from it. A configured `logging.directory` overrides it.
+   */
   globalLogsDir: string;
-  /** Reads current config for the debug/review write toggles (call-time). */
+  /**
+   * Reads current config at call time — for the debug/review write toggles and
+   * the `logging` destination, so a mid-session reload takes effect.
+   */
   getConfig: () => PermissionSystemExtensionConfig;
   /** Surfaces a warning message to the user; called at warn/IO-failure time. */
   notify: (message: string) => void;
@@ -57,16 +70,66 @@ export class PermissionSessionLogger implements SessionLogger {
   private readonly writer: PermissionSystemLogger;
   private readonly reported = new Set<string>();
   private readonly notify: (message: string) => void;
+  private readonly globalLogsDir: string;
+  private readonly getConfig: () => PermissionSystemExtensionConfig;
+  // Tightens a log inherited from an earlier version to owner-only on its first
+  // write rather than on every line. Per-session, like the logger itself.
+  private readonly hardened = new Set<string>();
 
   constructor(deps: SessionLoggerDeps) {
+    this.globalLogsDir = deps.globalLogsDir;
+    this.getConfig = deps.getConfig;
+    this.notify = deps.notify;
     this.writer = createPermissionSystemLogger({
       getConfig: deps.getConfig,
-      debugLogPath: join(deps.globalLogsDir, DEBUG_LOG_FILENAME),
-      reviewLogPath: join(deps.globalLogsDir, REVIEW_LOG_FILENAME),
-      ensureLogsDirectory: () =>
-        ensurePermissionSystemLogsDirectory(deps.globalLogsDir),
+      emit: (stream, line) => this.emit(stream, line),
     });
-    this.notify = deps.notify;
+  }
+
+  /**
+   * Route one line to the configured destination, re-read each write so a
+   * mid-session reload takes effect. A `stdout`/`stderr` destination creates no
+   * directory — the fix for a read-only filesystem where the default logs
+   * directory cannot be made.
+   */
+  private emit(stream: LogStream, line: string): string | undefined {
+    const logging = this.getConfig().logging;
+    const destination = logging?.destination ?? "file";
+    if (destination === "stdout") {
+      process.stdout.write(`${line}\n`);
+      return undefined;
+    }
+    if (destination === "stderr") {
+      process.stderr.write(`${line}\n`);
+      return undefined;
+    }
+
+    const dir = logging?.directory
+      ? expandHomePath(logging.directory)
+      : this.globalLogsDir;
+    const directoryError = ensurePermissionSystemLogsDirectory(dir);
+    if (directoryError) {
+      return directoryError;
+    }
+
+    const path = join(
+      dir,
+      stream === "debug" ? DEBUG_LOG_FILENAME : REVIEW_LOG_FILENAME,
+    );
+    try {
+      appendFileSync(path, `${line}\n`, {
+        encoding: "utf-8",
+        mode: OWNER_ONLY_FILE_MODE,
+      });
+      if (!this.hardened.has(path)) {
+        this.hardened.add(path);
+        restrictExistingPathToOwner(path, OWNER_ONLY_FILE_MODE);
+      }
+      return undefined;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return `Failed to write permission-system ${stream} log '${path}': ${message}`;
+    }
   }
 
   debug(event: string, details?: Record<string, unknown>): void {

--- a/packages/pi-permission-system/test/config-loader.test.ts
+++ b/packages/pi-permission-system/test/config-loader.test.ts
@@ -679,6 +679,49 @@ describe("mergeUnifiedConfigs", () => {
     const merged = mergeUnifiedConfigs({ debugLog: true }, { yoloMode: false });
     expect(merged).not.toHaveProperty("shellTools");
   });
+
+  it("base logging survives when override omits it", () => {
+    const merged = mergeUnifiedConfigs(
+      { logging: { destination: "stderr" } },
+      {},
+    );
+    expect(merged.logging).toEqual({ destination: "stderr" });
+  });
+
+  it("override logging survives when base omits it", () => {
+    const merged = mergeUnifiedConfigs(
+      {},
+      { logging: { destination: "stdout" } },
+    );
+    expect(merged.logging).toEqual({ destination: "stdout" });
+  });
+
+  it("shallow-merges logging by field: override directory keeps base destination", () => {
+    const merged = mergeUnifiedConfigs(
+      { logging: { destination: "file" } },
+      { logging: { directory: "~/pi-logs" } },
+    );
+    expect(merged.logging).toEqual({
+      destination: "file",
+      directory: "~/pi-logs",
+    });
+  });
+
+  it("override logging destination wins on a field collision", () => {
+    const merged = mergeUnifiedConfigs(
+      { logging: { destination: "file", directory: "~/pi-logs" } },
+      { logging: { destination: "stderr" } },
+    );
+    expect(merged.logging).toEqual({
+      destination: "stderr",
+      directory: "~/pi-logs",
+    });
+  });
+
+  it("logging is absent when both base and override omit it", () => {
+    const merged = mergeUnifiedConfigs({ debugLog: true }, { yoloMode: false });
+    expect(merged).not.toHaveProperty("logging");
+  });
 });
 
 describe("loadAndMergeConfigs", () => {

--- a/packages/pi-permission-system/test/config-reporter.test.ts
+++ b/packages/pi-permission-system/test/config-reporter.test.ts
@@ -1,10 +1,4 @@
-import {
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "vitest";
@@ -94,11 +88,6 @@ test("buildResolvedConfigLogEntry surfaces legacy detection flags", () => {
 test("config.resolved entry appears in review log via logger", () => {
   const tempDir = mkdtempSync(join(tmpdir(), "config-resolved-log-"));
   try {
-    const logsDir = join(tempDir, "logs");
-    mkdirSync(logsDir, { recursive: true });
-    const reviewLogPath = join(logsDir, "review.jsonl");
-    const debugLogPath = join(logsDir, "debug.jsonl");
-
     const globalConfigPath = join(tempDir, "pi-permissions.jsonc");
     writeFileSync(globalConfigPath, "{}", "utf-8");
     const agentsDir = join(tempDir, "agents");
@@ -108,6 +97,7 @@ test("config.resolved entry appears in review log via logger", () => {
       agentsDir,
     });
 
+    let reviewLine: string | undefined;
     const logger = createPermissionSystemLogger({
       getConfig: () => ({
         debugLog: false,
@@ -115,9 +105,10 @@ test("config.resolved entry appears in review log via logger", () => {
         yoloMode: false,
         doublePressToConfirm: true,
       }),
-      debugLogPath,
-      reviewLogPath,
-      ensureLogsDirectory: () => undefined,
+      emit: (_stream, line) => {
+        reviewLine = line;
+        return undefined;
+      },
     });
 
     const policyPaths = pm.getResolvedPolicyPaths();
@@ -127,8 +118,7 @@ test("config.resolved entry appears in review log via logger", () => {
       entry as unknown as Record<string, unknown>,
     );
 
-    const logContent = readFileSync(reviewLogPath, "utf-8").trim();
-    const parsed = JSON.parse(logContent) as Record<string, unknown>;
+    const parsed = JSON.parse(reviewLine ?? "") as Record<string, unknown>;
 
     expect(parsed.event).toBe("config.resolved");
     expect(parsed.globalConfigPath).toBe(globalConfigPath);

--- a/packages/pi-permission-system/test/config-schema.test.ts
+++ b/packages/pi-permission-system/test/config-schema.test.ts
@@ -155,6 +155,46 @@ describe("unifiedConfigSchema", () => {
       expect(result.success).toBe(false);
     });
   });
+
+  describe("logging field", () => {
+    it("accepts a stderr destination", () => {
+      expect(
+        unifiedConfigSchema.safeParse({ logging: { destination: "stderr" } })
+          .success,
+      ).toBe(true);
+    });
+
+    it("accepts a file destination with a custom directory", () => {
+      expect(
+        unifiedConfigSchema.safeParse({
+          logging: { destination: "file", directory: "~/pi-logs" },
+        }).success,
+      ).toBe(true);
+    });
+
+    it("accepts an empty logging object", () => {
+      expect(unifiedConfigSchema.safeParse({ logging: {} }).success).toBe(true);
+    });
+
+    it("rejects an unknown destination", () => {
+      expect(
+        unifiedConfigSchema.safeParse({ logging: { destination: "syslog" } })
+          .success,
+      ).toBe(false);
+    });
+
+    it("rejects an empty-string directory", () => {
+      expect(
+        unifiedConfigSchema.safeParse({ logging: { directory: "" } }).success,
+      ).toBe(false);
+    });
+
+    it("rejects an unknown field inside logging", () => {
+      expect(
+        unifiedConfigSchema.safeParse({ logging: { rotate: true } }).success,
+      ).toBe(false);
+    });
+  });
 });
 
 describe("inferred types match the hand-written domain types", () => {

--- a/packages/pi-permission-system/test/extension-config.test.ts
+++ b/packages/pi-permission-system/test/extension-config.test.ts
@@ -191,6 +191,38 @@ describe("normalizePermissionSystemConfig", () => {
     const result = normalizePermissionSystemConfig({});
     expect("authorizerChain" in result).toBe(false);
   });
+
+  it("omits logging when absent", () => {
+    const result = normalizePermissionSystemConfig({});
+    expect("logging" in result).toBe(false);
+  });
+
+  it("includes logging with the configured destination", () => {
+    const result = normalizePermissionSystemConfig({
+      logging: { destination: "stderr" },
+    });
+    expect(result.logging).toEqual({ destination: "stderr" });
+  });
+
+  it("defaults the logging destination to 'file' when only a directory is set", () => {
+    const result = normalizePermissionSystemConfig({
+      logging: { directory: "~/pi-logs" },
+    });
+    expect(result.logging).toEqual({
+      destination: "file",
+      directory: "~/pi-logs",
+    });
+  });
+
+  it("carries a custom directory alongside the file destination", () => {
+    const result = normalizePermissionSystemConfig({
+      logging: { destination: "file", directory: "/var/log/pi" },
+    });
+    expect(result.logging).toEqual({
+      destination: "file",
+      directory: "/var/log/pi",
+    });
+  });
 });
 
 describe("ensurePermissionSystemLogsDirectory", () => {

--- a/packages/pi-permission-system/test/logging.test.ts
+++ b/packages/pi-permission-system/test/logging.test.ts
@@ -1,90 +1,39 @@
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 import {
   DEFAULT_EXTENSION_CONFIG,
   type PermissionSystemExtensionConfig,
 } from "#src/extension-config";
-import { createPermissionSystemLogger } from "#src/logging";
+import { createPermissionSystemLogger, type LogStream } from "#src/logging";
 
 describe("createPermissionSystemLogger", () => {
-  let baseDir: string;
-  let logsDir: string;
-  let debugLogPath: string;
-  let reviewLogPath: string;
   let config: PermissionSystemExtensionConfig;
+  let lines: Array<{ stream: LogStream; line: string }>;
 
   beforeEach(() => {
-    baseDir = mkdtempSync(join(tmpdir(), "pi-permission-system-logs-"));
-    logsDir = join(baseDir, "logs");
-    debugLogPath = join(logsDir, "debug.jsonl");
-    reviewLogPath = join(logsDir, "review.jsonl");
     config = { ...DEFAULT_EXTENSION_CONFIG };
-  });
-
-  afterEach(() => {
-    rmSync(baseDir, { recursive: true, force: true });
+    lines = [];
   });
 
   function makeLogger() {
     return createPermissionSystemLogger({
       getConfig: () => config,
-      debugLogPath,
-      reviewLogPath,
-      ensureLogsDirectory: () => {
-        mkdirSync(logsDir, { recursive: true });
+      emit: (stream, line) => {
+        lines.push({ stream, line });
         return undefined;
       },
     });
   }
 
-  describe("file permissions", () => {
-    test("creates the review log owner-only", () => {
-      makeLogger().review("permission_request.waiting", { toolName: "write" });
-
-      expect(statSync(reviewLogPath).mode & 0o777).toBe(0o600);
-    });
-
-    test("creates the debug log owner-only", () => {
-      config.debugLog = true;
-      makeLogger().debug("permission.decision", { toolName: "write" });
-
-      expect(statSync(debugLogPath).mode & 0o777).toBe(0o600);
-    });
-
-    test("tightens a log inherited from an earlier version on next write", () => {
-      mkdirSync(logsDir, { recursive: true });
-      writeFileSync(reviewLogPath, "{}\n", "utf-8");
-      chmodSync(reviewLogPath, 0o644);
-
-      makeLogger().review("permission_request.waiting", { toolName: "write" });
-
-      expect(statSync(reviewLogPath).mode & 0o777).toBe(0o600);
-    });
-  });
-
   describe("redaction", () => {
     test("masks sensitive-keyed values before they reach the review log", () => {
-      const logger = makeLogger();
-
-      logger.review("permission_request.waiting", {
+      makeLogger().review("permission_request.waiting", {
         toolName: "http",
         headers: { authorization: "Bearer TEST_VALUE" },
       });
 
-      const written = readFileSync(reviewLogPath, "utf8");
-      expect(written).not.toContain("TEST_VALUE");
-      expect(JSON.parse(written.trim())).toMatchObject({
+      expect(lines).toHaveLength(1);
+      expect(lines[0].line).not.toContain("TEST_VALUE");
+      expect(JSON.parse(lines[0].line)).toMatchObject({
         toolName: "http",
         headers: { authorization: "[redacted]" },
       });
@@ -92,54 +41,44 @@ describe("createPermissionSystemLogger", () => {
 
     test("masks sensitive-keyed values in the debug log too", () => {
       config.debugLog = true;
-      const logger = makeLogger();
 
-      logger.debug("permission.decision", {
+      makeLogger().debug("permission.decision", {
         toolName: "http",
         apiKey: "sk-real-value",
       });
 
-      const written = readFileSync(debugLogPath, "utf8");
-      expect(written).not.toContain("sk-real-value");
-      expect(JSON.parse(written.trim())).toMatchObject({
+      expect(lines[0].line).not.toContain("sk-real-value");
+      expect(JSON.parse(lines[0].line)).toMatchObject({
         toolName: "http",
         apiKey: "[redacted]",
       });
     });
 
     test("leaves a bash command string unredacted, as documented", () => {
-      const logger = makeLogger();
-
-      logger.review("permission_request.waiting", {
+      makeLogger().review("permission_request.waiting", {
         toolName: "bash",
         command: "deploy --token abc123",
       });
 
-      expect(readFileSync(reviewLogPath, "utf8")).toContain(
-        "deploy --token abc123",
-      );
+      expect(lines[0].line).toContain("deploy --token abc123");
     });
   });
 
   test("respects debug toggle and keeps review log enabled by default", () => {
     const logger = makeLogger();
 
-    const initialDebugWarning = logger.debug("debug.disabled", {
-      sample: true,
-    });
-    const reviewWarning = logger.review("permission_request.waiting", {
-      toolName: "write",
-    });
-
-    expect(initialDebugWarning).toBe(undefined);
-    expect(reviewWarning).toBe(undefined);
-    expect(existsSync(debugLogPath)).toBe(false);
-    expect(existsSync(reviewLogPath)).toBe(true);
+    expect(logger.debug("debug.disabled", { sample: true })).toBe(undefined);
+    expect(
+      logger.review("permission_request.waiting", { toolName: "write" }),
+    ).toBe(undefined);
+    expect(lines.map((l) => l.stream)).toEqual(["review"]);
 
     config.debugLog = true;
-    const enabledDebugWarning = logger.debug("debug.enabled", { sample: true });
-    expect(enabledDebugWarning).toBe(undefined);
-    expect(existsSync(debugLogPath)).toBe(true);
-    expect(readFileSync(debugLogPath, "utf8")).toMatch(/debug\.enabled/);
+    logger.debug("debug.enabled", { sample: true });
+    expect(
+      lines.some(
+        (l) => l.stream === "debug" && l.line.includes("debug.enabled"),
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/pi-permission-system/test/session-logger.test.ts
+++ b/packages/pi-permission-system/test/session-logger.test.ts
@@ -1,7 +1,15 @@
-import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DEBUG_LOG_FILENAME, REVIEW_LOG_FILENAME } from "#src/config-paths";
 import {
   DEFAULT_EXTENSION_CONFIG,
@@ -17,6 +25,15 @@ let tempDir: string;
 beforeEach(() => {
   tempDir = mkdtempSync(join(tmpdir(), "ps-session-logger-"));
 });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Spy on a process stream's `write`, suppressing real output and recording calls. */
+function spyOnStream(name: "stdout" | "stderr") {
+  return vi.spyOn(process[name], "write").mockImplementation(() => true);
+}
 
 function makeDeps(
   overrides: {
@@ -195,6 +212,165 @@ describe("PermissionSessionLogger", () => {
       const logger = new PermissionSessionLogger(deps);
 
       expect(() => logger.warn("test")).not.toThrow();
+    });
+  });
+
+  // ── file permissions ──────────────────────────────────────────────────────
+
+  describe("file permissions", () => {
+    it("creates the review log owner-only", () => {
+      new PermissionSessionLogger(makeDeps()).review(
+        "permission_request.waiting",
+        { toolName: "write" },
+      );
+
+      expect(statSync(join(tempDir, REVIEW_LOG_FILENAME)).mode & 0o777).toBe(
+        0o600,
+      );
+    });
+
+    it("creates the debug log owner-only", () => {
+      new PermissionSessionLogger(
+        makeDeps({
+          getConfig: () => ({ ...DEFAULT_EXTENSION_CONFIG, debugLog: true }),
+        }),
+      ).debug("permission.decision", { toolName: "write" });
+
+      expect(statSync(join(tempDir, DEBUG_LOG_FILENAME)).mode & 0o777).toBe(
+        0o600,
+      );
+    });
+
+    it("tightens a log inherited from an earlier version on next write", () => {
+      const reviewLogPath = join(tempDir, REVIEW_LOG_FILENAME);
+      writeFileSync(reviewLogPath, "{}\n", "utf-8");
+      chmodSync(reviewLogPath, 0o644);
+
+      new PermissionSessionLogger(makeDeps()).review(
+        "permission_request.waiting",
+        { toolName: "write" },
+      );
+
+      expect(statSync(reviewLogPath).mode & 0o777).toBe(0o600);
+    });
+  });
+
+  // ── logging destination ─────────────────────────────────────────────────
+
+  describe("logging destination", () => {
+    it("writes review lines to stderr instead of a file", () => {
+      const stderr = spyOnStream("stderr");
+      const deps = makeDeps({
+        getConfig: () => ({
+          ...DEFAULT_EXTENSION_CONFIG,
+          logging: { destination: "stderr" },
+        }),
+      });
+
+      new PermissionSessionLogger(deps).review("permission.granted", {
+        agentName: "coder",
+      });
+
+      expect(existsSync(join(tempDir, REVIEW_LOG_FILENAME))).toBe(false);
+      expect(stderr).toHaveBeenCalledOnce();
+      const line = String(stderr.mock.calls[0][0]);
+      expect(line.endsWith("\n")).toBe(true);
+      expect(JSON.parse(line)).toMatchObject({
+        stream: "review",
+        event: "permission.granted",
+        agentName: "coder",
+      });
+      expect(deps.notify).not.toHaveBeenCalled();
+    });
+
+    it("routes debug lines to stdout when destination is stdout", () => {
+      const stdout = spyOnStream("stdout");
+      const deps = makeDeps({
+        getConfig: () => ({
+          ...DEFAULT_EXTENSION_CONFIG,
+          debugLog: true,
+          logging: { destination: "stdout" },
+        }),
+      });
+
+      new PermissionSessionLogger(deps).debug("permission.decision", {
+        toolName: "write",
+      });
+
+      expect(existsSync(join(tempDir, DEBUG_LOG_FILENAME))).toBe(false);
+      expect(stdout).toHaveBeenCalledOnce();
+      expect(JSON.parse(String(stdout.mock.calls[0][0]))).toMatchObject({
+        stream: "debug",
+        event: "permission.decision",
+      });
+    });
+
+    it("keeps logging on a read-only filesystem when destination is a stream", () => {
+      // The whole point of the feature: the default logs directory cannot be
+      // created, but a stream destination never tries to, so no warning fires.
+      const stderr = spyOnStream("stderr");
+      const deps = makeDeps({
+        globalLogsDir: makeBlockedLogsDir(),
+        getConfig: () => ({
+          ...DEFAULT_EXTENSION_CONFIG,
+          logging: { destination: "stderr" },
+        }),
+      });
+
+      new PermissionSessionLogger(deps).review("permission_request.waiting", {
+        toolName: "write",
+      });
+
+      expect(stderr).toHaveBeenCalledOnce();
+      expect(deps.notify).not.toHaveBeenCalled();
+    });
+
+    it("writes to a configured file directory instead of the default logs dir", () => {
+      const customDir = join(tempDir, "nested", "custom-logs");
+      const deps = makeDeps({
+        getConfig: () => ({
+          ...DEFAULT_EXTENSION_CONFIG,
+          logging: { destination: "file", directory: customDir },
+        }),
+      });
+
+      new PermissionSessionLogger(deps).review("permission.granted");
+
+      expect(existsSync(join(tempDir, REVIEW_LOG_FILENAME))).toBe(false);
+      expect(existsSync(join(customDir, REVIEW_LOG_FILENAME))).toBe(true);
+      expect(deps.notify).not.toHaveBeenCalled();
+    });
+
+    it("defaults to the file destination when no logging config is present", () => {
+      new PermissionSessionLogger(makeDeps()).review("permission.granted");
+
+      expect(readdirSync(tempDir)).toContain(REVIEW_LOG_FILENAME);
+    });
+
+    it("follows a mid-session switch from file to stderr", () => {
+      const stderr = spyOnStream("stderr");
+      let destination: "file" | "stderr" = "file";
+      const deps = makeDeps({
+        getConfig: () => ({
+          ...DEFAULT_EXTENSION_CONFIG,
+          logging: { destination },
+        }),
+      });
+      const logger = new PermissionSessionLogger(deps);
+
+      logger.review("first.event");
+      expect(readFileSync(join(tempDir, REVIEW_LOG_FILENAME), "utf8")).toMatch(
+        /first\.event/,
+      );
+
+      destination = "stderr";
+      logger.review("second.event");
+      expect(stderr).toHaveBeenCalledOnce();
+      expect(String(stderr.mock.calls[0][0])).toMatch(/second\.event/);
+      // The file did not gain the second line.
+      expect(
+        readFileSync(join(tempDir, REVIEW_LOG_FILENAME), "utf8"),
+      ).not.toMatch(/second\.event/);
     });
   });
 });


### PR DESCRIPTION
…/stderr)

The debug and permission-review logs were hardcoded to write files under `<agentDir>/extensions/pi-permission-system/logs/`. On a read-only filesystem or in a sandbox where that directory cannot be created, every write failed with a repeated warning:

    Failed to create permission-system log directory '…/logs':
    EACCES: permission denied, mkdir '…/logs'

Add a `logging` config object that selects where logs go:

    "logging": { "destination": "stderr" }              // or "stdout"
    "logging": { "destination": "file", "directory": "~/pi-logs" }