### PR TITLE
feat(pi-permission-system): align dialogs with native settings UI

### DIFF
--- a/packages/pi-permission-system/src/authority/permission-prompt-component.ts
+++ b/packages/pi-permission-system/src/authority/permission-prompt-component.ts
@@ -25,6 +25,7 @@ import {
 } from "#src/presentation/dialog-renderer";
 import { fitLinesToWidth } from "#src/presentation/line-fitting";
 import type { PromptPayload } from "#src/presentation/prompt-payload";
+import { renderBorderedPanel } from "#src/ui/bordered-panel";
 
 /**
  * Inline `ctx.ui.custom` permission dialog for TUI sessions.
@@ -186,7 +187,11 @@ class PermissionPromptComponent implements Component {
   }
 
   render(width: number): string[] {
-    return fitLinesToWidth(this.renderStep(width), width);
+    return renderBorderedPanel(
+      fitLinesToWidth(this.renderStep(width), width),
+      width,
+      (text) => this.theme.fg("accent", text),
+    );
   }
 
   private renderStep(width: number): string[] {

--- a/packages/pi-permission-system/src/config-modal.ts
+++ b/packages/pi-permission-system/src/config-modal.ts
@@ -3,7 +3,12 @@ import {
   type ExtensionCommandContext,
   getSettingsListTheme,
 } from "@earendil-works/pi-coding-agent";
-import { type SettingItem, SettingsList } from "@earendil-works/pi-tui";
+import {
+  type SettingItem,
+  SettingsList,
+  Spacer,
+  Text,
+} from "@earendil-works/pi-tui";
 import { BorderedPanel } from "#src/ui/bordered-panel";
 import type { CommandConfigStore } from "./config-store";
 import {
@@ -196,6 +201,14 @@ async function openSettingsModal(
       );
 
       const panel = new BorderedPanel((text) => theme.fg("border", text));
+      panel.addChild(
+        new Text(
+          theme.bold(theme.fg("accent", "Permission System Settings")),
+          0,
+          0,
+        ),
+      );
+      panel.addChild(new Spacer(1));
       panel.addChild(settingsList);
       return panel;
     },

--- a/packages/pi-permission-system/src/config-modal.ts
+++ b/packages/pi-permission-system/src/config-modal.ts
@@ -4,7 +4,7 @@ import {
   getSettingsListTheme,
 } from "@earendil-works/pi-coding-agent";
 import { type SettingItem, SettingsList } from "@earendil-works/pi-tui";
-
+import { BorderedPanel } from "#src/ui/bordered-panel";
 import type { CommandConfigStore } from "./config-store";
 import {
   DEFAULT_EXTENSION_CONFIG,
@@ -187,7 +187,7 @@ async function openSettingsModal(
 
   // eslint-disable-next-line @typescript-eslint/no-invalid-void-type -- ctx.ui.custom<void> is valid; rule does not allow void in generic fn call type args
   await ctx.ui.custom<void>(
-    (_tui, _theme, _keybindings, done) => {
+    (_tui, theme, _keybindings, done) => {
       let current = controller.config.current();
       const settingsList = new SettingsList(
         buildSettingItems(current),
@@ -202,7 +202,9 @@ async function openSettingsModal(
         () => done(),
       );
 
-      return settingsList;
+      const panel = new BorderedPanel((text) => theme.fg("accent", text));
+      panel.addChild(settingsList);
+      return panel;
     },
     { overlay: true, overlayOptions },
   );

--- a/packages/pi-permission-system/src/config-modal.ts
+++ b/packages/pi-permission-system/src/config-modal.ts
@@ -178,13 +178,6 @@ async function openSettingsModal(
   ctx: ExtensionCommandContext,
   controller: PermissionSystemConfigController,
 ): Promise<void> {
-  const overlayOptions = {
-    anchor: "center" as const,
-    width: 82,
-    maxHeight: "85%" as const,
-    margin: 1,
-  };
-
   // eslint-disable-next-line @typescript-eslint/no-invalid-void-type -- ctx.ui.custom<void> is valid; rule does not allow void in generic fn call type args
   await ctx.ui.custom<void>(
     (_tui, theme, _keybindings, done) => {
@@ -202,11 +195,11 @@ async function openSettingsModal(
         () => done(),
       );
 
-      const panel = new BorderedPanel((text) => theme.fg("accent", text));
+      const panel = new BorderedPanel((text) => theme.fg("border", text));
       panel.addChild(settingsList);
       return panel;
     },
-    { overlay: true, overlayOptions },
+    { overlay: false },
   );
 }
 

--- a/packages/pi-permission-system/src/ui/bordered-panel.ts
+++ b/packages/pi-permission-system/src/ui/bordered-panel.ts
@@ -5,18 +5,30 @@ import {
 } from "@earendil-works/pi-tui";
 
 /**
- * Add the horizontal accent rules used by the permission prompt panel.
+ * Add the horizontal rules used by the inline permission panels.
  *
  * The prompt content is rendered by the structured payload renderer first, so
  * this wrapper deliberately owns only the presentation chrome.
  */
