### PR TITLE
fix(pi-permission-system): preserve serving for UI self-parent hints

### DIFF
--- a/packages/pi-permission-system/docs/architecture/architecture.md
+++ b/packages/pi-permission-system/docs/architecture/architecture.md
@@ -509,8 +509,9 @@ This requires two detections:
    Each concurrent sibling child of the same parent receives a unique session id from `sessionManager.newSession()`, so siblings occupy distinct keys - one sibling's `disposed` event cannot evict another's entry (fixes #298).
    The registry is a process-global singleton (via `getSubagentSessionRegistry()`, backed by `globalThis` + `Symbol.for()`) because each session's `ResourceLoader` creates its own `pi.events` bus: the parent's instance registers the child over the parent bus, while the child's separate jiti instance reads the same global store to detect itself and resolve its forwarding target.
 2. **Env vars** (`SUBAGENT_ENV_HINT_KEYS`) - returns `true` when any key is set to a non-empty, non-whitespace value.
-   Used by process-based subagent extensions.
-   The list is composed from the per-extension markers plus `SUBAGENT_PARENT_SESSION_ENV_CANDIDATES`, since a process that names a parent session is a child by definition - which is what makes the convention's single out-of-process obligation sufficient on its own (#789).
+   A UI host's parent-session hint is ignored only when it matches that host's own non-empty session id.
+   All other hints remain child evidence, including a matching parent-session hint in a headless process.
+   The list is composed from the per-extension markers plus `SUBAGENT_PARENT_SESSION_ENV_CANDIDATES`, so naming a parent session remains the convention's single sufficient out-of-process obligation (#789).
 3. **Filesystem path** - session-directory path-based fallback (child session dir is nested under `subagentSessionsDir`).
 
 ### Parent-session resolution (`resolvePermissionForwardingTargetSessionId`)

--- a/packages/pi-permission-system/docs/subagent-integration.md
+++ b/packages/pi-permission-system/docs/subagent-integration.md
@@ -51,7 +51,9 @@ PI_SUBAGENT_PARENT_SESSION=<parent-session-id>
 ```
 
 That is the whole obligation.
-The variable identifies the session the child forwards its asks to, and naming a parent session is itself sufficient to mark the process as a child — a separate "I am a subagent" marker is neither required nor expected.
+The variable identifies the session the child forwards its asks to, and naming a parent session is itself sufficient to mark a process as a child — a separate "I am a subagent" marker is neither required nor expected.
+For compatibility with extensions that export the marker from their interactive host, the permission detector ignores it only when it matches that UI host's own session id.
+A headless process receives no such exception.
 
 Earlier per-extension variables are grandfathered for compatibility: the markers `PI_IS_SUBAGENT`, `PI_SUBAGENT_CHILD`, `PI_SUBAGENT_NAME` and their siblings still register as child hints, and `PI_AGENT_ROUTER_PARENT_SESSION_ID` is still honored as a parent-session source, checked ahead of the convention name.
 New implementations use `PI_SUBAGENT_PARENT_SESSION` only.

--- a/packages/pi-permission-system/src/authority/permission-forwarding.ts
+++ b/packages/pi-permission-system/src/authority/permission-forwarding.ts
@@ -52,11 +52,11 @@ const THIRD_PARTY_SUBAGENT_ENV_HINTS = [
 /**
  * Env vars whose presence marks the current process as a subagent child.
  *
- * A process that names a parent session is a child by definition, so every
- * parent-session candidate is a detection hint too. That is what makes the
- * subagent adapter convention's single out-of-process obligation — set
- * `PI_SUBAGENT_PARENT_SESSION` — sufficient on its own: an implementation owes
- * the announcement and nothing else, and detection is this package's job.
+ * Parent-session candidates remain detection hints so the subagent adapter
+ * convention's single out-of-process obligation — set
+ * `PI_SUBAGENT_PARENT_SESSION` — is sufficient on its own. The detector has a
+ * narrow compatibility exception for a UI host inheriting its own id as that
+ * marker; all other non-empty hints remain child evidence.
  */
 export const SUBAGENT_ENV_HINT_KEYS: readonly string[] = [
   ...THIRD_PARTY_SUBAGENT_ENV_HINTS,

--- a/packages/pi-permission-system/src/authority/subagent-context.ts
+++ b/packages/pi-permission-system/src/authority/subagent-context.ts
@@ -1,14 +1,19 @@
 import type { PathFlavor } from "#src/path/path-flavor";
 import { readSessionId } from "#src/session/session-identity";
-import { SUBAGENT_ENV_HINT_KEYS } from "./permission-forwarding";
+import {
+  normalizePermissionForwardingSessionId,
+  SUBAGENT_ENV_HINT_KEYS,
+  SUBAGENT_PARENT_SESSION_ENV_CANDIDATES,
+} from "./permission-forwarding";
 import type { SubagentSessionRegistry } from "./subagent-registry";
 
 /**
- * Narrow context for subagent detection — the only session-manager readers
+ * Narrow context for subagent detection — the only context fields
  * {@link isSubagentExecutionContext} and {@link isRegisteredSubagentChild}
  * consume. A full `ExtensionContext` satisfies this structurally.
  */
 export interface SubagentDetectionContext {
+  hasUI: boolean;
   sessionManager: {
     getSessionId(): string;
     getSessionDir(): string;
@@ -56,14 +61,28 @@ export function isSubagentExecutionContext(
   }
 
   const sessionDir = ctx.sessionManager.getSessionDir();
+  const ownSessionId = ctx.hasUI
+    ? normalizePermissionForwardingSessionId(readSessionId(ctx))
+    : null;
 
   // 2. Env vars — process-based subagent extensions (nicobailon/pi-subagents,
-  //    HazAT/pi-interactive-subagents, pi-agent-router, etc.).
+  //    HazAT/pi-interactive-subagents, pi-agent-router, etc.). A UI host may
+  //    inherit its own id as a parent-session marker from an extension that
+  //    prepares child processes. That marker is not child evidence, but every
+  //    other hint remains authoritative.
   for (const key of SUBAGENT_ENV_HINT_KEYS) {
     const value = process.env[key];
-    if (typeof value === "string" && value.trim()) {
-      return true;
+    if (typeof value !== "string" || !value.trim()) {
+      continue;
     }
+    if (
+      ownSessionId !== null &&
+      SUBAGENT_PARENT_SESSION_ENV_CANDIDATES.includes(key) &&
+      value.trim() === ownSessionId
+    ) {
+      continue;
+    }
+    return true;
   }
 
   // 3. Filesystem path — fallback heuristic for extensions that store sessions

--- a/packages/pi-permission-system/test/authority/approval-escalator.test.ts
+++ b/packages/pi-permission-system/test/authority/approval-escalator.test.ts
@@ -9,11 +9,12 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { ParentAuthorizer } from "#src/authority/approval-escalator";
 import {
   type ForwardedPermissionRequest,
   PERMISSION_FORWARDING_SERVING_GRACE_MS,
+  SUBAGENT_ENV_HINT_KEYS,
 } from "#src/authority/permission-forwarding";
 import { ServingSessionRegistry } from "#src/authority/serving-registry";
 import {
@@ -28,6 +29,16 @@ import {
   makePromptDetails,
   makePromptPayload,
 } from "#test/helpers/prompt-details-fixtures";
+
+beforeEach(() => {
+  for (const key of SUBAGENT_ENV_HINT_KEYS) {
+    vi.stubEnv(key, undefined);
+  }
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 // ── Local poll helper ────────────────────────────────────────────────────
 //

--- a/packages/pi-permission-system/test/authority/subagent-context.test.ts
+++ b/packages/pi-permission-system/test/authority/subagent-context.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { SUBAGENT_ENV_HINT_KEYS } from "#src/authority/permission-forwarding";
 import {
   isRegisteredSubagentChild,
@@ -9,6 +9,12 @@ import {
 import { SubagentSessionRegistry } from "#src/authority/subagent-registry";
 import { posixPathFlavor, win32PathFlavor } from "#src/path/path-flavor";
 
+beforeEach(() => {
+  for (const key of SUBAGENT_ENV_HINT_KEYS) {
+    vi.stubEnv(key, undefined);
+  }
+});
+
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
@@ -17,8 +23,10 @@ afterEach(() => {
 function makeCtx(
   sessionDir: string | null,
   sessionId: string = "",
+  hasUI: boolean = false,
 ): SubagentDetectionContext {
   return {
+    hasUI,
     sessionManager: {
       getSessionDir: vi.fn(() => sessionDir ?? ""),
       getSessionId: vi.fn(() => sessionId),
@@ -54,6 +62,7 @@ describe("isRegisteredSubagentChild", () => {
     const registry = new SubagentSessionRegistry();
     registry.register(childSessionId, {});
     const ctx: SubagentDetectionContext = {
+      hasUI: false,
       sessionManager: {
         getSessionDir: vi.fn(() => ""),
         getSessionId: vi.fn(() => {
@@ -261,6 +270,7 @@ describe("isSubagentExecutionContext — env hint detection", () => {
   // The adapter convention's parent-session variables (ADR 0012 decision 5).
   // A process that names a parent session is a child by definition, so naming
   // one is sufficient on its own — an implementation owes no second marker.
+  // The UI host's own inherited marker is the one compatibility exception.
   test("returns true when PI_SUBAGENT_PARENT_SESSION is set alone", () => {
     vi.stubEnv("PI_SUBAGENT_PARENT_SESSION", "parent-session-id");
     expect(
@@ -271,6 +281,107 @@ describe("isSubagentExecutionContext — env hint detection", () => {
       ),
     ).toBe(true);
   });
+
+  test("does not classify a UI host from its own parent-session hint", () => {
+    vi.stubEnv("PI_SUBAGENT_PARENT_SESSION", "ui-session");
+    expect(
+      isSubagentExecutionContext(
+        makeCtx(null, "ui-session", true),
+        "/sessions/subagents",
+        posixPathFlavor,
+      ),
+    ).toBe(false);
+  });
+
+  test.each([
+    "PI_AGENT_ROUTER_PARENT_SESSION_ID",
+    "PI_SUBAGENT_PARENT_SESSION",
+  ])("ignores a whitespace-padded self hint from a UI host (%s)", (key) => {
+    vi.stubEnv(key, "  ui-session  ");
+    expect(
+      isSubagentExecutionContext(
+        makeCtx(null, " ui-session ", true),
+        "/sessions/subagents",
+        posixPathFlavor,
+      ),
+    ).toBe(false);
+  });
+
+  test("keeps a headless child classified when its parent hint equals its own id", () => {
+    vi.stubEnv("PI_SUBAGENT_PARENT_SESSION", "child-session");
+    expect(
+      isSubagentExecutionContext(
+        makeCtx(null, "child-session"),
+        "/sessions/subagents",
+        posixPathFlavor,
+      ),
+    ).toBe(true);
+  });
+
+  test("keeps a UI child classified when its parent hint names another session", () => {
+    vi.stubEnv("PI_SUBAGENT_PARENT_SESSION", "parent-session");
+    expect(
+      isSubagentExecutionContext(
+        makeCtx(null, "ui-session", true),
+        "/sessions/subagents",
+        posixPathFlavor,
+      ),
+    ).toBe(true);
+  });
+
+  test("keeps a distinct parent hint alongside a self hint", () => {
+    vi.stubEnv("PI_AGENT_ROUTER_PARENT_SESSION_ID", "ui-session");
+    vi.stubEnv("PI_SUBAGENT_PARENT_SESSION", "parent-session");
+    expect(
+      isSubagentExecutionContext(
+        makeCtx(null, "ui-session", true),
+        "/sessions/subagents",
+        posixPathFlavor,
+      ),
+    ).toBe(true);
+  });
+
+  test("keeps a UI child classified when another child marker is also set", () => {
+    vi.stubEnv("PI_SUBAGENT_PARENT_SESSION", "ui-session");
+    vi.stubEnv("PI_SUBAGENT_CHILD", "1");
+    expect(
+      isSubagentExecutionContext(
+        makeCtx(null, "ui-session", true),
+        "/sessions/subagents",
+        posixPathFlavor,
+      ),
+    ).toBe(true);
+  });
+
+  test("keeps a parent hint when a UI session id is unavailable", () => {
+    vi.stubEnv("PI_SUBAGENT_PARENT_SESSION", "ui-session");
+    const ctx: SubagentDetectionContext = {
+      hasUI: true,
+      sessionManager: {
+        getSessionDir: vi.fn(() => ""),
+        getSessionId: vi.fn(() => {
+          throw new Error("session id unavailable");
+        }),
+      },
+    };
+    expect(
+      isSubagentExecutionContext(ctx, "/sessions/subagents", posixPathFlavor),
+    ).toBe(true);
+  });
+
+  test.each(["", "   "])(
+    "keeps a parent hint when a UI session id is blank (%j)",
+    (sessionId) => {
+      vi.stubEnv("PI_SUBAGENT_PARENT_SESSION", "ui-session");
+      expect(
+        isSubagentExecutionContext(
+          makeCtx(null, sessionId, true),
+          "/sessions/subagents",
+          posixPathFlavor,
+        ),
+      ).toBe(true);
+    },
+  );
 
   test("returns true when PI_AGENT_ROUTER_PARENT_SESSION_ID is set alone", () => {
     vi.stubEnv("PI_AGENT_ROUTER_PARENT_SESSION_ID", "parent-session-id");
@@ -346,6 +457,17 @@ describe("isSubagentExecutionContext — session dir detection", () => {
     expect(
       isSubagentExecutionContext(
         makeCtx(subagentRoot),
+        subagentRoot,
+        posixPathFlavor,
+      ),
+    ).toBe(true);
+  });
+
+  test("keeps filesystem evidence alongside a UI host's self hint", () => {
+    vi.stubEnv("PI_SUBAGENT_PARENT_SESSION", "ui-session");
+    expect(
+      isSubagentExecutionContext(
+        makeCtx(`${subagentRoot}/ui-session`, "ui-session", true),
         subagentRoot,
         posixPathFlavor,
       ),
@@ -547,6 +669,20 @@ describe("isSubagentExecutionContext — registry detection", () => {
     expect(
       isSubagentExecutionContext(
         makeCtx(outsideDir, childSessionId),
+        subagentRoot,
+        posixPathFlavor,
+        registry,
+      ),
+    ).toBe(true);
+  });
+
+  test("registry evidence wins over a UI host's self hint", () => {
+    const registry = new SubagentSessionRegistry();
+    registry.register("ui-session", {});
+    vi.stubEnv("PI_SUBAGENT_PARENT_SESSION", "ui-session");
+    expect(
+      isSubagentExecutionContext(
+        makeCtx(outsideDir, "ui-session", true),
         subagentRoot,
         posixPathFlavor,
         registry,

--- a/packages/pi-permission-system/test/authority/subagent-detection.test.ts
+++ b/packages/pi-permission-system/test/authority/subagent-detection.test.ts
@@ -1,9 +1,16 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
+import { SUBAGENT_ENV_HINT_KEYS } from "#src/authority/permission-forwarding";
 import type { SubagentDetectionContext } from "#src/authority/subagent-context";
 import { SubagentDetection } from "#src/authority/subagent-detection";
 import { SubagentSessionRegistry } from "#src/authority/subagent-registry";
 import { posixPathFlavor } from "#src/path/path-flavor";
+
+beforeEach(() => {
+  for (const key of SUBAGENT_ENV_HINT_KEYS) {
+    vi.stubEnv(key, undefined);
+  }
+});
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -15,6 +22,7 @@ function makeCtx(
   sessionId: string = "",
 ): SubagentDetectionContext {
   return {
+    hasUI: false,
     sessionManager: {
       getSessionDir: vi.fn(() => sessionDir ?? ""),
       getSessionId: vi.fn(() => sessionId),

--- a/packages/pi-permission-system/test/composition-root.test.ts
+++ b/packages/pi-permission-system/test/composition-root.test.ts
@@ -33,6 +33,7 @@ import { childNodeAbsentMessage } from "#src/authority/child-node-audit";
 import {
   createPermissionForwardingLocation,
   type ForwardedPermissionRequest,
+  SUBAGENT_ENV_HINT_KEYS,
 } from "#src/authority/permission-forwarding";
 import { getServingSessionRegistry } from "#src/authority/serving-registry";
 import {
@@ -78,6 +79,9 @@ const EXPECTED_HANDLERS = [
 let agentDir: string;
 
 beforeEach(() => {
+  for (const key of SUBAGENT_ENV_HINT_KEYS) {
+    vi.stubEnv(key, undefined);
+  }
   agentDir = mkdtempSync(join(tmpdir(), "pi-perm-comp-root-"));
   vi.stubEnv("PI_CODING_AGENT_DIR", agentDir);
 });
@@ -497,6 +501,36 @@ describe("unguarded in-process child detection", () => {
     expect(notified).toEqual([]);
 
     rmSync(childCwd, { recursive: true, force: true });
+  });
+});
+
+describe("interactive serving eligibility", () => {
+  it("keeps serving when the root inherits its own parent-session marker", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-perm-root-serving-cwd-"));
+    const pi = makeFakePi();
+    const ctx = makeBaseCtx(cwd, "ui-root-session");
+    piPermissionSystemExtension(pi as unknown as ExtensionAPI);
+
+    await fireSessionStart(pi, ctx);
+    expect(getServingSessionRegistry().servingIds()).toEqual([
+      "ui-root-session",
+    ]);
+
+    // pi-subagents sets this marker after the root has initialized, and child
+    // processes inherit it when they are launched later.
+    vi.stubEnv("PI_SUBAGENT_PARENT_SESSION", "ui-root-session");
+    await pi.fire(
+      "before_agent_start",
+      { systemPrompt: "", systemPromptOptions: { cwd: "/test" } },
+      ctx,
+    );
+
+    expect(getServingSessionRegistry().servingIds()).toEqual([
+      "ui-root-session",
+    ]);
+
+    await pi.fire("session_shutdown");
+    rmSync(cwd, { recursive: true, force: true });
   });
 });
 

--- a/packages/pi-permission-system/test/service/permission-events.test.ts
+++ b/packages/pi-permission-system/test/service/permission-events.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { SUBAGENT_ENV_HINT_KEYS } from "#src/authority/permission-forwarding";
 import { getGlobalConfigPath } from "#src/config/config-paths";
 import piPermissionSystemExtension from "#src/index";
 import type {
@@ -19,6 +20,16 @@ import {
   PERMISSIONS_UI_PROMPT_CHANNEL,
 } from "#src/service/permission-events";
 import { makePromptPayload } from "#test/helpers/prompt-details-fixtures";
+
+beforeEach(() => {
+  for (const key of SUBAGENT_ENV_HINT_KEYS) {
+    vi.stubEnv(key, undefined);
+  }
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 // ── Minimal EventBus stub ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Addresses the root self-parent-marker misclassification described in https://github.com/gotgenes/pi-packages/issues/907.

- Ignore an inherited parent-session hint only when the context has a UI and the hint matches its valid, normalized current session ID.
- Preserve registry precedence, explicit child markers, distinct-parent hints, filesystem evidence, and headless-child detection (including headless self-reference).
- Leave permission evaluation, forwarding-target resolution, and serving lifecycle logic unchanged.
- Add detection and composition-root regressions and isolate detection environment hints in five affected test fixtures.

The self-reference proposal and the headless-child constraint came from @gaop154's report; the commit includes co-author credit.

## Automated local testing

- Reproduced the original serving withdrawal with the isolated installed-code reproduction before implementing the fix.
- Added a composition-root regression: start the interactive root, set its own parent-session marker, invoke `before_agent_start`, and assert that its serving registration remains present.
- Added detection coverage for both parent-session keys, whitespace normalization, headless self-reference, distinct parents, mixed hints, invalid/unavailable current IDs, registry precedence, and filesystem evidence.
- Reproduced environment-dependent test failures: 22 failures in the interactive parent test context and 24 in a delegated context; clearing inherited detection hints in the test subprocess made the affected 158 tests pass.
- Fixed the fixtures to stub every authoritative `SUBAGENT_ENV_HINT_KEYS` entry before each test and restore the original environment afterward; individual cases explicitly set their required hints.
- Full permission-package suite with all detection hints absent: **157 files, 4,139 tests passed**.
- Full permission-package suite with all 13 detection hints deliberately populated: **157 files, 4,139 tests passed**.
- Workspace `pnpm run check`, `pnpm run lint`, `pnpm run test`, and `pnpm fallow dead-code`: **passed** in fresh pre-completion review.
- Independent Standards and Spec reviews found no blocking code issues.

## Local live background-child testing

Inspected the operator's September 11 session `01a08e17-1f67-70a9-b927-03a866899420` and the child transcripts/launch receipts, rather than relying only on agent summaries.

The `permission-e2e` agent used `tools: bash` and explicitly configured the patched Git checkout's `packages/pi-permission-system/src/index.ts` through `subagentOnlyExtensions`.
That checkout resolves to this PR's commit, `11ea9e38eba19b8fda9d2ac083a7ee6ff4d414c1`.
Both launches used `async: true`, fresh context, shared cwd, and no worktree.
Both launch receipts included the configured patched entry-point identity (`sha256:191d32dcad00cc28`) and allowed ambient discovery.

| Probe | Run ID | Actual child tool result |
| --- | --- | --- |
| `printf 'permission-e2e-probe\n'` | `87b8ed4e-17a8-416c-920f-65fc9df3ffe1` | `permission-e2e-probe` followed by a newline; `isError: false` |
| `rm ./ask-to-remove-me` on an operator-created disposable file | `3d723d39-1ee8-458b-880a-60014cac3554` | `(no output)`; `isError: false` |

These runs confirm explicit patched-extension selection and successful command execution by actual background children.
The supplied transcript does **not** record the human dialog choices or correlated forwarding review-log events, and it does not establish that the `printf` probe matched an `ask` rule.
Accordingly, this PR does not claim a fully evidenced live deny-then-approve round trip from those artifacts alone.

Earlier foreground removal probes were not equivalent forwarding validation: their receipts showed only the subagent prompt runtime and no permission extension; one child also substituted Python `unlink()` for `rm`.
Those results are not counted as successful permission tests.

## Scope and remaining limitations

- This is a narrow repair, not a claim that every finding in #907 is resolved.
- Session-ID churn, stale serving/target identities, Windows heartbeat rename failures, and #909 authority routing remain outside this change.
- Child extension discovery/injection is a separate integration concern; this live test explicitly selected the patched extension.
- The new composition test asserts serving-registry retention, not a complete filesystem-heartbeat refresh round trip.
- Pre-completion review returned WARN for unavailable Mermaid rendering tooling (unchanged diagrams), an additional reviewer-only forced-environment probe blocked before execution, and the live approval-evidence limitation above; the implementer's full contaminated-environment suite did pass.

Refs #907
