### PR TITLE
Dispose AgentWidget during session shutdown (#849)

### DIFF
--- a/packages/pi-subagents/src/handlers/lifecycle.ts
+++ b/packages/pi-subagents/src/handlers/lifecycle.ts
@@ -26,6 +26,7 @@ export interface LifecycleRuntime {
  * Constructor deps:
  * - `runtime` — owns session context state
  * - `manager` — manages agent lifecycle (clear, abort, dispose)
+ * - `disposeWidget` — unregisters the live widget and stops its timer
  * - `disposeNotifications` — tears down the notification system on shutdown
  * - `unpublishService` — unpublishes the SubagentsService symbol on shutdown
  */
@@ -35,6 +36,7 @@ export class SessionLifecycleHandler {
     private readonly manager: LifecycleManager,
     private readonly disposeNotifications: () => void,
     private readonly unpublishService: () => void,
+    private readonly disposeWidget: () => void = () => {},
   ) {}
 
   handleSessionStart(_event: unknown, ctx: unknown): Promise<void> {
@@ -48,15 +50,17 @@ export class SessionLifecycleHandler {
 
   // Cleanup order matters:
   // 1. Unpublish service — prevent new cross-extension calls
-  // 2. Clear session context — no more session state
-  // 3. Dispose notifications — silence nudges *before* the aborts that would
+  // 2. Dispose the widget — unregister UI state and stop its timer while its context is valid
+  // 3. Clear session context — no more session state
+  // 4. Dispose notifications — silence nudges *before* the aborts that would
   //    raise them: no parent run is active at shutdown, so a terminal
   //    transition delivers its nudge synchronously and Pi cannot recall it
-  // 4. Abort all agents — stop running and queued work
-  // 5. Dispose manager — final cleanup, awaited so each child's extensions get
+  // 5. Abort all agents — stop running and queued work
+  // 6. Dispose manager — final cleanup, awaited so each child's extensions get
   //    their `session_shutdown` before Pi tears the parent down (#709)
   handleSessionShutdown(): Promise<void> {
     this.unpublishService();
+    this.disposeWidget();
     this.runtime.clearSessionContext();
     this.disposeNotifications();
     this.manager.abortAll();

--- a/packages/pi-subagents/src/index.ts
+++ b/packages/pi-subagents/src/index.ts
@@ -175,20 +175,22 @@ export default function (pi: ExtensionAPI) {
   const service = new SubagentsServiceAdapter(manager, resolveModel, runtime);
   publishSubagentsService(service);
 
+  // Live widget: constructed after the manager (it polls listAgents()) and
+  // registered as a lifecycle observer so it self-drives its update timer.
+  const widget = new AgentWidget(manager, registry);
+
   const lifecycle = new SessionLifecycleHandler(
     runtime,
     manager,
     () => notifications.dispose(),
     unpublishSubagentsService,
+    () => widget.dispose(),
   );
 
   pi.on("session_start", (event, ctx) => lifecycle.handleSessionStart(event, ctx));
   pi.on("session_before_switch", () => lifecycle.handleSessionBeforeSwitch());
   pi.on("session_shutdown", () => lifecycle.handleSessionShutdown());
 
-  // Live widget: constructed after the manager (it polls listAgents()) and
-  // registered as a lifecycle observer so it self-drives its update timer.
-  const widget = new AgentWidget(manager, registry);
   observer.add(widget);
 
   // Grab UI context from first tool execution + clear lingering widget on new turn

--- a/packages/pi-subagents/test/handlers/lifecycle.test.ts
+++ b/packages/pi-subagents/test/handlers/lifecycle.test.ts
@@ -12,6 +12,7 @@ describe("SessionLifecycleHandler", () => {
   let mockDispose: ReturnType<typeof vi.fn<LifecycleManager["dispose"]>>;
   let mockDisposeNotifications: ReturnType<typeof vi.fn<() => void>>;
   let mockUnpublishService: ReturnType<typeof vi.fn<() => void>>;
+  let mockDisposeWidget: ReturnType<typeof vi.fn<() => void>>;
   let handler: SessionLifecycleHandler;
 
   beforeEach(() => {
@@ -22,6 +23,7 @@ describe("SessionLifecycleHandler", () => {
     mockDispose = vi.fn(() => Promise.resolve());
     mockDisposeNotifications = vi.fn();
     mockUnpublishService = vi.fn();
+    mockDisposeWidget = vi.fn();
 
     runtime = {
       setSessionContext: mockSetSessionContext,
@@ -38,6 +40,7 @@ describe("SessionLifecycleHandler", () => {
       manager,
       mockDisposeNotifications,
       mockUnpublishService,
+      mockDisposeWidget,
     );
   });
 
@@ -112,6 +115,7 @@ describe("SessionLifecycleHandler", () => {
       await handler.handleSessionShutdown();
 
       expect(mockUnpublishService).toHaveBeenCalled();
+      expect(mockDisposeWidget).toHaveBeenCalled();
       expect(mockClearSessionContext).toHaveBeenCalled();
       expect(mockAbortAll).toHaveBeenCalled();
       expect(mockDisposeNotifications).toHaveBeenCalled();
@@ -121,6 +125,7 @@ describe("SessionLifecycleHandler", () => {
     it("calls cleanup in correct order", async () => {
       const callOrder: string[] = [];
       mockUnpublishService.mockImplementation(() => { callOrder.push("unpublishService"); });
+      mockDisposeWidget.mockImplementation(() => { callOrder.push("disposeWidget"); });
       mockClearSessionContext.mockImplementation(() => {
         callOrder.push("clearSessionContext");
       });
@@ -140,6 +145,7 @@ describe("SessionLifecycleHandler", () => {
       // cannot recall a message already handed to it.
       expect(callOrder).toEqual([
         "unpublishService",
+        "disposeWidget",
         "clearSessionContext",
         "disposeNotifications",
         "abortAll",

--- a/packages/pi-subagents/test/ui/agent-widget.test.ts
+++ b/packages/pi-subagents/test/ui/agent-widget.test.ts
@@ -311,6 +311,30 @@ describe("AgentWidget — self-drives from lifecycle notifications", () => {
 		expect(typeof lastContent()).toBe("function");
 	});
 
+	it("disposes the timer and UI registrations", () => {
+		const setWidget = vi.fn<UICtx["setWidget"]>();
+		const setStatus = vi.fn<UICtx["setStatus"]>();
+		const manager = {
+			listAgents: () => [{
+				isBackground: true,
+				id: "a1",
+				status: "running",
+				completedAt: undefined,
+			}],
+		} as unknown as SubagentManager;
+		const widget = new AgentWidget(manager, new AgentTypeRegistry(() => new Map()));
+		widget.setUICtx({ setWidget, setStatus });
+
+		widget.onSubagentStarted(createTestSubagent({ id: "a1", status: "running" }));
+		expect(vi.getTimerCount()).toBe(1);
+
+		widget.dispose();
+
+		expect(vi.getTimerCount()).toBe(0);
+		expect(setWidget).toHaveBeenLastCalledWith("agents", undefined);
+		expect(setStatus).toHaveBeenLastCalledWith("subagents", undefined);
+	});
+
 	it("renders the finished agent on onSubagentCompleted", () => {
 		const { widget, lastContent } = makeWidget([{ id: "a1", status: "completed", completedAt: 5000 }]);
 


### PR DESCRIPTION
## Summary / Problem

Fixes #849.

`AgentWidget` owns a polling interval and UI registrations, but `session_shutdown` never called its existing `dispose()` method. A session could therefore retain the interval and widget/status entries until process exit.

## Changes

- Inject widget disposal into `SessionLifecycleHandler` and call it during shutdown while the UI context is still valid.
- Wire the composition root to dispose the live `AgentWidget`.
- Add lifecycle-order and timer/UI-registration regression tests.

## Tests

- `pnpm --filter @gotgenes/pi-subagents run check` — passed.
- `pnpm --filter @gotgenes/pi-subagents run test -- test/handlers/lifecycle.test.ts test/ui/agent-widget.test.ts` — 35 passed.
- `pnpm --filter @gotgenes/pi-subagents run test` — 1346 passed, 4 failed. The failures are existing Windows path-separator expectations in `test/session/session-dir.test.ts` and `test/composition-root.test.ts`.
- `pnpm --filter @gotgenes/pi-subagents run lint` — Biome and ESLint passed; the Markdown subcommand could not expand `*.md` on Windows.
- `git diff --check` — passed.

## Compatibility / Known limitations

The lifecycle constructor keeps a no-op default for callers that do not provide a widget. Full-suite and Markdown-lint limitations are environment-specific and are recorded above.

## Issue link

Fixes #849
