### PR TITLE
fix(pi-subagents): forward parent modelRuntime to child sessions

### DIFF
--- a/packages/pi-subagents/src/index.ts
+++ b/packages/pi-subagents/src/index.ts
@@ -121,7 +121,19 @@ export default function (pi: ExtensionAPI) {
           ...rest,
           sessionManager: sessionManager as SessionManager,
           resourceLoader: resourceLoader as ResourceLoader,
+          // Pi >=0.80.8 dropped `modelRegistry` from CreateAgentSessionOptions in
+          // favour of `modelRuntime`; passing only `modelRegistry` is silently
+          // ignored, so the child builds a fresh runtime from config + auth and
+          // loses any RUNTIME-registered providers the parent added (e.g.
+          // pi-claude-bridge, registered via pi.registerProvider), which surfaces
+          // as "No API key found for <provider>" inside subagents. Forward the
+          // parent registry's underlying runtime so the child inherits every
+          // provider the parent has. Keep `modelRegistry` for older Pi builds
+          // whose option was still the registry facade.
           modelRegistry: modelRegistry as SdkModelRegistry,
+          ...((modelRegistry as unknown as { runtime?: unknown }).runtime !== undefined
+            ? { modelRuntime: (modelRegistry as unknown as { runtime?: unknown }).runtime as never }
+            : {}),
         }),
       assemblerIO: {
         buildAgentPrompt,


### PR DESCRIPTION
## Problem

When a subagent runs on a provider that was registered at **runtime** via `pi.registerProvider` (rather than from config/auth), the child session fails to resolve it:

```
Error: No API key found for claude-bridge.
```

`pi-claude-bridge` is the common trigger — it registers its provider dynamically (`apiKey: "not-used"`, custom `streamSimple`). Interactive sessions work; every subagent fails.

## Root cause

Pi ≥ 0.80.8 replaced `createAgentSession`'s `modelRegistry` option with `modelRuntime` (`CreateAgentSessionOptions` now exposes only `modelRuntime?: ModelRuntime`). The composition root still passes only `modelRegistry`:

```ts
createSession: ({ sessionManager, resourceLoader, modelRegistry, ...rest }) =>
  createAgentSession({
    ...rest,
    sessionManager: sessionManager as SessionManager,
    resourceLoader: resourceLoader as ResourceLoader,
    modelRegistry: modelRegistry as SdkModelRegistry, // ← ignored by the SDK on ≥0.80.8
  }),
```

Since the SDK ignores `modelRegistry`, each child builds a **fresh** runtime from config + auth, which does not include any runtime-registered providers the parent added. The provider is then unresolvable in the child → "No API key found".

## Fix

Forward the parent registry's underlying `runtime` as `modelRuntime`, so the child inherits every provider the parent has. `modelRegistry` is kept for older Pi builds whose option was still the registry facade. This mirrors the shim in `@tintinweb/pi-subagents` (`agent-runner.ts`), which is why that implementation is unaffected.

```ts
modelRegistry: modelRegistry as SdkModelRegistry,
...((modelRegistry as unknown as { runtime?: unknown }).runtime !== undefined
  ? { modelRuntime: (modelRegistry as unknown as { runtime?: unknown }).runtime as never }
  : {}),
```

`modelRuntime` is the **provider pool**, orthogonal to model *selection* — per-agent `model` (e.g. a haiku `Explore` under an opus parent) is unaffected.

## Testing

On Pi 0.84.3 with stock `pi-claude-bridge` and default model `claude-bridge/claude-opus-4-8`:

- **Before:** any subagent → `No API key found for claude-bridge`.
- **After:** subagents resolve the bridge provider; an `Explore` agent pinned to `claude-bridge/claude-haiku-4-5` runs correctly under an opus parent (confirms model-per-child still works). No prompt-capture regressions.
