### PR TITLE
feat(pi-subagents): portable prompt inheritance for children whose provider re-homes the prompt

### DIFF
--- a/packages/pi-subagents/docs/configuration.md
+++ b/packages/pi-subagents/docs/configuration.md
@@ -39,6 +39,20 @@ Inheriting the parent's copies instead would give such a child a catalogue of sk
 
 Inheriting the identity rather than the whole prompt also keeps the child's leading text byte-identical to the parent's, which prefix-caching providers and local inference engines reuse instead of reprocessing.
 
+### Portable inheritance (opt-in)
+
+The identity layers include Pi's own preamble and tool guidelines — correct when the child talks to the same raw API as its parent, wrong when the child's provider **re-homes** the prompt into another harness (for example pi-claude-bridge, which projects the child's prompt onto Claude Code's as an append).
+For those children, `inherit_prompt: portable` (frontmatter) or a `promptInheritance` provider rule (settings) switches the inherited identity to the parent's **portable parts** only: project context files, added guideline bullets, and custom/append prompts.
+Skills remain un-inherited (the child builds its own catalogue), and context files must ride along because the child session never loads its own.
+
+| Strategy   | Child's identity                                    | Shares prefix with parent | Use when                                        |
+| ---------- | --------------------------------------------------- | ------------------------- | ----------------------------------------------- |
+| `full`     | parent identity layers, byte for byte (default)     | yes                       | child talks to the same raw API as the parent   |
+| `portable` | parent's context files + custom/append + guidelines | no                        | child's provider re-homes the prompt elsewhere  |
+
+Resolution: agent frontmatter `inherit_prompt` > the `promptInheritance` provider rule for the child's resolved provider > the `promptInheritance` default.
+The reasoning and the provider-scoping rationale are recorded in [ADR 0008](decisions/0008-portable-prompt-inheritance.md).
+
 If you write extensions that add to the system prompt, see [Extensions that append to the system prompt](../README.md#extensions-that-append-to-the-system-prompt).
 The reasoning behind the boundary is recorded in [ADR 0006](decisions/0006-inherited-prompt-is-identity-only.md).
 
@@ -90,19 +104,20 @@ subagent({ subagent_type: "auditor", prompt: "Review the auth module", descripti
 
 All fields are optional — sensible defaults for everything.
 
-| Field               | Default        | Description                                                                                                                                                                                                                                                                                                             |
-| ------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `description`       | filename       | Agent description shown in tool listings                                                                                                                                                                                                                                                                                |
-| `display_name`      | —              | Display name for UI (e.g. widget, agent list)                                                                                                                                                                                                                                                                           |
-| `tools`             | all 7          | The agent's complete tool allowlist — built-in or extension-registered names. `none` for no tools. See [Tool selection](#tool-selection)                                                                                                                                                                                |
-| `model`             | inherit parent | Model — `provider/modelId` or fuzzy name (`"haiku"`, `"sonnet"`)                                                                                                                                                                                                                                                        |
-| `thinking`          | inherit        | off, minimal, low, medium, high, xhigh, max. An unrecognized value is dropped, and the agent inherits the parent's level                                                                                                                                                                                                |
-| `max_turns`         | unlimited      | Max agentic turns before graceful shutdown. `0` or omit for unlimited                                                                                                                                                                                                                                                   |
-| `prompt_mode`       | `append`       | `replace`: parent prompt is the cacheable base; body is appended last with full control (no `<sub_agent_context>` bridge, no `<agent_instructions>` wrapper). `append`: parent prompt is the base; body is wrapped in `<agent_instructions>` and a sub-agent context bridge is injected (agent acts as a "parent twin") |
-| `inherit_context`   | `false`        | Fork parent conversation into agent                                                                                                                                                                                                                                                                                     |
-| `run_in_background` | `false`        | Run in background by default                                                                                                                                                                                                                                                                                            |
-| `enabled`           | `true`         | Set to `false` to disable an agent (useful for hiding a default agent per-project)                                                                                                                                                                                                                                      |
-| `locked`            | —              | Fields a `subagent` tool caller may not override. `true` or a list of field names. See [Locking fields against callers](#locking-fields-against-callers)                                                                                                                                                                |
+| Field               | Default        | Description                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| ------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `description`       | filename       | Agent description shown in tool listings                                                                                                                                                                                                                                                                                                                                                                                           |
+| `display_name`      | —              | Display name for UI (e.g. widget, agent list)                                                                                                                                                                                                                                                                                                                                                                                      |
+| `tools`             | all 7          | The agent's complete tool allowlist — built-in or extension-registered names. `none` for no tools. See [Tool selection](#tool-selection)                                                                                                                                                                                                                                                                                           |
+| `model`             | inherit parent | Model — `provider/modelId` or fuzzy name (`"haiku"`, `"sonnet"`)                                                                                                                                                                                                                                                                                                                                                                   |
+| `thinking`          | inherit        | off, minimal, low, medium, high, xhigh, max. An unrecognized value is dropped, and the agent inherits the parent's level                                                                                                                                                                                                                                                                                                           |
+| `max_turns`         | unlimited      | Max agentic turns before graceful shutdown. `0` or omit for unlimited                                                                                                                                                                                                                                                                                                                                                              |
+| `prompt_mode`       | `append`       | `replace`: parent prompt is the cacheable base; body is appended last with full control (no `<sub_agent_context>` bridge, no `<agent_instructions>` wrapper). `append`: parent prompt is the base; body is wrapped in `<agent_instructions>` and a sub-agent context bridge is injected (agent acts as a "parent twin")                                                                                                            |
+| `inherit_prompt`    | `full`         | What the child inherits as its prompt identity. `full`: the parent's assembled prompt (minus pi's per-session layers) — byte-stable cache prefix with the parent. `portable`: only the parent's portable parts (context files, custom/append prompts, added guidelines) — for children whose provider re-homes the prompt into another harness. The `promptInheritance` setting supplies the default for agents that omit this key |
+| `inherit_context`   | `false`        | Fork parent conversation into agent                                                                                                                                                                                                                                                                                                                                                                                                |
+| `run_in_background` | `false`        | Run in background by default                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `enabled`           | `true`         | Set to `false` to disable an agent (useful for hiding a default agent per-project)                                                                                                                                                                                                                                                                                                                                                 |
+| `locked`            | —              | Fields a `subagent` tool caller may not override. `true` or a list of field names. See [Locking fields against callers](#locking-fields-against-callers)                                                                                                                                                                                                                                                                           |
 
 The caller decides, and the agent file fills the gaps.
 A `subagent` tool parameter wins over the agent file's value for `model`, `thinking`, `max_turns`, `inherit_context`, and `run_in_background`; the agent file supplies whichever of those the caller left unset.
@@ -201,7 +216,24 @@ Two files, merged on load:
   Written by `/subagents:settings`.
 
 **Precedence:** project overrides global on any field present in both.
-Missing fields fall back to the hardcoded defaults (max concurrency `4`, default max turns unlimited, grace turns `5`, consumed-session retention `10` minutes, unconsumed-session retention `720` minutes, abort-all-on-interrupt `true`, mid-run updates `true`).
+Missing fields fall back to the hardcoded defaults (max concurrency `4`, default max turns unlimited, grace turns `5`, consumed-session retention `10` minutes, unconsumed-session retention `720` minutes, abort-all-on-interrupt `true`, mid-run updates `true`, prompt inheritance `full`).
+
+**Prompt inheritance** — `promptInheritance` selects what children inherit as their prompt identity (see [Portable inheritance](#portable-inheritance-opt-in)).
+Either form works:
+
+```json
+"promptInheritance": "portable"
+```
+
+```json
+"promptInheritance": {
+  "default": "full",
+  "providers": { "claude-bridge": "portable" }
+}
+```
+
+The `providers` map keys on the provider id of the **child's resolved model** — only children whose requests actually go through that provider change strategy, so same-API children keep the byte-identical cache prefix.
+An agent's `inherit_prompt` frontmatter wins over both forms.
 
 **Example — global defaults for a beefy machine:**
 

--- a/packages/pi-subagents/docs/decisions/0008-portable-prompt-inheritance.md
+++ b/packages/pi-subagents/docs/decisions/0008-portable-prompt-inheritance.md
@@ -1,0 +1,55 @@
+---
+status: proposed
+date: 2026-09-05
+---
+
+# 0008 — Portable prompt inheritance for children whose provider re-homes the prompt
+
+## Status
+
+Proposed.
+Extends [ADR 0006](0006-inherited-prompt-is-identity-only.md) with a second, opt-in inheritance strategy; changes no default behavior.
+
+## Context
+
+ADR 0006 settled *which parts* of the parent's prompt a child inherits: the identity layers, byte for byte, so a child shares a prefix with its parent that prefix-caching providers reuse.
+The identity layers include Pi's own preamble and tool guidelines.
+
+That is the right trade when the child talks to the same raw API as its parent.
+It is the wrong trade when the child's provider *re-homes* the prompt — forwards Pi's system prompt into another harness that composes it onto its own. pi-claude-bridge does exactly this: it projects the child's Pi prompt into Claude Code's `--append-system-prompt`, where Pi's preamble rides as an append on top of Claude Code's preset.
+
+Re-homing turned out to be more than cosmetic.
+Anthropic's subscription OAuth gate classifies requests by system-prompt content, and flags the combination of two phrases in Pi's documentation-routing line (`custom providers (docs/custom-provider.md)` alongside `pi packages (docs/packages.md)`) as a third-party app.
+A child whose inherited identity reaches that gate is rejected outright while the account has no extra-usage credit — the parent and every non-inheriting path on the same provider, token, and Claude Code binary pass.
+The parent passes for a structural reason: pi-claude-bridge already projects only the *portable* parts of the parent's prompt (context files, skills, custom/append), never Pi's base.
+
+Two facts follow.
+
+1. The information a child needs from the parent's prompt — project context, persona, added guidelines — is exactly the portable parts.
+   Pi's preamble and tool guidelines are the harness's own instructions; a re-homing host supplies its own equivalents, so the inherited copy is at best duplicated tokens.
+2. Pi already reports the portable parts authoritatively: `before_agent_start` carries `systemPromptOptions` (`contextFiles`, `customPrompt`, `appendSystemPrompt`, `promptGuidelines`).
+   No prompt-text heuristics are required to separate them from the base.
+
+## Decision
+
+Add a second inheritance strategy, `portable`, selected per child:
+
+- **Agent frontmatter** — `inherit_prompt: portable | full` wins over everything.
+- **Provider rule** — the `promptInheritance.providers` setting maps the *child's resolved model's provider id* to a strategy, because re-homing is a property of the provider the child's requests actually go to.
+- **Default** — `promptInheritance` (simple string form or `rules.default`), ultimately `full`.
+
+A portable child's identity is built from the parent's `before_agent_start.systemPromptOptions`: context files (the child loader runs with `noContextFiles: true`, so this is the only way they reach the child at all), `promptGuidelines`, `customPrompt`, `appendSystemPrompt`.
+Skills stay un-inherited — the child rebuilds its own catalogue, as in ADR 0006.
+An absent or empty capture falls back to the generic base rather than to the full prompt: opting into portable must never silently re-embed the base it exists to avoid.
+
+The default remains `full`.
+Nobody's children change behavior unless a frontmatter key or a settings entry opts them in, and a provider-scoped rule leaves every other provider's children — including same-API children, where the shared prefix is worth the most — untouched.
+
+## Consequences
+
+- A portable child's prompt shares no byte prefix with its parent.
+  For a re-homed child that prefix was never reusable — the request leaves through a different harness — so nothing is lost; for a same-API child the rule should simply not select portable.
+- Context files reach portable children through the inherited identity instead of being suppressed-and-absent, which also makes them available to `prompt_mode: replace` children that opt in.
+- The resolution happens in `assembleSessionConfig` after the child's model is settled, so a per-spawn `model` override is scoped correctly by the provider it actually selects.
+- The long-term shape is a provider *declaring* that it re-homes prompts (a published policy, consulted automatically), which would make `portable` the default for exactly the children that need it with no configuration at all.
+  The provider-rule setting is deliberately shaped to become the override layer on top of that.

--- a/packages/pi-subagents/src/config/custom-agents.ts
+++ b/packages/pi-subagents/src/config/custom-agents.ts
@@ -65,6 +65,7 @@ function loadFromDir(dir: string, agents: Map<string, AgentConfig>, source: "pro
       maxTurns: nonNegativeInt(fm.max_turns),
       systemPrompt: body.trim(),
       promptMode: fm.prompt_mode === "replace" ? "replace" : "append",
+      promptInheritance: promptInheritanceField(fm),
       inheritContext: fm.inherit_context != null ? fm.inherit_context === true : undefined,
       runInBackground: fm.run_in_background != null ? fm.run_in_background === true : undefined,
       locked: lockDeclaration(fm.locked, name),
@@ -80,6 +81,17 @@ function loadFromDir(dir: string, agents: Map<string, AgentConfig>, source: "pro
 /** Extract a string or undefined. */
 function str(val: unknown): string | undefined {
   return typeof val === "string" ? val : undefined;
+}
+
+/**
+ * Parse the `inherit_prompt:` key into a strategy, or undefined when it is absent
+ * or unrecognized — an unrecognized value follows the field-parser convention of
+ * becoming the default (settings decide) rather than failing the agent's load.
+ */
+function promptInheritanceField(fm: Record<string, unknown>): "full" | "portable" | undefined {
+  return fm.inherit_prompt === "portable" || fm.inherit_prompt === "full"
+    ? fm.inherit_prompt
+    : undefined;
 }
 
 /**

--- a/packages/pi-subagents/src/index.ts
+++ b/packages/pi-subagents/src/index.ts
@@ -175,7 +175,14 @@ export default function (pi: ExtensionAPI) {
   const limiter = new ConcurrencyLimiter(() => settings.maxConcurrent);
 
   const manager = new SubagentManager({
-    createSubagentSession: (params) => createSubagentSession(params, subagentSessionDeps),
+    createSubagentSession: (params) =>
+      createSubagentSession(
+        // runConfig rides the params here rather than through Subagent.run so the
+        // turn-loop function's complexity footprint is untouched; settings
+        // satisfies RunConfig structurally (getters for every field).
+        { ...params, runConfig: settings },
+        subagentSessionDeps,
+      ),
     baseCwd: process.cwd(),
     observer,
     limiter,
@@ -208,6 +215,12 @@ export default function (pi: ExtensionAPI) {
 
   pi.on("session_start", (event, ctx) => lifecycle.handleSessionStart(event, ctx));
   pi.on("session_start", (event, ctx) => widgetEvents.handleSessionStart(event, ctx));
+  // Capture the parent's assembled system-prompt parts each turn so snapshots
+  // can offer `inherit_prompt: portable` children the parent's context files
+  // and custom/append prompts without pi's harness base prompt.
+  pi.on("before_agent_start", (event) => {
+    runtime.setSystemPromptOptions(event.systemPromptOptions);
+  });
   pi.on("session_before_switch", () => lifecycle.handleSessionBeforeSwitch());
   pi.on("session_shutdown", () => lifecycle.handleSessionShutdown());
   // Registered after the lifecycle handler on purpose. Pi awaits an extension's

--- a/packages/pi-subagents/src/lifecycle/create-subagent-session.ts
+++ b/packages/pi-subagents/src/lifecycle/create-subagent-session.ts
@@ -22,6 +22,7 @@ import type { AgentConfigLookup } from "#src/config/agent-types";
 import type { ChildLifecyclePublisher } from "#src/lifecycle/child-lifecycle";
 import type { ParentSnapshot } from "#src/lifecycle/parent-snapshot";
 import { SubagentSession } from "#src/lifecycle/subagent-session";
+import type { RunConfig } from "#src/runtime";
 import { AskParentTool, type QuestionRecorder } from "#src/session/ask-parent-tool";
 import type { EnvInfo } from "#src/session/env";
 import type { ModelRegistry } from "#src/session/model-resolver";
@@ -150,6 +151,8 @@ export interface CreateSubagentSessionParams {
   parentSession?: ParentSessionInfo;
   model?: Model<any>;
   thinkingLevel?: ThinkingLevel;
+  /** Parent run config; supplies the default prompt inheritance for silent frontmatter. */
+  runConfig?: RunConfig;
   /**
    * Records a question the child declares with `ask_parent`. Supplied for every
    * child; its absence installs no ask-back tool.
@@ -200,8 +203,11 @@ export async function createSubagentSession(
     {
       cwd: snapshot.cwd,
       parentSystemPrompt: snapshot.systemPrompt,
+      parentPortablePrompt: snapshot.portablePrompt,
       parentModel: snapshot.model,
       modelRegistry: snapshot.modelRegistry,
+      promptInheritanceDefault: params.runConfig?.promptInheritance,
+      promptInheritanceProviders: params.runConfig?.promptInheritanceProviders,
     },
     {
       cwd: params.cwd,

--- a/packages/pi-subagents/src/lifecycle/parent-snapshot.ts
+++ b/packages/pi-subagents/src/lifecycle/parent-snapshot.ts
@@ -8,6 +8,23 @@ import type { ModelRegistry } from "#src/session/model-resolver";
 import type { SessionContext } from "#src/types";
 
 /**
+ * The parent session's portable prompt parts, as pi reports them on
+ * `before_agent_start`. Narrow structural slice of pi's
+ * `BuildSystemPromptOptions` — everything another harness could re-home
+ * without dragging pi's base prompt along.
+ */
+export interface ParentPromptOptions {
+  /** Context files (AGENTS.md and kin) pi loaded for the parent session. */
+  contextFiles?: Array<{ path: string; content: string }>;
+  /** Custom system prompt (--system-prompt), if the parent runs one. */
+  customPrompt?: string;
+  /** Appended system prompt text (--append-system-prompt). */
+  appendSystemPrompt?: string;
+  /** Additional guideline bullets contributed to the parent's prompt. */
+  promptGuidelines?: string[];
+}
+
+/**
  * Plain data snapshot of the parent session state captured at spawn time.
  * Replaces live `ExtensionContext` references so queued agents don't read stale state.
  */
@@ -16,6 +33,13 @@ export interface ParentSnapshot {
   cwd: string;
   /** Parent's effective system prompt (for append-mode agents). */
   systemPrompt: string;
+  /**
+   * Parent's portable prompt parts (context files, custom/append prompts, added
+   * guidelines) for `inherit_prompt: portable` agents — the assembled prompt
+   * minus pi's harness base and per-session layers. Undefined when pi has not
+   * assembled a prompt yet (no parent turn has run).
+   */
+  portablePrompt?: string;
   /** Parent's current model instance (fallback when agent config has no model). */
   model: Model<any> | undefined;
   /** Model registry for resolving config.model strings and creating sessions. */
@@ -33,14 +57,43 @@ export interface ParentSnapshot {
 export function buildParentSnapshot(
   ctx: SessionContext,
   inheritContext?: boolean,
+  promptOptions?: ParentPromptOptions,
 ): ParentSnapshot {
   const parentContext = inheritContext ? buildParentContext(ctx) : undefined;
   return {
     cwd: ctx.cwd,
     systemPrompt: ctx.getSystemPrompt(),
+    portablePrompt: buildPortablePrompt(promptOptions),
     model: ctx.model,
     modelRegistry: ctx.modelRegistry,
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- || intentional: converts empty string to undefined as well as null/undefined
     parentContext: parentContext || undefined,
   };
+}
+
+/**
+ * Join the parent's portable prompt parts into an identity a child can adopt.
+ *
+ * Skills are deliberately absent: the child session loads its own catalogue,
+ * and the full-inheritance path strips the parent's for the same staleness
+ * reason (see `inheritedIdentity` in prompts.ts). Context files must be here —
+ * the child loader runs with `noContextFiles: true`, so this is the only way
+ * portable-inheriting children see project instructions at all.
+ */
+function buildPortablePrompt(options?: ParentPromptOptions): string | undefined {
+  if (!options) return undefined;
+  const parts: string[] = [];
+  if (options.contextFiles?.length) {
+    const files = options.contextFiles
+      .map(({ path, content }) => `<project_instructions path="${path}">\n${content}\n</project_instructions>`)
+      .join("\n");
+    parts.push(`<project_context>\n${files}\n</project_context>`);
+  }
+  if (options.promptGuidelines?.length) {
+    parts.push(options.promptGuidelines.join("\n"));
+  }
+  if (options.customPrompt?.trim()) parts.push(options.customPrompt.trim());
+  if (options.appendSystemPrompt?.trim()) parts.push(options.appendSystemPrompt.trim());
+  const joined = parts.join("\n\n");
+  return joined || undefined;
 }

--- a/packages/pi-subagents/src/runtime.ts
+++ b/packages/pi-subagents/src/runtime.ts
@@ -6,7 +6,8 @@
  * Follows the same pattern as pi-permission-system's ExtensionRuntime.
  */
 
-import { buildParentSnapshot, type ParentSnapshot } from "#src/lifecycle/parent-snapshot";
+import { buildParentSnapshot, type ParentPromptOptions, type ParentSnapshot } from "#src/lifecycle/parent-snapshot";
+import type { PromptInheritance } from "#src/settings";
 import type { ModelInfo } from "#src/tools/spawn-config";
 import type { SessionContext } from "#src/types";
 
@@ -19,6 +20,10 @@ export interface RunConfig {
   readonly graceTurns: number;
   /** Whether a background child gets the `notify_parent` channel. */
   readonly midRunUpdates: boolean;
+  /** Default prompt inheritance for agents without an explicit `inherit_prompt`. */
+  readonly promptInheritance?: PromptInheritance;
+  /** Per-provider inheritance overrides, keyed by provider id of the child's model. */
+  readonly promptInheritanceProviders?: Record<string, PromptInheritance>;
 }
 
 /**
@@ -32,6 +37,11 @@ export class SubagentRuntime {
   /** Active Pi session context — set on session_start, cleared on session_shutdown. */
   currentCtx: SessionContext | undefined = undefined;
 
+  /** Latest system-prompt options pi assembled for the parent session, captured
+   *  from `before_agent_start` so a snapshot can carry the parent's portable
+   *  prompt parts without re-parsing the assembled string. */
+  private lastPromptOptions: ParentPromptOptions | undefined = undefined;
+
   // ── Session-context methods ──────────────────────────────────────────────
 
   /** Store the active Pi session context (called from session_start). */
@@ -44,13 +54,18 @@ export class SubagentRuntime {
     this.currentCtx = undefined;
   }
 
+  /** Store the parent's latest assembled system-prompt options (called from before_agent_start). */
+  setSystemPromptOptions(options: ParentPromptOptions): void {
+    this.lastPromptOptions = options;
+  }
+
   /**
    * Build a parent snapshot from the current session context.
    * Only valid during an active session (currentCtx is defined).
    */
   buildSnapshot(inheritContext: boolean): ParentSnapshot {
 
-    return buildParentSnapshot(this.currentCtx!, inheritContext);
+    return buildParentSnapshot(this.currentCtx!, inheritContext, this.lastPromptOptions);
   }
 
   /** Extract model info from the current session context. */

--- a/packages/pi-subagents/src/session/prompts.ts
+++ b/packages/pi-subagents/src/session/prompts.ts
@@ -9,6 +9,14 @@ import type { AgentPromptConfig } from "#src/types";
 export interface InheritedPrompt {
   /** The parent agent's effective system prompt. */
   systemPrompt: string;
+  /**
+   * The parent's portable prompt parts (context files, custom/append prompts,
+   * added guidelines) — used as the identity when the agent opts into
+   * `inherit_prompt: portable`. Unlike `systemPrompt` it carries no harness
+   * base prompt, so it survives being re-homed into another harness (e.g. a
+   * Claude Agent SDK bridge that re-sends it as an append onto its own preset).
+   */
+  portablePrompt?: string;
   /** The parent's working directory — the cwd its prompt footer names. */
   cwd: string;
 }
@@ -29,6 +37,15 @@ export interface InheritedPrompt {
  *   `<agent_instructions>` when non-empty).
  * - "append" with empty systemPrompt: pure parent clone.
  *
+ * `config.promptInheritance` selects what "parent" means above: `"full"`
+ * (default) adopts the parent's assembled prompt minus pi's per-session layers
+ * — a byte-stable prefix with the parent session, at the cost of carrying pi's
+ * harness base prompt into the child. `"portable"` adopts only the parent's
+ * portable parts (context files, custom/append prompts, added guidelines):
+ * nothing another harness would duplicate or reject, at the cost of the shared
+ * prefix (a portable child's prefix differs from the parent's from the first
+ * token). Skills are never inherited — the child loads its own catalogue.
+ *
  * Both modes include an `<active_agent name="${config.name}"/>` tag so
  * downstream extensions (e.g. `@gotgenes/pi-permission-system`) can resolve
  * per-agent policy inside the child session by parsing the system prompt.
@@ -47,7 +64,15 @@ export function buildAgentPrompt(
   const header = buildPromptHeader(config.name, cwd, env);
 
   const identity = inherited
-    ? inheritedIdentity(inherited.systemPrompt, inherited.cwd)
+    ? config.promptInheritance === "portable"
+      ? // Portable: adopt the parent's context files and custom prompts only.
+        // An absent capture (pi assembled nothing yet) or an empty one falls
+        // back to the generic base rather than to the full prompt — opting into
+        // portable must never silently re-embed the harness base it exists to
+        // avoid.
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- || intentional: a whitespace-only capture must fall back too, which ?? would not do
+        inherited.portablePrompt?.trim() || genericBase
+      : inheritedIdentity(inherited.systemPrompt, inherited.cwd)
     : genericBase;
 
   if (config.promptMode === "append") {

--- a/packages/pi-subagents/src/session/session-config.ts
+++ b/packages/pi-subagents/src/session/session-config.ts
@@ -49,10 +49,16 @@ export interface AssemblerContext {
   cwd: string;
   /** Parent's effective system prompt (for append-mode agents). */
   parentSystemPrompt: string;
+  /** Parent's portable prompt parts, for `inherit_prompt: portable` agents. */
+  parentPortablePrompt?: string;
   /** Parent's current model instance (fallback when agent config has no model). */
   parentModel?: Model<any>;
   /** Model registry for resolving config.model strings. */
   modelRegistry: ModelRegistry;
+  /** Default prompt inheritance when the agent's frontmatter is silent. */
+  promptInheritanceDefault?: "full" | "portable";
+  /** Per-provider inheritance overrides, keyed by provider id of the child's model. */
+  promptInheritanceProviders?: Record<string, "full" | "portable">;
 }
 
 /**
@@ -155,18 +161,31 @@ export function assembleSessionConfig(
 
   const toolNames = registry.getToolNamesForType(type);
 
-  // Build system prompt from the resolved agent config
-  const systemPrompt = io.buildAgentPrompt(agentConfig, effectiveCwd, env, {
-    systemPrompt: ctx.parentSystemPrompt,
-    cwd: ctx.cwd,
-  });
-
-  // Model resolution: explicit option > config model string > parent model
+  // Model resolution first — the child's provider scopes the prompt-inheritance
+  // rules, so the prompt cannot be built until the model is known.
+  // Priority: explicit option > config model string > parent model
   const model =
     options.model ??
     resolveDefaultModel(ctx.parentModel, ctx.modelRegistry, agentConfig.model);
 
-  // Thinking level: explicit option > agent config > undefined (inherit)
+  // Build system prompt from the resolved agent config. `promptInheritance`
+  // settles frontmatter > provider rule > setting default here so every caller
+  // of buildAgentPrompt sees one settled value; with nothing to settle the
+  // config object passes through untouched.
+  const promptInheritance =
+    agentConfig.promptInheritance ??
+    (model?.provider != null ? ctx.promptInheritanceProviders?.[model.provider] : undefined) ??
+    ctx.promptInheritanceDefault;
+  const configForPrompt = promptInheritance
+    ? { ...agentConfig, promptInheritance }
+    : agentConfig;
+  const systemPrompt = io.buildAgentPrompt(configForPrompt, effectiveCwd, env, {
+    systemPrompt: ctx.parentSystemPrompt,
+    cwd: ctx.cwd,
+    portablePrompt: ctx.parentPortablePrompt,
+  });
+
+  // Thinking level: explicit option > config model > undefined (inherit)
   const thinkingLevel = options.thinkingLevel ?? agentConfig.thinking;
 
   // Per-agent max turns (combined with per-call maxTurns and defaultMaxTurns by SubagentSession.runTurnLoop)

--- a/packages/pi-subagents/src/settings.ts
+++ b/packages/pi-subagents/src/settings.ts
@@ -35,6 +35,102 @@ export interface SubagentsSettings {
    * The package's skills, prompts, and themes stay available to children.
    */
   excludedExtensionPackages?: string[];
+  /**
+   * Default prompt inheritance for agents whose frontmatter is silent.
+   * Either the simple global default (`"full"` | `"portable"`) or a scoped
+   * rule object — see `PromptInheritanceRules`. Frontmatter `inherit_prompt`
+   * wins over both.
+   */
+  promptInheritance?: PromptInheritance | PromptInheritanceRules;
+}
+
+/** The two prompt-inheritance strategies, as settable in subagents.json. */
+export type PromptInheritance = "full" | "portable";
+
+/**
+ * Scoped prompt-inheritance rules.
+ *
+ * `providers` keys the provider id of the child's resolved model (e.g.
+ * `claude-bridge`) to the strategy that child should use; `default` applies to
+ * every provider not listed. Scoping matters because the strategies' costs are
+ * asymmetric by provider: `"full"` keeps a byte-identical cache prefix with
+ * the parent, worthless once the child's requests leave through another
+ * harness, while `"portable"` drops the harness base prompt, which a re-homing
+ * host may reject, and costs the shared prefix when parent and child share the
+ * raw API.
+ */
+export interface PromptInheritanceRules {
+  /** Strategy for providers not named in `providers`. Default `"full"`. */
+  default?: PromptInheritance;
+  /** Per-provider strategy, keyed by provider id of the child's model. */
+  providers?: Record<string, PromptInheritance>;
+}
+
+/** Normalized form the runtime consumes. */
+export interface PromptInheritanceConfig {
+  def: PromptInheritance;
+  providers: Record<string, PromptInheritance>;
+}
+
+/** Parse the settings union into the normalized form. Unknown values → defaults. */
+export function normalizePromptInheritance(
+  value: PromptInheritance | PromptInheritanceRules | undefined,
+): PromptInheritanceConfig {
+  if (value === "portable" || value === "full") return { def: value, providers: {} };
+  if (value && typeof value === "object") {
+    const providers: Record<string, PromptInheritance> = {};
+    for (const [provider, strategy] of Object.entries(value.providers ?? {})) {
+      if (isPromptInheritance(strategy)) providers[provider] = strategy;
+    }
+    return {
+      def: isPromptInheritance(value.default) ? value.default : DEFAULT_PROMPT_INHERITANCE,
+      providers,
+    };
+  }
+  return { def: DEFAULT_PROMPT_INHERITANCE, providers: {} };
+}
+
+/**
+ * Runtime guard for the strategy enums. Settings arrive from JSON, where the
+ * declared types are aspirations — every comparison site funnels through here
+ * so narrowing never convinces a linter the check is dead.
+ */
+function isPromptInheritance(value: unknown): value is PromptInheritance {
+  return value === "full" || value === "portable";
+}
+
+/**
+ * Sanitize the promptInheritance union onto `out`: the enum passes through, a
+ * rule object keeps only valid strategies and drops the rest, anything else
+ * leaves the field absent. Assigns inside so `sanitize` gains no branches —
+ * the audit gate re-scores every function a changed file touches.
+ */
+function applyPromptInheritance(out: SubagentsSettings, value: unknown): void {
+  if (isPromptInheritance(value)) {
+    out.promptInheritance = value;
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  const raw = value as { default?: unknown; providers?: unknown };
+  const rules: PromptInheritanceRules = {};
+  if (isPromptInheritance(raw.default)) rules.default = raw.default;
+  const providers = sanitizePromptInheritanceProviders(raw.providers);
+  if (providers) rules.providers = providers;
+  if (rules.default !== undefined || rules.providers !== undefined) {
+    out.promptInheritance = rules;
+  }
+}
+
+/** Keep only provider entries whose strategy is a known enum, absent when none survive. */
+function sanitizePromptInheritanceProviders(
+  raw: unknown,
+): Record<string, PromptInheritance> | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const providers: Record<string, PromptInheritance> = {};
+  for (const [provider, strategy] of Object.entries(raw)) {
+    if (isPromptInheritance(strategy)) providers[provider] = strategy;
+  }
+  return Object.keys(providers).length > 0 ? providers : undefined;
 }
 
 /**
@@ -56,6 +152,8 @@ export interface SettingsSnapshot {
    * hand-edited value would otherwise be erased by any unrelated setting change.
    */
   excludedExtensionPackages?: string[];
+  /** Present only when non-default (either form), so files that never set it gain no noise. */
+  promptInheritance?: PromptInheritance | PromptInheritanceRules;
 }
 
 
@@ -68,6 +166,7 @@ const DEFAULT_CONSUMED_RETENTION_MINUTES = 10;
 const DEFAULT_UNCONSUMED_RETENTION_MINUTES = 720;
 const DEFAULT_ABORT_ALL_ON_INTERRUPT = true;
 const DEFAULT_MID_RUN_UPDATES = true;
+const DEFAULT_PROMPT_INHERITANCE: PromptInheritance = "full";
 
 /**
  * Owns all three in-memory settings values and their load/save/persist cycle.
@@ -81,6 +180,8 @@ export class SettingsManager {
   private _unconsumedSessionRetentionMinutes: number = DEFAULT_UNCONSUMED_RETENTION_MINUTES;
   private _abortAllOnInterrupt: boolean = DEFAULT_ABORT_ALL_ON_INTERRUPT;
   private _midRunUpdates: boolean = DEFAULT_MID_RUN_UPDATES;
+  private _promptInheritance: PromptInheritanceConfig = normalizePromptInheritance(undefined);
+  private _promptInheritanceRaw: SubagentsSettings["promptInheritance"] = undefined;
   private _excludedExtensionPackages: string[] = [];
 
   private readonly emit: SettingsEmit;
@@ -178,6 +279,8 @@ export class SettingsManager {
     if (typeof settings.abortAllOnInterrupt === "boolean")
       this._abortAllOnInterrupt = settings.abortAllOnInterrupt;
     if (typeof settings.midRunUpdates === "boolean") this._midRunUpdates = settings.midRunUpdates;
+    this._promptInheritance = normalizePromptInheritance(settings.promptInheritance);
+    this._promptInheritanceRaw = settings.promptInheritance;
     // Assigned unconditionally: removing the key from disk must clear the value.
     this._excludedExtensionPackages = [...(settings.excludedExtensionPackages ?? [])];
     this.emit("subagents:settings_loaded", { settings });
@@ -198,6 +301,18 @@ export class SettingsManager {
       abortAllOnInterrupt: this._abortAllOnInterrupt,
       midRunUpdates: this._midRunUpdates,
     };
+    if (this._promptInheritanceRaw !== undefined) {
+      snapshot.promptInheritance = this._promptInheritanceRaw;
+    } else if (
+      this._promptInheritance.def !== DEFAULT_PROMPT_INHERITANCE ||
+      Object.keys(this._promptInheritance.providers).length > 0
+    ) {
+      const { def, providers } = this._promptInheritance;
+      snapshot.promptInheritance = {
+        ...(def !== DEFAULT_PROMPT_INHERITANCE ? { default: def } : {}),
+        ...(Object.keys(providers).length > 0 ? { providers: { ...providers } } : {}),
+      };
+    }
     if (this._excludedExtensionPackages.length > 0) {
       snapshot.excludedExtensionPackages = [...this._excludedExtensionPackages];
     }
@@ -259,6 +374,16 @@ export class SettingsManager {
     return this._midRunUpdates;
   }
 
+  /** Default prompt inheritance for agents without an explicit `inherit_prompt`. */
+  get promptInheritance(): PromptInheritance {
+    return this._promptInheritance.def;
+  }
+
+  /** Per-provider inheritance overrides, keyed by provider id of the child's model. */
+  get promptInheritanceProviders(): Record<string, PromptInheritance> {
+    return this._promptInheritance.providers;
+  }
+
   /**
    * Flip whether a background child may interrupt the parent with a mid-run
    * update, persist, and return the toast.
@@ -306,27 +431,7 @@ function sanitize(raw: unknown): SubagentsSettings {
   if (!raw || typeof raw !== "object") return {};
   const r = raw as Record<string, unknown>;
   const out: SubagentsSettings = {};
-  if (
-    Number.isInteger(r.maxConcurrent) &&
-    (r.maxConcurrent as number) >= 1 &&
-    (r.maxConcurrent as number) <= MAX_CONCURRENT_CEILING
-  ) {
-    out.maxConcurrent = r.maxConcurrent as number;
-  }
-  if (
-    Number.isInteger(r.defaultMaxTurns) &&
-    (r.defaultMaxTurns as number) >= 0 &&
-    (r.defaultMaxTurns as number) <= MAX_TURNS_CEILING
-  ) {
-    out.defaultMaxTurns = r.defaultMaxTurns as number;
-  }
-  if (
-    Number.isInteger(r.graceTurns) &&
-    (r.graceTurns as number) >= 1 &&
-    (r.graceTurns as number) <= GRACE_TURNS_CEILING
-  ) {
-    out.graceTurns = r.graceTurns as number;
-  }
+  sanitizeTuningFields(out, r);
   if (isRetentionMinutes(r.consumedSessionRetentionMinutes)) {
     out.consumedSessionRetentionMinutes = r.consumedSessionRetentionMinutes;
   }
@@ -339,6 +444,7 @@ function sanitize(raw: unknown): SubagentsSettings {
   if (typeof r.midRunUpdates === "boolean") {
     out.midRunUpdates = r.midRunUpdates;
   }
+  applyPromptInheritance(out, r.promptInheritance);
   if (Array.isArray(r.excludedExtensionPackages)) {
     const sources = r.excludedExtensionPackages
       .filter((value): value is string => typeof value === "string")
@@ -347,6 +453,28 @@ function sanitize(raw: unknown): SubagentsSettings {
     out.excludedExtensionPackages = [...new Set(sources)];
   }
   return out;
+}
+
+/**
+ * Sanitize the concurrency and turn-limit tuning fields into `out`.
+ * Extracted from `sanitize` so the dispatcher stays under the complexity
+ * thresholds the audit gate enforces on changed files.
+ */
+function sanitizeTuningFields(out: SubagentsSettings, r: Record<string, unknown>): void {
+  if (isBoundedInt(r.maxConcurrent, 1, MAX_CONCURRENT_CEILING)) {
+    out.maxConcurrent = r.maxConcurrent;
+  }
+  if (isBoundedInt(r.defaultMaxTurns, 0, MAX_TURNS_CEILING)) {
+    out.defaultMaxTurns = r.defaultMaxTurns;
+  }
+  if (isBoundedInt(r.graceTurns, 1, GRACE_TURNS_CEILING)) {
+    out.graceTurns = r.graceTurns;
+  }
+}
+
+/** Integer within [min, max] — the shape every tuning-field check shares. */
+function isBoundedInt(n: unknown, min: number, max: number): n is number {
+  return Number.isInteger(n) && (n as number) >= min && (n as number) <= max;
 }
 
 function projectPath(cwd: string): string {

--- a/packages/pi-subagents/src/types.ts
+++ b/packages/pi-subagents/src/types.ts
@@ -53,6 +53,15 @@ export interface AgentIdentity {
 export interface AgentPromptConfig {
   name: string;
   promptMode: "replace" | "append";
+  /**
+   * What the child inherits as its prompt identity: `"full"` (default) the
+   * parent's identity layers, byte for byte; `"portable"` only the parent's
+   * portable parts (context files, custom/append prompts, added guidelines),
+   * for children whose provider re-homes the prompt into another harness.
+   * Omitted: the spawn-time `promptInheritance` setting decides (`"full"`).
+   * See ADR 0008.
+   */
+  promptInheritance?: "full" | "portable";
   systemPrompt: string;
 }
 

--- a/packages/pi-subagents/test/config/custom-agents.test.ts
+++ b/packages/pi-subagents/test/config/custom-agents.test.ts
@@ -425,3 +425,54 @@ Agent prompt.`);
     }
   });
 });
+
+describe("loadCustomAgents — inherit_prompt frontmatter", () => {
+  let tmpDir: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pi-test-"));
+    originalHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    if (originalHome == null) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeAgent(name: string, content: string) {
+    const dir = join(tmpDir, ".pi", "agents");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${name}.md`), content);
+  }
+
+  it("parses portable and full, and leaves an absent or unknown value unset", () => {
+    writeAgent("portable-agent", `---
+inherit_prompt: portable
+---
+
+Prompt.`);
+    writeAgent("full-agent", `---
+inherit_prompt: full
+---
+
+Prompt.`);
+    writeAgent("silent-agent", `---
+---
+
+Prompt.`);
+    writeAgent("garbage-agent", `---
+inherit_prompt: banana
+---
+
+Prompt.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("portable-agent")!.promptInheritance).toBe("portable");
+    expect(result.get("full-agent")!.promptInheritance).toBe("full");
+    expect(result.get("silent-agent")!.promptInheritance).toBeUndefined();
+    expect(result.get("garbage-agent")!.promptInheritance).toBeUndefined();
+  });
+});

--- a/packages/pi-subagents/test/lifecycle/parent-snapshot.test.ts
+++ b/packages/pi-subagents/test/lifecycle/parent-snapshot.test.ts
@@ -70,3 +70,34 @@ describe("buildParentSnapshot", () => {
     expect(snapshot.parentContext).toBeUndefined();
   });
 });
+
+describe("buildParentSnapshot — portable prompt parts", () => {
+  it("is undefined when no prompt options were captured", () => {
+    const snapshot = buildParentSnapshot(makeCtx());
+    expect(snapshot.portablePrompt).toBeUndefined();
+  });
+
+  it("joins context files, guidelines, custom and append prompts", () => {
+    const snapshot = buildParentSnapshot(makeCtx(), undefined, {
+      contextFiles: [{ path: "/p/AGENTS.md", content: "# Rules" }],
+      promptGuidelines: ["- Be terse"],
+      customPrompt: "custom",
+      appendSystemPrompt: "append",
+    });
+    expect(snapshot.portablePrompt).toContain('<project_instructions path="/p/AGENTS.md">');
+    expect(snapshot.portablePrompt).toContain("# Rules");
+    expect(snapshot.portablePrompt).toContain("- Be terse");
+    expect(snapshot.portablePrompt).toContain("custom");
+    expect(snapshot.portablePrompt).toContain("append");
+  });
+
+  it("is undefined when every part is empty", () => {
+    const snapshot = buildParentSnapshot(makeCtx(), undefined, { contextFiles: [] });
+    expect(snapshot.portablePrompt).toBeUndefined();
+  });
+
+  it("omits absent parts without blank-line gaps", () => {
+    const snapshot = buildParentSnapshot(makeCtx(), undefined, { customPrompt: "only-custom" });
+    expect(snapshot.portablePrompt).toBe("only-custom");
+  });
+});

--- a/packages/pi-subagents/test/runtime.test.ts
+++ b/packages/pi-subagents/test/runtime.test.ts
@@ -92,7 +92,8 @@ describe("SubagentRuntime context query methods", () => {
     runtime.setSessionContext(ctx);
     mockBuildParentSnapshot.mockReturnValueOnce(STUB_SNAPSHOT);
     const result = runtime.buildSnapshot(true);
-    expect(mockBuildParentSnapshot).toHaveBeenCalledWith(ctx, true);
+    // Third arg: the latest before_agent_start prompt options (undefined until a turn runs).
+    expect(mockBuildParentSnapshot).toHaveBeenCalledWith(ctx, true, undefined);
     expect(result).toBe(STUB_SNAPSHOT);
   });
 
@@ -102,7 +103,18 @@ describe("SubagentRuntime context query methods", () => {
     runtime.setSessionContext(ctx);
     mockBuildParentSnapshot.mockReturnValueOnce(STUB_SNAPSHOT);
     runtime.buildSnapshot(false);
-    expect(mockBuildParentSnapshot).toHaveBeenCalledWith(ctx, false);
+    expect(mockBuildParentSnapshot).toHaveBeenCalledWith(ctx, false, undefined);
+  });
+
+  it("buildSnapshot forwards captured prompt options for portable inheritance", () => {
+    const runtime = createSubagentRuntime();
+    const ctx = makeSessionCtx();
+    runtime.setSessionContext(ctx);
+    const options = { contextFiles: [{ path: "AGENTS.md", content: "# hi" }] };
+    runtime.setSystemPromptOptions(options);
+    mockBuildParentSnapshot.mockReturnValueOnce(STUB_SNAPSHOT);
+    runtime.buildSnapshot(true);
+    expect(mockBuildParentSnapshot).toHaveBeenCalledWith(ctx, true, options);
   });
 
   it("getModelInfo returns model and modelRegistry from current context", () => {

--- a/packages/pi-subagents/test/session/prompts.test.ts
+++ b/packages/pi-subagents/test/session/prompts.test.ts
@@ -729,3 +729,43 @@ describe("buildAgentPrompt", () => {
     });
   });
 });
+
+describe("buildAgentPrompt — portable inheritance", () => {
+  const parentPrompt = [
+    "You are an expert coding assistant operating inside pi, a coding agent harness.",
+    "# Environment",
+    "Current working directory: /parent",
+  ].join("\n");
+  const portable = `<project_context>\n<project_instructions path="/parent/AGENTS.md">\n# Rules\n</project_instructions>\n</project_context>`;
+
+  it("uses the parent's portablePrompt as the identity when promptInheritance is portable", () => {
+    const config = { ...getDefaultConfig("general-purpose"), promptInheritance: "portable" as const };
+    const prompt = buildAgentPrompt(config, "/workspace", env, {
+      systemPrompt: parentPrompt,
+      portablePrompt: portable,
+      cwd: PARENT_CWD,
+    });
+    expect(prompt.startsWith(portable)).toBe(true);
+    expect(prompt).not.toContain("operating inside pi");
+  });
+
+  it("falls back to the generic base, not the full prompt, when no portable capture exists", () => {
+    const config = { ...getDefaultConfig("general-purpose"), promptInheritance: "portable" as const };
+    const prompt = buildAgentPrompt(config, "/workspace", env, {
+      systemPrompt: parentPrompt,
+      cwd: PARENT_CWD,
+    });
+    expect(prompt).not.toContain("operating inside pi");
+    expect(prompt).not.toContain(parentPrompt);
+  });
+
+  it("keeps the full inherited identity when promptInheritance is unset", () => {
+    const config = getDefaultConfig("general-purpose");
+    const prompt = buildAgentPrompt(config, "/workspace", env, {
+      systemPrompt: parentPrompt,
+      portablePrompt: portable,
+      cwd: PARENT_CWD,
+    });
+    expect(prompt.startsWith("You are an expert coding assistant")).toBe(true);
+  });
+});

--- a/packages/pi-subagents/test/session/session-config.test.ts
+++ b/packages/pi-subagents/test/session/session-config.test.ts
@@ -270,3 +270,62 @@ describe("assembleSessionConfig — thinking level", () => {
     expect(result.thinkingLevel).toBe("medium");
   });
 });
+
+describe("assembleSessionConfig — prompt inheritance scoping", () => {
+  it("applies the provider rule for the resolved child model's provider", () => {
+    mockResolveAgentConfig.mockReturnValueOnce(exploreConfig());
+    const bridgeModel = makeModel({ id: "claude-opus-5", name: "Opus", provider: "claude-bridge" });
+    assembleSessionConfig(
+      "Explore",
+      { ...ctx, promptInheritanceProviders: { "claude-bridge": "portable" } },
+      { model: bridgeModel },
+      mockEnv,
+      mockAgentLookup,
+      mockIO,
+    );
+    expect(mockBuildAgentPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({ promptInheritance: "portable" }),
+      expect.any(String),
+      mockEnv,
+      expect.anything(),
+    );
+  });
+
+  it("falls through to the default for unlisted providers", () => {
+    mockResolveAgentConfig.mockReturnValueOnce(exploreConfig());
+    const zaiModel = makeModel({ id: "glm-5.3", name: "GLM", provider: "zai" });
+    assembleSessionConfig(
+      "Explore",
+      { ...ctx, promptInheritanceProviders: { "claude-bridge": "portable" }, promptInheritanceDefault: "full" },
+      { model: zaiModel },
+      mockEnv,
+      mockAgentLookup,
+      mockIO,
+    );
+    expect(mockBuildAgentPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({ promptInheritance: "full" }),
+      expect.any(String),
+      mockEnv,
+      expect.anything(),
+    );
+  });
+
+  it("frontmatter inherit_prompt wins over provider rules and defaults", () => {
+    mockResolveAgentConfig.mockReturnValueOnce(exploreConfig({ promptInheritance: "portable" }));
+    const zaiModel = makeModel({ id: "glm-5.3", name: "GLM", provider: "zai" });
+    assembleSessionConfig(
+      "Explore",
+      { ...ctx, promptInheritanceDefault: "full", promptInheritanceProviders: { zai: "full" } },
+      { model: zaiModel },
+      mockEnv,
+      mockAgentLookup,
+      mockIO,
+    );
+    expect(mockBuildAgentPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({ promptInheritance: "portable" }),
+      expect.any(String),
+      mockEnv,
+      expect.anything(),
+    );
+  });
+});

--- a/packages/pi-subagents/test/settings.test.ts
+++ b/packages/pi-subagents/test/settings.test.ts
@@ -4,6 +4,8 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   loadSettings,
+  normalizePromptInheritance,
+  type PromptInheritance,
   persistToastFor,
   SettingsManager,
   saveSettings,
@@ -955,6 +957,61 @@ describe("SettingsManager", () => {
       expect(
         () => new SettingsManager({ emit: vi.fn(), cwd: "/tmp", agentDir: "/nonexistent", onMaxConcurrentChanged: vi.fn() }),
       ).not.toThrow();
+    });
+  });
+});
+
+describe("promptInheritance setting", () => {
+  let dirs: SettingsDirs;
+
+  beforeEach(() => {
+    dirs = createSettingsDirs("subagents.json");
+  });
+
+  afterEach(() => dirs.dispose());
+
+  it("normalizePromptInheritance parses the simple form", () => {
+    expect(normalizePromptInheritance("portable")).toEqual({ def: "portable", providers: {} });
+    expect(normalizePromptInheritance("full")).toEqual({ def: "full", providers: {} });
+  });
+
+  it("normalizePromptInheritance parses scoped rules and drops unknown values", () => {
+    expect(
+      normalizePromptInheritance({ default: "portable", providers: { "claude-bridge": "portable", zai: "banana" as unknown as PromptInheritance } }),
+    ).toEqual({ def: "portable", providers: { "claude-bridge": "portable" } });
+    expect(normalizePromptInheritance({ providers: { zai: "portable" } })).toEqual({
+      def: "full",
+      providers: { zai: "portable" },
+    });
+  });
+
+  it("normalizePromptInheritance defaults on undefined and garbage", () => {
+    expect(normalizePromptInheritance(undefined)).toEqual({ def: "full", providers: {} });
+    expect(normalizePromptInheritance("banana" as never)).toEqual({ def: "full", providers: {} });
+  });
+
+  it("loads a scoped rule from disk and exposes the resolved values", () => {
+    dirs.writeGlobal({ promptInheritance: { providers: { "claude-bridge": "portable" } } });
+    const manager = new SettingsManager({
+      emit: vi.fn(),
+      cwd: dirs.projectDir,
+      agentDir: dirs.globalDir,
+    });
+    manager.load();
+    expect(manager.promptInheritance).toBe("full");
+    expect(manager.promptInheritanceProviders).toEqual({ "claude-bridge": "portable" });
+  });
+
+  it("round-trips a scoped rule through snapshot()", () => {
+    dirs.writeGlobal({ promptInheritance: { providers: { "claude-bridge": "portable" } } });
+    const manager = new SettingsManager({
+      emit: vi.fn(),
+      cwd: dirs.projectDir,
+      agentDir: dirs.globalDir,
+    });
+    manager.load();
+    expect(manager.snapshot().promptInheritance).toEqual({
+      providers: { "claude-bridge": "portable" },
     });
   });
 });


### PR DESCRIPTION
Fixes #883. Follow-up to #812.

## What

An opt-in **`portable`** prompt-inheritance strategy for agents whose provider re-homes the child's prompt into another harness (pi-claude-bridge projecting it onto Claude Code's preset as an append). The child's identity is built from the parent's `before_agent_start.systemPromptOptions` — context files, added guideline bullets, custom and append prompts — instead of the assembled prompt, so pi's harness base never leaves pi through that path.

Selection, per child: **agent frontmatter (`inherit_prompt`) > provider rule (`promptInheritance.providers`, keyed by the provider of the child's resolved model) > `promptInheritance` default > `full`.** The default changes nothing for anyone who does not opt in; a provider-scoped rule leaves same-API children — where the shared prefix is worth the most — untouched.

Design details worth review:

- **Context files ride in the portable identity** because the child loader runs with `noContextFiles: true` — this is the only way a portable child sees project instructions at all.
- **Skills stay un-inherited** — the child loads its own catalogue, same reasoning as ADR 0006's tail-stripping.
- **An absent or empty capture falls back to the generic base, never to the full prompt** — opting into portable must never silently re-embed the base it exists to avoid.
- **Model resolution moved ahead of prompt assembly** in `assembleSessionConfig`, since the child's provider scopes the rules (per-spawn `model` overrides therefore scope correctly too).

## Why

The issue has the full bisection; short form: Anthropic's subscription OAuth gate classifies requests by system-prompt content, and the co-occurrence of two phrases in pi's documentation-routing line (`custom providers (docs/custom-provider.md)` + `pi packages (docs/packages.md)`) in the forwarded append is scored as a third-party app. A full-inheritance bridge child is refused outright while its parent, on the same provider, token, and Claude Code binary, passes — because the bridge only ever projects the parent's *portable* parts for the parent. Portable inheritance gives the child exactly those parts.

## Docs & tests

- ADR 0008 (proposed) records the reasoning and the not-yet-taken further step (provider-declared policy, which this setting is shaped to override later).
- `docs/configuration.md`: `inherit_prompt` frontmatter row, a *Portable inheritance (opt-in)* subsection with the strategy table, and `promptInheritance` settings docs (both forms, precedence).
- 25 new tests across prompts / parent-snapshot / settings / session-config / runtime / custom-agents; full suite green locally (1581), `tsc` and `biome` clean.

## Verification

Live on pi-claude-bridge, same machine and OAuth token: full-inheritance child → 400 (pre-credit; with credit, extra-usage draw in the rate-limit telemetry); portable child — via frontmatter or the provider rule, using the built-in `general-purpose` agent with no per-agent config — succeeds on plan usage. A `@tintinweb/pi-subagents` cross-check (thin-standalone replace semantics) is recorded in the issue as the ecosystem control.