+type InputComponent = Component & {
+  handleInput(data: string): void;
+};
+
 export class BorderedPanel implements Component {
   private readonly content = new Container();
+  private inputComponent: InputComponent | undefined;
 
   constructor(private readonly border: (text: string) => string) {}
 
   addChild(component: Component): void {
     this.content.addChild(component);
+    if (hasInputHandler(component)) {
+      this.inputComponent = component;
+    }
+  }
+
+  handleInput(data: string): void {
+    this.inputComponent?.handleInput(data);
   }
 
   invalidate(): void {
@@ -26,6 +38,12 @@ export class BorderedPanel implements Component {
   render(width: number): string[] {
     return renderBorderedPanel(this.content.render(width), width, this.border);
   }
+}
+
+function hasInputHandler(component: Component): component is InputComponent {
+  return (
+    "handleInput" in component && typeof component.handleInput === "function"
+  );
 }
 
 export function renderBorderedPanel(

--- a/packages/pi-permission-system/src/ui/bordered-panel.ts
+++ b/packages/pi-permission-system/src/ui/bordered-panel.ts
@@ -1,4 +1,8 @@
-import { truncateToWidth } from "@earendil-works/pi-tui";
+import {
+  type Component,
+  Container,
+  truncateToWidth,
+} from "@earendil-works/pi-tui";
 
 /**
  * Add the horizontal accent rules used by the permission prompt panel.
@@ -6,6 +10,24 @@ import { truncateToWidth } from "@earendil-works/pi-tui";
  * The prompt content is rendered by the structured payload renderer first, so
  * this wrapper deliberately owns only the presentation chrome.
  */
+export class BorderedPanel implements Component {
+  private readonly content = new Container();
+
+  constructor(private readonly border: (text: string) => string) {}
+
+  addChild(component: Component): void {
+    this.content.addChild(component);
+  }
+
+  invalidate(): void {
+    this.content.invalidate();
+  }
+
+  render(width: number): string[] {
+    return renderBorderedPanel(this.content.render(width), width, this.border);
+  }
+}
+
 export function renderBorderedPanel(
   lines: readonly string[],
   width: number,

--- a/packages/pi-permission-system/src/ui/bordered-panel.ts
+++ b/packages/pi-permission-system/src/ui/bordered-panel.ts
@@ -1,0 +1,24 @@
+import { truncateToWidth } from "@earendil-works/pi-tui";
+
+/**
+ * Add the horizontal accent rules used by the permission prompt panel.
+ *
+ * The prompt content is rendered by the structured payload renderer first, so
+ * this wrapper deliberately owns only the presentation chrome.
+ */
+export function renderBorderedPanel(
+  lines: readonly string[],
+  width: number,
+  border: (text: string) => string,
+): string[] {
+  if (width <= 0) {
+    return [];
+  }
+
+  const horizontal = border("─".repeat(width));
+  return [
+    horizontal,
+    ...lines.map((line) => truncateToWidth(line, width, "")),
+    horizontal,
+  ];
+}

--- a/packages/pi-permission-system/test/authority/permission-prompt-component.test.ts
+++ b/packages/pi-permission-system/test/authority/permission-prompt-component.test.ts
@@ -129,8 +129,8 @@ function makeAsk(value = "/repo/secret.txt"): PromptPayload {
 
 const ASK = makeAsk();
 
-/** Title, blank separator, four decision options, blank, hint. */
-const DECISION_CHROME_ROWS = 8;
+/** Title, blank separator, four decision options, blank, hint, and panel rules. */
+const DECISION_CHROME_ROWS = 10;
 
 async function runPrompt(
   doublePressToConfirm: boolean,
@@ -157,7 +157,10 @@ describe("presentInlinePermissionPrompt", () => {
     const { view, captured } = makeFakeView(true);
     void presentInlinePermissionPrompt(view, "Permission Required", ASK);
     expect(captured.options).toEqual({ overlay: false });
-    const text = captured.component?.render(80).join("\n") ?? "";
+    const lines = captured.component?.render(80) ?? [];
+    const text = lines.join("\n");
+    expect(lines[0]).toBe("─".repeat(80));
+    expect(lines.at(-1)).toBe("─".repeat(80));
     expect(text).toContain("tool : read");
     expect(text).toContain("path : /repo/secret.txt");
     expect(text).toContain("Yes");
@@ -445,12 +448,12 @@ describe("presentInlinePermissionPrompt", () => {
       );
       const bounded = captured.component?.render(120) ?? [];
       expect(bounded).toContain("path : /repo/a/ve…");
-      expect(bounded.at(-1)).toContain("ctrl+o full request");
+      expect(bounded.at(-2)).toContain("ctrl+o full request");
 
       captured.component?.handleInput(CTRL_O);
       const expanded = captured.component?.render(120) ?? [];
       expect(expanded).toContain("path : /repo/a/very/long/secret.txt");
-      expect(expanded.at(-1)).toContain("ctrl+o collapse");
+      expect(expanded.at(-2)).toContain("ctrl+o collapse");
       // The host's own tool expansion still follows the same keystroke (#642).
       expect(setToolsExpanded).toHaveBeenCalledWith(true);
 
@@ -462,7 +465,7 @@ describe("presentInlinePermissionPrompt", () => {
       const { view, captured } = makeFakeView(true);
       void presentInlinePermissionPrompt(view, "Title", ASK);
 
-      expect(captured.component?.render(120).at(-1)).not.toContain("ctrl+o");
+      expect(captured.component?.render(120).at(-2)).not.toContain("ctrl+o");
     });
 
     it("does not intercept the expand key while a denial reason is typed", async () => {

--- a/packages/pi-permission-system/test/config-modal.test.ts
+++ b/packages/pi-permission-system/test/config-modal.test.ts
@@ -44,9 +44,11 @@ function createCommandContext(hasUI: boolean): {
   ctx: CommandContextStub;
   notifications: Notification[];
   getCustomCalls(): number;
+  getLastCustomOptions(): unknown;
 } {
   const notifications: Notification[] = [];
   let customCalls = 0;
+  let customOptions: unknown;
 
   return {
     ctx: {
@@ -57,15 +59,17 @@ function createCommandContext(hasUI: boolean): {
         },
         async custom<T>(
           _renderer: (...args: unknown[]) => unknown,
-          _options?: unknown,
+          options?: unknown,
         ): Promise<T> {
           customCalls += 1;
+          customOptions = options;
           return undefined as T;
         },
       },
     },
     notifications,
     getCustomCalls: () => customCalls,
+    getLastCustomOptions: () => customOptions,
   };
 }
 
@@ -235,6 +239,7 @@ test("permission-system command handlers manage config summary, persistence, and
     const modalCtx = createCommandContext(true);
     await definition!.handler("", modalCtx.ctx);
     expect(modalCtx.getCustomCalls()).toBe(1);
+    expect(modalCtx.getLastCustomOptions()).toEqual({ overlay: false });
   } finally {
     rmSync(baseDir, { recursive: true, force: true });
   }

--- a/packages/pi-permission-system/test/ui/bordered-panel.test.ts
+++ b/packages/pi-permission-system/test/ui/bordered-panel.test.ts
@@ -2,22 +2,32 @@ import { describe, expect, it } from "vitest";
 import { BorderedPanel } from "#src/ui/bordered-panel";
 
 class FixedLines {
+  readonly inputs: string[] = [];
+
   invalidate(): void {}
 
   render(): string[] {
     return ["settings"];
   }
+
+  handleInput(data: string): void {
+    this.inputs.push(data);
+  }
 }
 
 describe("BorderedPanel", () => {
-  it("wraps child content with accent rules", () => {
+  it("wraps child content and forwards input", () => {
     const panel = new BorderedPanel((text) => `[${text}]`);
-    panel.addChild(new FixedLines());
+    const child = new FixedLines();
+    panel.addChild(child);
 
     expect(panel.render(10)).toEqual([
       `[${"─".repeat(10)}]`,
       "settings",
       `[${"─".repeat(10)}]`,
     ]);
+
+    panel.handleInput("down");
+    expect(child.inputs).toEqual(["down"]);
   });
 });

--- a/packages/pi-permission-system/test/ui/bordered-panel.test.ts
+++ b/packages/pi-permission-system/test/ui/bordered-panel.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { BorderedPanel } from "#src/ui/bordered-panel";
+
+class FixedLines {
+  invalidate(): void {}
+
+  render(): string[] {
+    return ["settings"];
+  }
+}
+
+describe("BorderedPanel", () => {
+  it("wraps child content with accent rules", () => {
+    const panel = new BorderedPanel((text) => `[${text}]`);
+    panel.addChild(new FixedLines());
+
+    expect(panel.render(10)).toEqual([
+      `[${"─".repeat(10)}]`,
+      "settings",
+      `[${"─".repeat(10)}]`,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

This PR ports the permission-system UI design into the current `@gotgenes/pi-permission-system` architecture while preserving the structured prompt payload and existing permission behavior.

## What changed

### Permission prompt

- Adds a reusable `BorderedPanel` presentation component with native-style horizontal border rules.
- Wraps the inline permission prompt in the bordered panel without changing its decision model, payload rendering, expansion behavior, or fallback flow.
- Keeps the panel width-safe by truncating rendered rows to the host terminal width.

### Configuration dialog

- Changes `/permission-system` settings from an overlay popup to an inline selector with `{ overlay: false }`, matching Pi's native `/settings` interaction model.
- Adds the `Permission System Settings` title.
- Uses the native `border` theme color for the panel rules.
- Forwards keyboard input from the wrapper to `SettingsList`, preventing the settings screen from becoming non-interactive.
- Keeps the existing settings persistence, reset behavior, argument completions, and command routing unchanged.

## Compatibility and safety

- No permission surfaces, defaults, config schema fields, or policy evaluation rules were changed.
- The structured prompt payload contract remains intact.
- The existing session approval, tool expansion, and deny/ask/allow flows remain unchanged.

## Tests

- `pnpm --filter @gotgenes/pi-permission-system run check`
- `pnpm --filter @gotgenes/pi-permission-system exec vitest run test/config-modal.test.ts test/ui/bordered-panel.test.ts test/authority/permission-prompt-component.test.ts`
- Result: 27 tests passed.

## Manual validation

The active permission configuration was validated with a `*.key` path rule:

1. The initial write request was denied by the permission system.
2. After approval, the test key was written successfully.
3. Reading the key then completed through the installed local permission-system package.
