### PR TITLE
feat(pi-subagents): add additionalTools setting to append extra tool names to agent-type allowlists

### DIFF
--- a/packages/pi-subagents/src/index.ts
+++ b/packages/pi-subagents/src/index.ts
@@ -20,9 +20,10 @@ import {
   SettingsManager as SdkSettingsManager,
   SessionManager,
 } from "@earendil-works/pi-coding-agent";
-import { AgentTypeRegistry } from "#src/config/agent-types";
+import { type AgentConfigLookup, AgentTypeRegistry } from "#src/config/agent-types";
 import { loadCustomAgents } from "#src/config/custom-agents";
 import { InterruptHandler, SessionLifecycleHandler, ToolStartHandler } from "#src/handlers/index";
+import { loadLayeredSettings } from "#src/layered-settings";
 import { createChildLifecyclePublisher } from "#src/lifecycle/child-lifecycle";
 import { ConcurrencyLimiter } from "#src/lifecycle/concurrency-limiter";
 import { createSubagentSession, type SubagentSessionDeps } from "#src/lifecycle/create-subagent-session";
@@ -47,6 +48,64 @@ import { SteerTool } from "#src/tools/steer-tool";
 import { AgentWidget } from "#src/ui/agent-widget";
 import { SessionNavigatorHandler } from "#src/ui/session-navigator";
 import { SubagentsSettingsHandler } from "#src/ui/subagents-settings";
+
+// ── Fork divergence (plan/34): user-configured additive tool grants ──────────
+// additionalTools in subagents.json maps an agent-type name (case-insensitive,
+// or "*" for every type) to extra tool names appended to that type's allowlist
+// at spawn time. Read via a second sanitized pass over the same layered
+// subagents.json the SettingsManager loads — frozen settings.ts's sanitize()
+// drops unknown keys, and saveSettings() never rewrites the global file, so a
+// hand-edited global key is durable. The recursion guard (excludeTools) still
+// strips this extension's own three tools even if listed here. Read once at
+// init; config edits need a fresh session. A PROJECT-level additionalTools is
+// erased by the next /subagents:settings write (frozen snapshot() can't
+// round-trip it) — set this key globally.
+
+export function sanitizeAdditionalTools(raw: unknown): Record<string, string[]> | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const out: Record<string, string[]> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!Array.isArray(value)) continue;
+    const k = key.trim().toLowerCase();
+    const tools = value
+      .filter((v): v is string => typeof v === "string")
+      .map((v) => v.trim())
+      .filter(Boolean);
+    if (!k || tools.length === 0) continue;
+    out[k] = [...new Set([...(out[k] ?? []), ...tools])];
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+export function readAdditionalTools(agentDir: string, cwd: string): Record<string, string[]> | undefined {
+  return loadLayeredSettings<{ additionalTools: Record<string, string[]> }>({
+    agentDir,
+    cwd,
+    filename: "subagents.json",
+    sanitize: (raw) => {
+      if (!raw || typeof raw !== "object") return {};
+      const cleaned = sanitizeAdditionalTools((raw as Record<string, unknown>).additionalTools);
+      return cleaned ? { additionalTools: cleaned } : {};
+    },
+    warnLabel: "pi-subagents",
+  }).additionalTools;
+}
+
+export function withAdditionalTools(
+  registry: AgentConfigLookup & { resolveType(name: string): string | undefined },
+  config: Record<string, string[]> | undefined,
+): AgentConfigLookup {
+  if (!config) return registry;
+  return {
+    resolveAgentConfig: (type) => registry.resolveAgentConfig(type),
+    getToolNamesForType: (type) => {
+      const base = registry.getToolNamesForType(type);
+      const key = registry.resolveType(type)?.toLowerCase();
+      const extra = [...(config["*"] ?? []), ...(key ? (config[key] ?? []) : [])];
+      return extra.length > 0 ? [...new Set([...base, ...extra])] : base;
+    },
+  };
+}
 
 export default function (pi: ExtensionAPI) {
   // ---- Register custom notification renderer ----
@@ -128,7 +187,7 @@ export default function (pi: ExtensionAPI) {
       },
     },
     exec: (cmd, args, opts) => pi.exec(cmd, args, opts),
-    registry,
+    registry: withAdditionalTools(registry, readAdditionalTools(getAgentDir(), process.cwd())),
     lifecycle: createChildLifecyclePublisher((channel, data) => pi.events.emit(channel, data)),
   };
 

--- a/packages/pi-subagents/test/additional-tools.test.ts
+++ b/packages/pi-subagents/test/additional-tools.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readAdditionalTools, sanitizeAdditionalTools, withAdditionalTools } from "#src/index";
+import { createSettingsDirs, type SettingsDirs } from "#test/helpers/tmp-settings-dirs";
+
+describe("sanitizeAdditionalTools", () => {
+  it("rejects non-object roots (array, string, number, null, undefined)", () => {
+    expect(sanitizeAdditionalTools(["general-purpose"])).toBeUndefined();
+    expect(sanitizeAdditionalTools("general-purpose")).toBeUndefined();
+    expect(sanitizeAdditionalTools(42)).toBeUndefined();
+    expect(sanitizeAdditionalTools(null)).toBeUndefined();
+    expect(sanitizeAdditionalTools(undefined)).toBeUndefined();
+  });
+
+  it("drops keys whose value is not an array", () => {
+    expect(sanitizeAdditionalTools({ "general-purpose": "skill_manage" })).toBeUndefined();
+    expect(
+      sanitizeAdditionalTools({ "general-purpose": ["skill_manage"], "*": "memory_search" }),
+    ).toEqual({ "general-purpose": ["skill_manage"] });
+  });
+
+  it("filters non-string and blank members out of a tool array", () => {
+    expect(
+      sanitizeAdditionalTools({ "*": ["memory_search", "", "   ", 42, null, {}, "session_search"] }),
+    ).toEqual({ "*": ["memory_search", "session_search"] });
+  });
+
+  it("drops a key entirely when its array yields no valid tool names", () => {
+    expect(sanitizeAdditionalTools({ "*": ["", "   ", 42] })).toBeUndefined();
+    expect(
+      sanitizeAdditionalTools({ "*": ["", 42], "general-purpose": ["skill_manage"] }),
+    ).toEqual({ "general-purpose": ["skill_manage"] });
+  });
+
+  it("lowercases keys and unions colliding keys after trim/lowercase", () => {
+    expect(
+      sanitizeAdditionalTools({
+        "General-Purpose": ["skill_manage"],
+        "general-purpose": ["memory_add"],
+        " GENERAL-PURPOSE ": ["memory_add", "memory_remove"],
+      }),
+    ).toEqual({ "general-purpose": ["skill_manage", "memory_add", "memory_remove"] });
+  });
+
+  it("trims whitespace on both keys and tool names", () => {
+    expect(sanitizeAdditionalTools({ " * ": ["  memory_search  "] })).toEqual({ "*": ["memory_search"] });
+  });
+
+  it("returns undefined when every key sanitizes away (empty result)", () => {
+    expect(sanitizeAdditionalTools({})).toBeUndefined();
+    expect(sanitizeAdditionalTools({ "": ["memory_search"] })).toBeUndefined();
+  });
+});
+
+describe("readAdditionalTools", () => {
+  let dirs: SettingsDirs;
+  let globalDir: string;
+  let projectDir: string;
+  let writeGlobal: (obj: unknown) => void;
+  let writeProject: (obj: unknown) => void;
+
+  beforeEach(() => {
+    dirs = createSettingsDirs("subagents.json");
+    ({ globalDir, projectDir, writeGlobal, writeProject } = dirs);
+  });
+
+  afterEach(() => {
+    dirs.dispose();
+  });
+
+  it("returns undefined when both files are missing", () => {
+    expect(readAdditionalTools(globalDir, projectDir)).toBeUndefined();
+  });
+
+  it("reads a global-only additionalTools config", () => {
+    writeGlobal({ additionalTools: { "*": ["memory_search"], "general-purpose": ["skill_manage"] } });
+    expect(readAdditionalTools(globalDir, projectDir)).toEqual({
+      "*": ["memory_search"],
+      "general-purpose": ["skill_manage"],
+    });
+  });
+
+  it("project-layer additionalTools replaces global's, per loadLayeredSettings's shallow merge", () => {
+    writeGlobal({ additionalTools: { "*": ["memory_search"], "general-purpose": ["skill_manage"] } });
+    writeProject({ additionalTools: { "*": ["session_search"] } });
+    // Shallow merge means the whole `additionalTools` value from the project
+    // layer wins wholesale — it does not deep-merge per agent-type key.
+    expect(readAdditionalTools(globalDir, projectDir)).toEqual({ "*": ["session_search"] });
+  });
+
+  it("returns undefined when the config file has no additionalTools key", () => {
+    writeGlobal({ maxConcurrent: 4 });
+    expect(readAdditionalTools(globalDir, projectDir)).toBeUndefined();
+  });
+});
+
+describe("withAdditionalTools", () => {
+  function makeRegistry() {
+    return {
+      resolveAgentConfig: (type: string) => ({
+        name: type,
+        displayName: type,
+        description: "",
+        toolNames: ["read", "bash"],
+        systemPrompt: "",
+        promptMode: "append" as const,
+      }),
+      getToolNamesForType: (type: string) =>
+        type.toLowerCase() === "general-purpose" ? ["read", "bash", "edit", "write", "grep", "find", "ls"] : ["read"],
+      resolveType: (name: string) => (name.toLowerCase() === "general-purpose" ? "general-purpose" : undefined),
+    };
+  }
+
+  it("returns the same registry unchanged (passthrough) when config is undefined", () => {
+    const registry = makeRegistry();
+    expect(withAdditionalTools(registry, undefined)).toBe(registry);
+  });
+
+  it("unions '*' and per-type grants into the base list, deduped", () => {
+    const registry = makeRegistry();
+    const wrapped = withAdditionalTools(registry, {
+      "*": ["memory_search", "session_search"],
+      "general-purpose": ["skill_manage", "memory_add", "memory_search"], // memory_search dupes across "*"
+    });
+    expect(wrapped.getToolNamesForType("general-purpose")).toEqual([
+      "read",
+      "bash",
+      "edit",
+      "write",
+      "grep",
+      "find",
+      "ls",
+      "memory_search",
+      "session_search",
+      "skill_manage",
+      "memory_add",
+    ]);
+  });
+
+  it("grants only the '*' entries to a type the registry can't resolve", () => {
+    const registry = makeRegistry();
+    const wrapped = withAdditionalTools(registry, {
+      "*": ["memory_search", "session_search"],
+      "general-purpose": ["skill_manage"],
+    });
+    expect(wrapped.getToolNamesForType("Explore")).toEqual(["read", "memory_search", "session_search"]);
+  });
+
+  it("returns the base list unchanged when neither '*' nor the type has grants", () => {
+    const registry = makeRegistry();
+    const wrapped = withAdditionalTools(registry, { "general-purpose": ["skill_manage"] });
+    expect(wrapped.getToolNamesForType("Explore")).toEqual(["read"]);
+  });
+
+  it("delegates resolveAgentConfig unchanged", () => {
+    const registry = makeRegistry();
+    const wrapped = withAdditionalTools(registry, { "*": ["memory_search"] });
+    expect(wrapped.resolveAgentConfig("general-purpose")).toEqual(registry.resolveAgentConfig("general-purpose"));
+  });
+});


### PR DESCRIPTION
Refs #768

## What

Adds an opt-in `additionalTools` key to `subagents.json`.
It appends tool names to an agent type's resolved allowlist at spawn time, for both the `subagent` tool path and the SDK spawn path (`getSubagentsService().spawn()`).
Keys are agent-type names, case-insensitive, matching `resolveType()`, or `"*"` for every type.
The effective set is `getToolNamesForType(type) ∪ additionalTools["*"] ∪ additionalTools[type]`, deduplicated.
Leaving the key out of `subagents.json` is byte-for-byte identical to today's behavior.
The recursion guard (`excludeTools`) still strips this extension's own three tools even if someone lists them here.

## Why

Issue #768 has the full writeup.
Short version: extension tools are registered inside every child, since children inherit the parent's extensions, but the per-type allowlist drops them anyway.
The documented workaround, naming the tool in an agent's `tools:` frontmatter, has no good home for the three default agents.
Overriding a default with a same-name `.md` file works, but the frontmatter can't express `isDefault`/`toolGuideline`, so the override drops that agent's guideline line from the `subagent` tool description and moves it out of "Default agents:".

## How

`src/index.ts` gains three small exported helpers at the composition root: `sanitizeAdditionalTools`, `readAdditionalTools`, and `withAdditionalTools`.
`readAdditionalTools` runs a second, independently sanitized `loadLayeredSettings` pass over the same `subagents.json` file `SettingsManager` already loads, so it needs no changes to `settings.ts`'s own schema, sanitizer, or snapshot.
`withAdditionalTools` wraps the `AgentConfigLookup` handed to `subagentSessionDeps`, so `assembleSessionConfig`'s single `registry.getToolNamesForType(type)` call sees the extra grants on both spawn paths at once.
I picked this shape because it keeps the change to one file and mirrors how `loadLayeredSettings` is already meant to be used by extensions outside this package, but I'm not attached to it.
If you'd rather this ride through `settings.ts` properly (mirroring `excludedExtensionPackages`, including the snapshot round-trip so a project-level value survives a `/subagents:settings` write), I'm glad to rework it that way instead.

## Testing

`pnpm --filter @gotgenes/pi-subagents check && pnpm --filter @gotgenes/pi-subagents test` passes, including the new `test/additional-tools.test.ts` covering `sanitizeAdditionalTools`, `readAdditionalTools`, and `withAdditionalTools`.
