### PR TITLE
fix(pi-permission-system): match a bash rule against the command's resolved path spellings

### DIFF
--- a/.pi/skills/package-pi-permission-system/SKILL.md
+++ b/.pi/skills/package-pi-permission-system/SKILL.md
@@ -91,6 +91,9 @@ Neither rule sees a `vi.mock()` specifier, which is a call argument rather than 
   `docs/configuration.md` publishes the roster between `<!-- BEGIN PURE_READER_CORE -->` markers and a parity test in `test/access-intent/bash/command-effects.test.ts` fails on drift — edit both or neither.
   Doc guidance to repeat: the useful *grants* are `*_read: allow` and the bare key; `*_write` earns its keep as a *restriction* (`path_write: {"*": "deny"}` is a read-only-agent posture), and a `*_write: allow` alone does not silence an `edit`, which also reads.
 - Wildcard matching must be explicit and tested — silent over-matching is a permission bypass.
+- A `bash` rule is matched against the command as typed **and** against the same command with its path arguments resolved (`BashProgram.commandAliasTexts()`), last-match-wins across the union — the `bash` surface's counterpart of `AccessPath.matchValues()`, so `rm /tmp/x/*: allow` reaches `cd /tmp && rm x/f` without the operator writing a second rule.
+  The alias texts are built in `program.ts`, where the source text, the unit spans, and the resolver's `pathRewrites()` meet; a gate must not re-derive them, and the resolver records a rewrite only where an absolute form differs from the token as written, which is what keeps a non-literal base and a glob token on their typed text.
+  A decision that an alias decided carries `matchedAlias`, which the prompt shows as `resolved as` evidence and the review log records as a fact — the command as typed and the rule that matched it otherwise read as a mismatch.
 - `*` already crosses directory boundaries; `**` is not a distinct globstar and compiles identically.
   Write `~/dev/*`, never `~/dev/**` — in config examples, ADRs, schema descriptions, and tests alike (Refs #806).
 - Prefer config patterns over new runtime mechanisms.

--- a/packages/pi-permission-system/docs/configuration.md
+++ b/packages/pi-permission-system/docs/configuration.md
@@ -349,6 +349,17 @@ Command patterns use wildcards matched against each top-level command in the cha
 
 **Last matching rule wins** within a single command — put broad catch-alls first, specific overrides after.
 
+A path argument is matched in its resolved spellings as well as the one the command used.
+Each top-level command is evaluated against the text as typed **and** against the same text with every path argument replaced by its absolute form — and by its canonical form where a symlink resolves it elsewhere.
+So `"rm /tmp/agent-builds/*": "allow"` also covers `cd /tmp && rm agent-builds/x`, and a rule written in either spelling of a symlinked directory matches.
+**Last matching rule wins across that union**, exactly as it does within one text: an `allow` written after a broader `ask` decides, and one written before it does not.
+The prompt and the review log name the resolved spelling whenever it, rather than the text as typed, was what the rule matched.
+
+Three limits are worth knowing.
+A command whose path arguments resolve to spellings that disagree — one under a symlink, one not — matches a rule naming only one of them when that rule's own path agrees with every argument it names; a per-argument cross product is deliberately not built, because it would make the number of pattern lookups a function of how many arguments the command has.
+A session approval records the command the prompt showed, so approving one spelling does not cover the other and the next call in the other spelling asks once more.
+A quoted relative argument is substituted whole, delimiters included, so `rm "agent-builds/x"` matches the same rule as its unquoted form; a quoted *absolute* argument is left as typed, because its spelling already names the path and the string surface has never matched a quoted spelling.
+
 A bash invocation may be a chain of commands joined by `&&`, `||`, `;`, `|`, `&`, or newlines.
 Each top-level command is evaluated independently against the patterns, and the most restrictive result wins (`deny` > `ask` > `allow`).
 So `cd /repo && npm install x` evaluates both `cd /repo` and `npm install x`; if `npm *` is denied, the whole invocation is denied even when `cd *` is allowed.

--- a/packages/pi-permission-system/docs/plans/local-bash-path-alias-matching.md
+++ b/packages/pi-permission-system/docs/plans/local-bash-path-alias-matching.md
@@ -1,0 +1,242 @@
+---
+issue_title: "Match the bash surface against the command's resolved path forms"
+---
+
+# Match the bash surface against the command's resolved path forms
+
+## Release Recommendation
+
+**Release:** ship independently.
+
+No issue tracks this change.
+The operator declined remote tracking: the defect was filed as [#910] and closed again on the same day, and the fix is handled locally in this repository.
+The commit is a `fix:` and cuts its own release.
+
+It is not a step in the Phase 15 roadmap, whose spine is a lost token *role* and the declared-effects config shape.
+It touches no step that phase names as a defect source, and the surface it changes is the one [#804] replaces.
+
+## Problem Statement
+
+A `bash` rule written with an absolute path does not cover the same command written with a relative path, although both name the same file and both resolve to the same location.
+
+With this policy:
+
+```jsonc
+"external_directory": { "*": "ask", "/tmp": "allow", "/tmp/*": "allow" },
+"bash": { "*": "allow", "rm *": "ask", "rm /tmp/agent-builds/*": "allow" }
+```
+
+the two commands below reach the same file, and the second prompts while the first does not:
+
+```bash
+rm /tmp/agent-builds/pi-permission-system/config.json
+cd /tmp && rm agent-builds/pi-permission-system/config.json   # prompts, rule 'rm *'
+```
+
+The `external_directory` gate resolves both to `/tmp/agent-builds/…` and allows them; only the `bash` gate asks.
+The operator cannot see why: no rule in the config appears to name the command being refused.
+
+The cause is that the `bash` surface matches **the command text**, while the `path` and `external_directory` surfaces match **the resolved path's alias set** (the lexical ∪ canonical union of [#418]).
+
+- `src/access-intent/input-normalizer.ts` builds the bash lookup as `values: [matchValue]` from the raw command text; leading comment lines are stripped and nothing else is.
+- `src/policy/permission-manager.ts` `buildCheckResult` selects `evaluateAnyValue` only for a surface in `PATH_SURFACES`, so `bash` is evaluated by `evaluateFirst` over that single value.
+- `src/access-intent/bash/bash-path-resolver.ts` already computes the cd-aware alias set for every path token, but that slice reaches only the `path_*` surfaces through `BashProgram.pathRuleCandidates()`.
+
+The measurement is upstream of most of this phase: the same file reaches two surfaces under two matching domains, and the config cannot express the difference.
+`docs/configuration.md` `### bash Surface` states that patterns match each top-level command in the chain, and says nothing about how a path argument in that text relates to the path surfaces' alias matching.
+
+Severity is fail-closed: the spelling no rule covers falls through to the broader rule, so the result is an extra `ask` and never a silent allow.
+[#822] is the same "matched textually, not by meaning" shape on the `path` surface, and that one is a fail-open.
+
+## Goals
+
+- A `bash` rule whose pattern names a path in the absolute spelling matches the command written with that path's relative spelling, when both resolve to the same location.
+- The alias set used by the `bash` surface is the same idea the `path` surfaces already use: the as-typed text plus the resolved forms of the same command.
+- A change to matching is explicit and tested: every new match is a named case in the bash gate's test matrix, never a silent widening.
+- Fail-closed properties already pinned by the code are preserved: a non-literal base, a glob or expansion token, and a win32 POSIX-absolute literal each keep their current answer.
+- The prompt and the review log name the text the decision was made on, so an ask whose rule does not appear in the operator's config is explainable.
+
+## Non-Goals
+
+- **Structured command rules.**
+  The destination is [#804], whose config shape is decided in Phase 16; this change stays inside the string matcher that surface keeps until then.
+- **Whitespace and quote normalization of the whole command.**
+  [#804] records `git  diff` and `git "diff"` as reasons to leave string matching behind.
+  This change rewrites only the argument nodes it resolves, so a quoted path argument starts matching a path rule as a side effect — recorded under Risks rather than claimed as a goal.
+- **Changing the `path` or `external_directory` surfaces.**
+  Their alias handling is already correct, and a `path` allow still cannot loosen a stricter `external_directory` rule.
+- **Reviewing why the `bash` surface carries file policy at all.** `docs/configuration.md` says redirects are gated by the `path` surface, not `bash`; whether path-shaped bash rules should keep working is [#804]'s question, not this one.
+- **Session grants that cross spellings.**
+  A grant continues to record the command text the prompt showed; see the residual under Risks.
+
+## Background
+
+### The two matching domains
+
+```text
+cd /tmp && rm agent-builds/pi-permission-system/config.json
+
+bash gate                      matches text     values: [ "rm agent-builds/…" ]
+                               rules:  rm *  →  ask
+                                       rm /tmp/**  →  no match
+
+path / external_directory      matches paths    values: [ "/tmp/agent-builds/…",
+                                                        "/private/tmp/agent-builds/…" ]
+                               rules:  /tmp/*  →  allow
+```
+
+### Constraints from AGENTS.md and the package skill
+
+- The four path layers compose **most-restrictive-wins**, so a second value on one surface may not weaken another surface's decision.
+  This change adds a value to one surface only; the composition above the gates is untouched.
+- Wildcard matching must be explicit and tested; silent over-matching is a permission bypass.
+  The alias texts are therefore derived from the resolver's own already-classified candidates, never from a fresh text heuristic.
+- `AccessPath` is the single value object holding the two representations, and `PermissionResolver.resolve` is the sole `matchValues()` unwrap site (ADR 0002).
+  The alias text uses `AccessPath.value()`, the lexical absolute form — the same accessor the display paths use — not a new normalization.
+- The package prefers config patterns over new runtime mechanisms.
+  This is a change to an existing matcher rather than a new mechanism, and it is recorded as such here because it is the closest this change comes to that line.
+
+## Design Overview
+
+### The alias value set
+
+Each command unit is evaluated against a set of texts that name the same command:
+
+| Value     | Text                                                         | Purpose                                                                                            |
+| --------- | ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| raw       | the unit as typed                                            | today's behavior, unchanged                                                                        |
+| absolute  | each resolved path argument replaced by `AccessPath.value()` | a rule written in the absolute spelling                                                            |
+| canonical | the same, using `resolvedAlias()`                            | a rule written in the symlink-resolved spelling, which macOS `/tmp` → `/private/tmp` makes routine |
+
+The canonical value is added only when at least one token has a distinct `resolvedAlias()`, so the common case carries two values.
+The set is bounded at three values however many tokens a command has, because each value is one text, not a cross product: a command whose tokens are mixed between the two absolute spellings matches a rule written in either spelling only when every token in that rule's path agrees.
+That residual is recorded rather than solved — a per-token cross product would make the number of lookups a function of the argument count.
+
+Evaluation is last-match-wins across the union, which is `evaluateAnyValue`'s semantics, and it is the same treatment `AccessPath.matchValues()` already gives the path surfaces.
+The ordering is what makes the change work: `rm *: ask` matches the raw text, the operator's later `rm /tmp/agent-builds/*: allow` matches the absolute text, and the later rule decides.
+An `allow` written *before* the broader `ask` still loses, so the operator's ordering remains the lever.
+
+### Span retention
+
+The rewrite replaces an argument node's whole source span, not its resolved text.
+Quote removal and `$HOME` expansion in `resolveNodeText` mean the candidate's `token` string is not always the source substring, and replacing the resolved text inside a quoted argument would leave the quotes in the rewritten command, where no path pattern matches them.
+
+Two spans are therefore threaded through the existing walk:
+
+1. `PathToken` carries the argument node's `startIndex`/`endIndex`.
+   A token the collectors derive from something other than a node text (`collectStatementOperandTokens`, the `find` directive path, and the redirect directive path) carries no span and takes no part in the alias text, which keeps the rewrite fail-safe by construction: a token nobody can locate is never rewritten.
+2. `BashCommand` carries its own `startIndex`/`endIndex`, so a token belongs to the unit whose span contains it.
+
+`BashProgram` gains one accessor returning the alias texts per command unit, built by replacing each contained candidate's span with its resolved form, right to left so the remaining spans stay valid.
+
+### Attribution, prompt, and session approval
+
+- `evaluateAnyValue` already returns the value that matched.
+  `buildCheckResult` drops it for every surface but `mcp`; the new intent carries it into `PermissionCheckResult` so the prompt can show the resolving text beside the command as typed (ADR 0011).
+- The review log records the raw command as it does today and adds the alias text only when one decided, so a `deny` or `ask` reads with the same blame a path gate already provides.
+- The `bash` session-approval pattern stays the raw command text — the text the prompt showed.
+  A grant therefore covers the spelling that was approved and not its sibling; re-entering through the other spelling asks once more.
+  See Risks.
+
+## Module-Level Changes
+
+### `src/access-intent/bash/token-collection.ts`
+
+`PathToken` gains an optional source span.
+Each construction site that reads `resolveNodeText(child)` passes that child's span; the three sites built from a derived value pass none.
+
+### `src/access-intent/bash/command-enumeration.ts`
+
+`BashCommand` gains its source span.
+`collectCommands` already holds the statement node it emits from, so the span is read there.
+
+### `src/access-intent/bash/bash-path-resolver.ts`
+
+`PathCandidate` and `BashPathRuleCandidate` carry the span from the token.
+`probeBareToken` carries it through the existence probe.
+
+### `src/access-intent/bash/program.ts`
+
+One new accessor returning the alias texts for the parsed program's command units.
+`pathRuleCandidates()` stays the path surfaces' slice; the new accessor is the bash surface's.
+
+### `src/access-intent/access-intent.ts` and `src/policy/permission-manager.ts`
+
+A new `alias-values` intent kind: a surface plus two or three lookup values that name the same invocation.
+`buildCheckResult` evaluates it with `evaluateAnyValue` and records the matched value.
+The intent is string-based like `path-values`, so the manager's boundary (ADR 0002) is unchanged, and the resolver's family fold is not involved because `bash` is not a family.
+
+### `src/handlers/gates/bash-command.ts`
+
+`resolveOnBashSurface` takes the unit's alias texts and resolves the alias intent instead of the single-value `tool` intent.
+The wrapper floor, the unparsed-subtree floor, and the most-restrictive fold across units are untouched — they act on the result, not on the lookup.
+
+### `src/presentation/` and `src/handlers/gates/helpers.ts`
+
+The ask payload discloses the resolving text when it differs from the command as typed.
+
+### `docs/configuration.md`
+
+`### bash Surface` states that a path argument is matched in its resolved spellings as well as as-typed, names the mixed-spelling and session-grant residuals, and points at the path surfaces for policy that is about files rather than command shape.
+
+## Test Impact Analysis
+
+| File                                                   | Change                                                                                                                                                       |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `test/access-intent/bash/program.test.ts`              | New cases for the alias accessor: relative token, quoted argument, `~`, non-literal base, glob token, and the canonical form when a symlink resolves         |
+| `test/handlers/gates/bash-command.test.ts`             | Red case for the reported repro, then the ordering cases (allow after the ask decides; allow before it does not)                                             |
+| `test/policy/permission-manager-unified.test.ts`       | The alias intent's `evaluateAnyValue` semantics and the recorded matched value                                                                               |
+| `test/access-intent/bash/token-collection.test.ts`     | Spans on the node-derived tokens, and their absence on the derived ones                                                                                      |
+| `test/handlers/gates/bash-command-metamorphic.test.ts` | Existing metamorphic properties must hold with the larger value set: a wrapper floor stays an ask whatever the alias matches, and a deny is never downgraded |
+
+Existing bash-gate tests are the regression guard for the fail-closed cases, and they are expected to pass unchanged.
+
+## Invariants at risk
+
+| Invariant                                                | Where it is pinned                                                   | Why this change could break it                                                                            |
+| -------------------------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| A chain's most restrictive unit decides                  | `test/handlers/gates/bash-command.test.ts`                           | Aliases are per unit; a wider lookup must not be applied to the whole chain                               |
+| A wrapper's `allow` floors to `ask`                      | `bash-command.ts` `WRAPPER_SENTINEL` cases                           | The floor is applied after the resolve, so it must read the floored result and not the alias that matched |
+| An unparsed subtree's `allow` floors to `ask`            | `UNPARSED_SUBTREE_SENTINEL` cases                                    | same                                                                                                      |
+| An explicit `deny` is never downgraded                   | `pickMostRestrictive` cases                                          | a new matching value can only add matches within one unit; the fold still sees every unit's worst result  |
+| A `path` allow cannot loosen an `external_directory` ask | package skill, `test/handlers/gates/tool-call-gate-pipeline.test.ts` | this change adds no cross-surface composition, and must not start one                                     |
+| The known base is required for resolution                | [#393] cases in `bash-path-resolver` tests                           | the alias text must be empty for an unknown base rather than falling back to the session cwd              |
+
+## TDD Order
+
+1. `refactor:` thread the source span through `PathToken` and `BashPathRuleCandidate`, with spans absent on the derived tokens.
+   Existing tests must pass unchanged.
+2. `refactor:` add the source span to `BashCommand`.
+3. `test:` add the alias accessor's cases to `program.test.ts` — they fail until step 4.
+4. `feat:` implement the alias accessor on `BashProgram`.
+5. `test:` add the alias intent's cases to `permission-manager-unified.test.ts`, then `refactor:` add the intent kind and route it through `evaluateAnyValue`.
+6. `test:` add the reported repro and the ordering cases to `bash-command.test.ts`, then `feat:` wire the alias texts into `resolveOnBashSurface`.
+7. `feat:` disclose the resolving text in the ask payload and the review log.
+8. `docs:` update `### bash Surface` and the package skill's matching note.
+
+## Risks and Mitigations
+
+| Risk                                                                                | Assessment                                                                                                                                                                                                                             | Mitigation                                                                                                                             |
+| ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| A silent permission widening                                                        | The intended widening: a rule written in an absolute spelling now governs the relative spelling of the same resolved path. It cannot reach a path the resolver did not resolve, and an unresolvable token keeps its literal value (R1) | The rewrite reads only classified candidates with a span; every new match is a named test case; the change is documented as a widening |
+| A quoted path argument starts matching a path rule                                  | Real, and a widening beyond the reported repro, because the rewrite replaces the quoted node span                                                                                                                                      | Covered by its own test case and named in `docs/configuration.md`                                                                      |
+| A session grant does not cross spellings                                            | Real. The grant records the approved command text, so the sibling spelling asks once more                                                                                                                                              | Stated in the docs as a residual; widening the grant to the alias text would grant a pattern the prompt never showed                   |
+| A command whose tokens are mixed between the two absolute spellings matches neither | Real but narrow                                                                                                                                                                                                                        | Stated as a residual; the three-value bound is what keeps the lookup count independent of the argument count                           |
+| Collision with Phase 15 steps 1–3                                                   | Real: they rewrite `token-collection.ts`, `command-enumeration.ts`, and the resolver this change edits, and their prep tidying touches the same loops                                                                                  | Sequence this change before or after those steps, never beside them; no other session is in this package while it lands                |
+| The alias text drifts from the gate's own token set                                 | A second derivation of the same list is the failure this package has paid for before                                                                                                                                                   | The accessor consumes `pathRuleCandidates()`'s own spans; no second walk over the AST                                                  |
+
+## Open Questions
+
+1. Should the alias text be built for tokens inside the working directory as well, or only for external ones?
+   Uniform handling is simpler to reason about and lets a rule written either way match; external-only keeps the rewritten text closer to what the operator typed.
+   The recommendation is uniform, because the containment decision is already a separate question from pattern matching.
+2. Should the review log record both texts on every bash decision, or the alias only when it decided?
+   The recommendation is the latter, so the log stays a record of decisions rather than of derivations.
+
+## References
+
+[#393]: https://github.com/gotgenes/pi-packages/issues/393
+[#418]: https://github.com/gotgenes/pi-packages/issues/418
+[#804]: https://github.com/gotgenes/pi-packages/issues/804
+[#822]: https://github.com/gotgenes/pi-packages/issues/822
+[#910]: https://github.com/gotgenes/pi-packages/issues/910

--- a/packages/pi-permission-system/src/access-intent/access-intent.ts
+++ b/packages/pi-permission-system/src/access-intent/access-intent.ts
@@ -50,8 +50,14 @@ export interface AccessPathAccessIntent {
   agentName?: string;
 }
 
-/** What a gate emits — a raw tool input or an `AccessPath`. */
-export type AccessIntent = ToolAccessIntent | AccessPathAccessIntent;
+/**
+ * What a gate emits — a raw tool input, an `AccessPath`, or the spellings of
+ * one invocation on a text-matching surface.
+ */
+export type AccessIntent =
+  | ToolAccessIntent
+  | AccessPathAccessIntent
+  | AliasValuesAccessIntent;
 
 /**
  * What the manager consumes — the `access-path` variant has already been
@@ -62,4 +68,31 @@ export type AccessIntent = ToolAccessIntent | AccessPathAccessIntent;
  * (`docs/decisions/0002-path-values-string-boundary.md`), guarded by a
  * `no-restricted-imports` lint rule on `permission-manager.ts`.
  */
-export type ResolvedAccessIntent = ToolAccessIntent | PathValuesAccessIntent;
+export type ResolvedAccessIntent =
+  | ToolAccessIntent
+  | PathValuesAccessIntent
+  | AliasValuesAccessIntent;
+
+/**
+ * Several spellings of one invocation, for a surface that matches text.
+ *
+ * The `bash` surface matches a command string, and the same command can name
+ * the same file in its absolute spelling. The gate supplies the unit's texts
+ * here — the text as typed first — so the manager evaluates them as *aliases*:
+ * last-match-wins across the union, rather than stopping at the first text that
+ * matches a rule. That is the treatment `AccessPath.matchValues()` already
+ * gives the lexical and canonical forms of a path (#418).
+ *
+ * `resultExtras` is the emitter's, because it knows the surface's own fields
+ * (`command` for bash) and the manager must not learn them: it is copied onto
+ * the result exactly as `NormalizedInput.resultExtras` is.
+ */
+export interface AliasValuesAccessIntent {
+  kind: "alias-values";
+  /** The surface whose rules the texts are matched against. */
+  surface: string;
+  /** The invocation's spellings, the one as typed first. */
+  values: readonly string[];
+  resultExtras: Record<string, unknown>;
+  agentName?: string;
+}

--- a/packages/pi-permission-system/src/access-intent/bash/bash-path-resolver.ts
+++ b/packages/pi-permission-system/src/access-intent/bash/bash-path-resolver.ts
@@ -8,7 +8,7 @@ import { normalizePathPolicyLiteral } from "#src/access-intent/path-normalizatio
 import type { PathNormalizer } from "#src/path/path-normalizer";
 import { isSafeSystemPath } from "#src/path/safe-system-paths";
 import { ARG_NODE_TYPES, SKIP_SUBTREE_TYPES } from "./node-text";
-import type { TSNode } from "./parser";
+import type { SourceSpan, TSNode } from "./parser";
 import {
   classifyBareTokenCandidate,
   classifyTokenAsPathCandidate,
@@ -47,6 +47,8 @@ interface PathCandidate {
   readonly token: string;
   readonly base: EffectiveBase;
   readonly effect: TokenEffect;
+  /** The argument node's span, when the token was read from one. */
+  readonly span?: SourceSpan;
 }
 
 /** A promoted bare token and its resolved path, before an effect is attached. */
@@ -64,12 +66,41 @@ export interface BashPathRuleCandidate {
   readonly path: AccessPath;
   /** The attributed effect that routes the token to a directional surface. */
   readonly effect: TokenEffect;
+  /**
+   * The argument node's span in the source command, for the one caller that
+   * rewrites the command text with resolved paths.
+   *
+   * Absent for a token the collectors derived from something other than a
+   * node's own text; such a token takes no part in the rewrite.
+   */
 }
 
 /** A path resolving outside the working directory, with its attributed effect. */
 export interface BashExternalPath {
   readonly path: AccessPath;
   readonly effect: TokenEffect;
+}
+
+/**
+ * One path argument to substitute in the command text, and what to put there.
+ *
+ * The rewrite exists so a `bash` rule written with a path in its absolute
+ * spelling also matches the command that names the same path relatively. The
+ * span is the argument node's own range, quotes included, because replacing a
+ * resolved token *inside* a quoted argument would leave the delimiters in the
+ * rewritten command where no path pattern matches them.
+ */
+export interface BashPathRewrite {
+  readonly span: SourceSpan;
+  /**
+   * The forms to substitute, at most one per alias text: the path's absolute
+   * lexical form first, then its canonical form when a symlink resolves it
+   * elsewhere.
+   *
+   * A rewrite with one form leaves the second alias text with its own first
+   * form, so the alias count is the longest list rather than a cross product.
+   */
+  readonly replacements: readonly string[];
 }
 
 /**
@@ -81,6 +112,14 @@ export interface ResolvedBashPaths {
   readonly externalAccesses: readonly BashExternalPath[];
   /** Every path-rule token paired with its cd-aware policy values (#393). */
   readonly ruleCandidates: readonly BashPathRuleCandidate[];
+  /**
+   * Path arguments to substitute with their absolute form, for the `bash`
+   * surface's second lookup value.
+   *
+   * One entry per rule candidate that carries a span and an absolute form, in
+   * source order.
+   */
+  readonly pathRewrites: readonly BashPathRewrite[];
 }
 
 // ── Walk-time constants ──────────────────────────────────────────────────────
@@ -134,11 +173,14 @@ export class BashPathResolver {
         ? CWD_BASE
         : this.deriveBaseFromCdTarget(CWD_BASE, this.workdir);
     const candidates = this.collectPathCandidates(rootNode, initialBase);
+    const { ruleCandidates, pathRewrites } =
+      this.projectRuleCandidates(candidates);
     return {
       externalAccesses: this.withWorkdirExternal(
         this.projectExternalPaths(candidates),
       ),
-      ruleCandidates: this.projectRuleCandidates(candidates),
+      ruleCandidates,
+      pathRewrites,
     };
   }
 
@@ -534,13 +576,15 @@ export class BashPathResolver {
    * A token after a non-literal `cd` keeps only its literal value so no
    * spurious absolute rule can match (#393).
    */
-  private projectRuleCandidates(
-    candidates: readonly PathCandidate[],
-  ): BashPathRuleCandidate[] {
+  private projectRuleCandidates(candidates: readonly PathCandidate[]): {
+    ruleCandidates: BashPathRuleCandidate[];
+    pathRewrites: BashPathRewrite[];
+  } {
     const seen = new Map<string, number>();
     const result: BashPathRuleCandidate[] = [];
+    const rewrites: BashPathRewrite[] = [];
 
-    for (const { token, base, effect } of candidates) {
+    for (const { token, base, effect, span } of candidates) {
       const shaped = classifyTokenAsRuleCandidate(
         token,
         this.normalizer.flavor,
@@ -553,6 +597,23 @@ export class BashPathResolver {
 
       const matchValues = probed.path.matchValues();
       if (matchValues.length === 0) continue;
+
+      // One rewrite per *occurrence*, not per resolved path: the dedup below
+      // folds two tokens naming the same path into one candidate, but both
+      // spans still appear in the command text and both must be substituted.
+      //
+      // Recorded only when a form actually differs from the token as written.
+      // A token already spelled absolutely needs no rewrite, and leaving it out
+      // keeps the list to the arguments whose text has to change. A token whose
+      // base was unknown keeps its literal value, which is not absolute, so it
+      // is excluded by the same test.
+      const replacements = [probed.path.value(), probed.path.resolvedAlias()]
+        .filter((value): value is string => value !== undefined)
+        .filter((value) => this.normalizer.isAbsolute(value));
+      const changesText = replacements.some((value) => value !== token);
+      if (span !== undefined && changesText) {
+        rewrites.push({ span, replacements });
+      }
 
       const key = matchValues.join("\0");
       const index = seen.get(key);
@@ -571,7 +632,7 @@ export class BashPathResolver {
       result.push({ ...probed, effect });
     }
 
-    return result;
+    return { ruleCandidates: result, pathRewrites: rewrites };
   }
 
   /**
@@ -659,7 +720,8 @@ function tagTokens(
   base: EffectiveBase,
   out: PathCandidate[],
 ): void {
-  for (const { token, effect } of tokens) out.push({ token, base, effect });
+  for (const { token, effect, span } of tokens)
+    out.push({ token, base, effect, span });
 }
 
 /**

--- a/packages/pi-permission-system/src/access-intent/bash/command-enumeration.ts
+++ b/packages/pi-permission-system/src/access-intent/bash/command-enumeration.ts
@@ -1,6 +1,11 @@
 import type { BashCommandContext, FloorExemption } from "#src/types";
 import { EXECUTION_HOST_TYPES, forEachExecutionIn } from "./nested-execution";
-import { parseUnresolvedWithin, type TSNode } from "./parser";
+import {
+  parseUnresolvedWithin,
+  type SourceSpan,
+  spanOf,
+  type TSNode,
+} from "./parser";
 import { redirectMayWriteFile } from "./redirect-analysis";
 import {
   type CommandWord,
@@ -206,16 +211,51 @@ const STATEMENT_TYPES = new Set([
  * wrapper unit (`bash -c`/`eval`, or an indirection wrapper such as `sudo`) is
  * tagged with a {@link WrapperKind} so its decision is later floored to `ask`.
  */
+/**
+ * One command unit paired with the source span it was read from.
+ *
+ * The pairing matters because the two are not interchangeable: `text` is a
+ * slice of `span`, with any leading `variable_assignment` prefix stripped.
+ */
+interface EmittedUnit {
+  readonly unit: BashCommand;
+  readonly span: SourceSpan;
+}
+
+/**
+ * Records one unit and its span in a single call, so the two slices an
+ * enumeration produces cannot drift apart.
+ */
+type EmitUnit = (emitted: EmittedUnit) => void;
+
+/** The two parallel slices one enumeration pass produces. */
+export interface BashCommandUnits {
+  /** The command-pattern units, in source order. */
+  readonly commands: BashCommand[];
+  /** One source span per unit, at the same index. */
+  readonly spans: SourceSpan[];
+}
+
 export function collectCommands(node: TSNode): BashCommand[] {
-  const out: BashCommand[] = [];
-  collectCommandsInto(node, TOP_LEVEL_SCOPE, out);
-  return out;
+  return collectCommandUnits(node).commands;
+}
+
+/** Enumerate `node`'s command units together with their source spans. */
+export function collectCommandUnits(node: TSNode): BashCommandUnits {
+  const commands: BashCommand[] = [];
+  const spans: SourceSpan[] = [];
+  const emit: EmitUnit = ({ unit, span }) => {
+    commands.push(unit);
+    spans.push(span);
+  };
+  collectCommandsInto(node, TOP_LEVEL_SCOPE, emit);
+  return { commands, spans };
 }
 
 function collectCommandsInto(
   node: TSNode,
   inherited: UnitScope,
-  out: BashCommand[],
+  emit: EmitUnit,
 ): void {
   // Anonymous tokens (operators `&&`/`;`/`|`, delimiters `$(`/`)`/`` ` ``/`(`)
   // carry no command.
@@ -225,44 +265,44 @@ function collectCommandsInto(
   const scope = unresolvedScope(node, inherited);
 
   if (node.type === "command") {
-    out.push(makeCommandUnit(node, scope));
+    emit(makeCommandUnit(node, scope));
     // A command's text already contains any substitution; descend its subtree
     // to ALSO emit the inner commands of command/process substitutions.
-    collectHostedCommands(node, out);
+    collectHostedCommands(node, emit);
     return;
   }
 
   if (node.type === "redirected_statement") {
-    descendCommandChildren(node, redirectedScope(node, scope), out);
+    descendCommandChildren(node, redirectedScope(node, scope), emit);
     return;
   }
 
   if (EXECUTION_HOST_TYPES.has(node.type)) {
     // Not a command itself, but its subtree can host one that really runs
     // (`> $(rm x)`, `< <(rm c)`). Emit only what it hosts (#741).
-    collectHostedCommands(node, out);
+    collectHostedCommands(node, emit);
     return;
   }
 
   if (node.type === "subshell") {
-    out.push(makeUnit(node.text, scope)); // never-weaker whole emit
-    descendCommandChildren(node, { ...scope, context: "subshell" }, out);
+    emitWhole(node, scope, emit);
+    descendCommandChildren(node, { ...scope, context: "subshell" }, emit);
     return;
   }
 
   if (COMMAND_ENUM_DESCEND.has(node.type)) {
-    descendCommandChildren(node, scope, out);
+    descendCommandChildren(node, scope, emit);
     return;
   }
 
   if (COMPOUND_STATEMENT_TYPES.has(node.type)) {
-    out.push(makeUnit(node.text, scope)); // never-weaker whole emit
-    descendStatementChildren(node, scope, out);
+    emitWhole(node, scope, emit);
+    descendStatementChildren(node, scope, emit);
     return;
   }
 
   if (STATEMENT_GROUP_TYPES.has(node.type)) {
-    descendStatementChildren(node, scope, out);
+    descendStatementChildren(node, scope, emit);
     return;
   }
 
@@ -271,7 +311,7 @@ function collectCommandsInto(
     // inside an ERROR subtree are not evidence that anything runs: descending
     // one turns backtick-quoted prose in an unterminated heredoc into command
     // units. Emit the unparsed blob whole and stop (#742).
-    out.push(makeUnit(node.text, scope));
+    emitWhole(node, scope, emit);
     return;
   }
 
@@ -280,8 +320,8 @@ function collectCommandsInto(
   // A declaration, assignment, test, or `unset` still hosts executions that
   // really run (`local x=$(rm y)`, `[[ $(rm x) ]]`), so those are enumerated
   // in addition to the statement (#742).
-  out.push(makeUnit(node.text, scope));
-  collectHostedCommands(node, out);
+  emitWhole(node, scope, emit);
+  collectHostedCommands(node, emit);
 }
 
 /**
@@ -334,20 +374,31 @@ function makeUnit(
 }
 
 /**
+ * Emit one whole-node unit — a subshell, compound statement, ERROR blob, or
+ * other statement — whose text is the node's own text.
+ */
+function emitWhole(node: TSNode, scope: UnitScope, emit: EmitUnit): void {
+  emit({ unit: makeUnit(node.text, scope), span: spanOf(node) });
+}
+
+/**
  * Build the unit for a `command` node, reading its words once to answer all
  * three wrapper questions: whether the unit is floored, what it actually runs,
  * and whether the floor still has a reason to hold.
  */
-function makeCommandUnit(node: TSNode, scope: UnitScope): BashCommand {
-  const text = commandUnitText(node);
+function makeCommandUnit(node: TSNode, scope: UnitScope): EmittedUnit {
+  const { text, span } = commandUnitText(node);
   const words = readCommandWords(node);
-  return makeUnit(text, scope, {
-    wrapperKind: classifyWrapperWords(words),
-    executedUnit: executedUnitOf(text, words) ?? undefined,
-    floorExemption: isTransparentWrapper(words, scope)
-      ? "core-reader"
-      : undefined,
-  });
+  return {
+    unit: makeUnit(text, scope, {
+      wrapperKind: classifyWrapperWords(words),
+      executedUnit: executedUnitOf(text, words) ?? undefined,
+      floorExemption: isTransparentWrapper(words, scope)
+        ? "core-reader"
+        : undefined,
+    }),
+    span,
+  };
 }
 
 /**
@@ -403,25 +454,30 @@ function readCommandWords(node: TSNode): CommandWord[] {
  * (the `command_name`) onward, sliced verbatim to preserve spacing. A pure
  * assignment (`FOO=bar`, no `command_name`) runs no command and is returned
  * unchanged.
+ * Returns the span alongside the text: the text is what a rule is matched
+ * against, and the span is what locates the unit's path tokens in the source.
  */
-function commandUnitText(node: TSNode): string {
+function commandUnitText(node: TSNode): { text: string; span: SourceSpan } {
   for (let i = 0; i < node.childCount; i++) {
     const child = node.child(i);
     if (child?.isNamed && child.type !== "variable_assignment") {
-      return node.text.slice(child.startIndex - node.startIndex);
+      return {
+        text: node.text.slice(child.startIndex - node.startIndex),
+        span: { start: child.startIndex, end: node.endIndex },
+      };
     }
   }
-  return node.text;
+  return { text: node.text, span: spanOf(node) };
 }
 
 function descendCommandChildren(
   node: TSNode,
   scope: UnitScope,
-  out: BashCommand[],
+  emit: EmitUnit,
 ): void {
   for (let i = 0; i < node.childCount; i++) {
     const child = node.child(i);
-    if (child) collectCommandsInto(child, scope, out);
+    if (child) collectCommandsInto(child, scope, emit);
   }
 }
 
@@ -444,13 +500,14 @@ function descendCommandChildren(
 function descendStatementChildren(
   node: TSNode,
   scope: UnitScope,
-  out: BashCommand[],
+  emit: EmitUnit,
 ): void {
   for (let i = 0; i < node.childCount; i++) {
     const child = node.child(i);
     if (!child?.isNamed) continue;
-    if (STATEMENT_TYPES.has(child.type)) collectCommandsInto(child, scope, out);
-    else collectHostedCommands(child, out);
+    if (STATEMENT_TYPES.has(child.type))
+      collectCommandsInto(child, scope, emit);
+    else collectHostedCommands(child, emit);
   }
 }
 
@@ -465,7 +522,7 @@ function descendStatementChildren(
  * `node` may be a context outright or merely host one, so the traversal is the
  * root-inclusive `forEachExecutionIn`.
  */
-function collectHostedCommands(node: TSNode, out: BashCommand[]): void {
+function collectHostedCommands(node: TSNode, emit: EmitUnit): void {
   forEachExecutionIn(node, (contextNode, context) => {
     // A nested execution starts fresh: an enclosing statement's redirect is
     // that statement's, not the substitution's, exactly as #807 attributes a
@@ -476,7 +533,7 @@ function collectHostedCommands(node: TSNode, out: BashCommand[]): void {
     descendCommandChildren(
       contextNode,
       { context, writesViaRedirect: false, parseUnresolved: false },
-      out,
+      emit,
     );
   });
 }

--- a/packages/pi-permission-system/src/access-intent/bash/parser.ts
+++ b/packages/pi-permission-system/src/access-intent/bash/parser.ts
@@ -13,8 +13,18 @@ import { memoizeAsyncWithRetry } from "./async-cache";
 export interface TSNode {
   readonly type: string;
   readonly text: string;
-  /** Absolute byte offset of this node's start in the parsed source. */
+  /**
+   * Start of this node in the parsed source, as a UTF-16 code-unit index into
+   * the source *string* — not a byte offset, and not a row/column.
+   *
+   * The distinction matters to any caller that slices the source: measured
+   * against the installed `web-tree-sitter`, an emoji costs two code units
+   * (`"cat 😀 /tmp/x"` puts the emoji at 4..6 and the next word at 7), where a
+   * byte offset would have put them at 4..8 and 9. Pinned in `parser.test.ts`.
+   */
   readonly startIndex: number;
+  /** End of this node, in the same index space as {@link startIndex}. */
+  readonly endIndex: number;
   readonly childCount: number;
   /** False for anonymous tokens (operators, delimiters); true for named nodes. */
   readonly isNamed: boolean;
@@ -23,6 +33,20 @@ export interface TSNode {
   /** The node immediately before this one under the same parent, named or not. */
   readonly previousSibling: TSNode | null;
   child(index: number): TSNode | null;
+}
+
+/**
+ * A half-open range of the parsed source, in {@link TSNode.startIndex}'s
+ * UTF-16 code-unit index space.
+ */
+export interface SourceSpan {
+  readonly start: number;
+  readonly end: number;
+}
+
+/** The source span of `node`, for a caller that slices the command text. */
+export function spanOf(node: TSNode): SourceSpan {
+  return { start: node.startIndex, end: node.endIndex };
 }
 
 /**

--- a/packages/pi-permission-system/src/access-intent/bash/program.ts
+++ b/packages/pi-permission-system/src/access-intent/bash/program.ts
@@ -2,10 +2,11 @@ import type { PathNormalizer } from "#src/path/path-normalizer";
 import {
   type BashExternalPath,
   BashPathResolver,
+  type BashPathRewrite,
   type BashPathRuleCandidate,
 } from "./bash-path-resolver";
-import { type BashCommand, collectCommands } from "./command-enumeration";
-import { getParser } from "./parser";
+import { type BashCommand, collectCommandUnits } from "./command-enumeration";
+import { getParser, type SourceSpan } from "./parser";
 
 export type { BashCommand, BashExternalPath, BashPathRuleCandidate };
 
@@ -23,8 +24,10 @@ export class BashProgram {
   private constructor(
     private readonly sourceCommand: string,
     private readonly commandUnits: readonly BashCommand[],
+    private readonly unitSpans: readonly SourceSpan[],
     private readonly resolvedExternalAccesses: readonly BashExternalPath[],
     private readonly resolvedRuleCandidates: readonly BashPathRuleCandidate[],
+    private readonly resolvedPathRewrites: readonly BashPathRewrite[],
   ) {}
 
   /**
@@ -53,18 +56,21 @@ export class BashProgram {
   ): Promise<BashProgram> {
     const parser = await getParser();
     const tree = parser.parse(command);
-    if (!tree) return new BashProgram(command, [], [], []);
+    if (!tree) return new BashProgram(command, [], [], [], [], []);
 
     try {
-      const { externalAccesses, ruleCandidates } = new BashPathResolver(
-        normalizer,
-        options?.workdir,
-      ).resolve(tree.rootNode);
+      const { externalAccesses, ruleCandidates, pathRewrites } =
+        new BashPathResolver(normalizer, options?.workdir).resolve(
+          tree.rootNode,
+        );
+      const { commands, spans } = collectCommandUnits(tree.rootNode);
       return new BashProgram(
         command,
-        collectCommands(tree.rootNode),
+        commands,
+        spans,
         externalAccesses,
         ruleCandidates,
+        pathRewrites,
       );
     } finally {
       tree.delete();
@@ -132,4 +138,67 @@ export class BashProgram {
   pathRuleCandidates(): BashPathRuleCandidate[] {
     return [...this.resolvedRuleCandidates];
   }
+
+  /**
+   * The alias texts for each command unit, at the same index as {@link commands}.
+   *
+   * Each is the unit's text with its resolved path arguments replaced by an
+   * absolute form, so a `bash` rule written in that spelling matches a command
+   * the operator wrote relatively. The gate tries them after the text as typed,
+   * last-match-wins across the union — the treatment
+   * `AccessPath.matchValues()` already gives the path surfaces.
+   *
+   * At most two per unit: the absolute lexical forms, then the canonical form of
+   * each argument a symlink resolves elsewhere. A unit whose arguments are every
+   * one already spelled absolutely yields none, because the resolver records a
+   * rewrite only when a form differs from the token as written, and any text
+   * equal to the unit's own is dropped here.
+   */
+  commandAliasTexts(): string[][] {
+    const source = this.sourceCommand;
+    return this.unitSpans.map((unit) => {
+      const inside = this.resolvedPathRewrites.filter(
+        (rewrite) =>
+          rewrite.span.start >= unit.start && rewrite.span.end <= unit.end,
+      );
+      if (inside.length === 0) return [];
+      const widths = Math.max(1, ...inside.map((r) => r.replacements.length));
+      const typed = source.slice(unit.start, unit.end);
+      const seen = new Set<string>([typed]);
+      const aliases: string[] = [];
+      for (let index = 0; index < widths; index++) {
+        const text = rewriteUnitText(source, unit, inside, index);
+        if (seen.has(text)) continue;
+        seen.add(text);
+        aliases.push(text);
+      }
+      return aliases;
+    });
+  }
+}
+
+/**
+ * `unit`'s source text with each rewrite's `index`-th replacement applied.
+ *
+ * Replacements run right to left, so the offsets of the ones not yet applied
+ * stay valid. A rewrite offering fewer forms than `index` reuses its last one,
+ * which is what keeps the alias count the longest list rather than a cross
+ * product over the command's arguments.
+ */
+function rewriteUnitText(
+  source: string,
+  unit: SourceSpan,
+  rewrites: readonly BashPathRewrite[],
+  index: number,
+): string {
+  let text = source.slice(unit.start, unit.end);
+  const ordered = [...rewrites].sort((a, b) => b.span.start - a.span.start);
+  for (const rewrite of ordered) {
+    const replacement =
+      rewrite.replacements[Math.min(index, rewrite.replacements.length - 1)];
+    const start = rewrite.span.start - unit.start;
+    const end = rewrite.span.end - unit.start;
+    text = `${text.slice(0, start)}${replacement}${text.slice(end)}`;
+  }
+  return text;
 }

--- a/packages/pi-permission-system/src/access-intent/bash/token-collection.ts
+++ b/packages/pi-permission-system/src/access-intent/bash/token-collection.ts
@@ -7,7 +7,7 @@ import {
   resolveNodeText,
   SKIP_SUBTREE_TYPES,
 } from "./node-text";
-import type { TSNode } from "./parser";
+import { type SourceSpan, spanOf, type TSNode } from "./parser";
 import { redirectEffectForDestination } from "./redirect-analysis";
 
 /**
@@ -20,6 +20,16 @@ import { redirectEffectForDestination } from "./redirect-analysis";
 export interface PathToken {
   readonly token: string;
   readonly effect: TokenEffect;
+  /**
+   * The source span of the argument node this token was read from, for the one
+   * caller that rewrites the command text with resolved paths.
+   *
+   * Absent when the token is derived from something other than a node's own
+   * text — an embedded `--opt=value`, a `find` directive path — because that
+   * node's span covers text the token does not stand for, so rewriting it would
+   * drop the flag. A token without a span takes no part in the rewrite.
+   */
+  readonly span?: SourceSpan;
 }
 
 // ── Public surface ─────────────────────────────────────────────────────────
@@ -117,7 +127,12 @@ export function collectRedirectTokens(node: TSNode): PathToken[] {
     if (!child) continue;
     if (ARG_NODE_TYPES.has(child.type)) {
       const effect = redirectEffectForDestination(node, child);
-      if (effect) tokens.push({ token: resolveNodeText(child), effect });
+      if (effect)
+        tokens.push({
+          token: resolveNodeText(child),
+          effect,
+          span: spanOf(child),
+        });
     }
     tokens.push(...collectHostedExecutionTokens(child));
   }
@@ -201,7 +216,11 @@ function collectStatementOperandTokens(
       tokens.push(...collectPathCandidateTokens(child));
       continue;
     }
-    tokens.push({ token: resolveNodeText(child), effect: UNPROVEN_EFFECT });
+    tokens.push({
+      token: resolveNodeText(child),
+      effect: UNPROVEN_EFFECT,
+      span: spanOf(child),
+    });
     tokens.push(...collectHostedExecutionTokens(child));
   }
   return tokens;
@@ -632,7 +651,12 @@ function collectPatternCommandTokens(
         tokens.push(...collectPathCandidateTokens(child));
         continue;
       }
-      const discharge = dischargePendingConsumption(consumption, text, effect);
+      const discharge = dischargePendingConsumption(
+        consumption,
+        text,
+        effect,
+        spanOf(child),
+      );
       if (discharge.token) tokens.push(discharge.token);
       if (discharge.consumed) continue;
     }
@@ -695,7 +719,7 @@ function collectPatternCommandTokens(
     if (!hasExplicitScript && positionalsSeen < patternPositionals) {
       positionalsSeen++; // Skip: this is an inline pattern/script.
     } else {
-      tokens.push({ token: text, effect });
+      tokens.push({ token: text, effect, span: spanOf(child) });
     }
     // A quoted flag never reaches the flag branch above, so its embedded value
     // is split here instead.
@@ -736,10 +760,11 @@ function dischargePendingConsumption(
   role: PatternFlagRole,
   text: string,
   effect: TokenEffect,
+  span: SourceSpan,
 ): ConsumptionDischarge {
   switch (role) {
     case "script-file":
-      return { consumed: true, token: { token: text, effect } };
+      return { consumed: true, token: { token: text, effect, span } };
     case "script":
     case "value":
       return { consumed: true };
@@ -781,7 +806,11 @@ function collectGenericCommandTokens(
 
     // Argument nodes: resolve their text and collect.
     if (ARG_NODE_TYPES.has(child.type)) {
-      tokens.push({ token: resolveNodeText(child), effect });
+      tokens.push({
+        token: resolveNodeText(child),
+        effect,
+        span: spanOf(child),
+      });
       continue;
     }
 

--- a/packages/pi-permission-system/src/handlers/gates/bash-command.ts
+++ b/packages/pi-permission-system/src/handlers/gates/bash-command.ts
@@ -69,12 +69,25 @@ export function resolveBashCommandCheck(
   commands: BashCommand[],
   agentName: string | undefined,
   resolver: ScopedPermissionResolver,
+  /**
+   * Per-unit alias texts, at the same index as `commands`.
+   *
+   * Each is the unit's text with its path arguments in an absolute spelling, so
+   * a rule written with that path matches a command written relatively. The
+   * gate tries them after the text as typed, last-match-wins across the union.
+   *
+   * Empty (the default) means the unit is matched on its text alone, which is
+   * what the whole-command and wrapper-inner resolves below do — both stay
+   * fail-closed rather than reaching for an alias they cannot attribute to a
+   * unit.
+   */
+  aliasTexts: readonly (readonly string[])[] = [],
 ): PermissionCheckResult {
   if (commands.length === 0) {
     if (isTriviallyEmptyCommand(command)) {
-      return resolveOnBashSurface(command, agentName, resolver);
+      return resolveOnBashSurface(command, [], agentName, resolver);
     }
-    const whole = resolveOnBashSurface(command, agentName, resolver);
+    const whole = resolveOnBashSurface(command, [], agentName, resolver);
     if (whole.state === "deny") {
       return whole;
     }
@@ -88,12 +101,18 @@ export function resolveBashCommandCheck(
     };
   }
 
-  const results = commands.map((cmd) =>
-    resolveCommandUnit(cmd, command, agentName, resolver),
+  const results = commands.map((cmd, index) =>
+    resolveCommandUnit(
+      cmd,
+      aliasTexts[index] ?? [],
+      command,
+      agentName,
+      resolver,
+    ),
   );
   return (
     pickMostRestrictive(results) ??
-    resolveOnBashSurface(command, agentName, resolver)
+    resolveOnBashSurface(command, [], agentName, resolver)
   );
 }
 
@@ -104,11 +123,12 @@ export function resolveBashCommandCheck(
  */
 function resolveCommandUnit(
   cmd: BashCommand,
+  aliases: readonly string[],
   command: string,
   agentName: string | undefined,
   resolver: ScopedPermissionResolver,
 ): PermissionCheckResult {
-  const base = resolveOnBashSurface(cmd.text, agentName, resolver);
+  const base = resolveOnBashSurface(cmd.text, aliases, agentName, resolver);
   const floored =
     cmd.wrapperKind && base.state === "allow"
       ? resolveWrapperUnit(cmd, cmd.wrapperKind, base, agentName, resolver)
@@ -190,7 +210,7 @@ function resolveWrapperUnit(
   // `command`, and naming a fragment of the command line there would offer a
   // grant that does not cover what the user is looking at.
   return {
-    ...resolveOnBashSurface(inner, agentName, resolver),
+    ...resolveOnBashSurface(inner, [], agentName, resolver),
     command: base.command,
     floorExemption: cmd.floorExemption,
   };
@@ -219,13 +239,27 @@ function isTriviallyEmptyCommand(command: string): boolean {
  */
 function resolveOnBashSurface(
   command: string,
+  aliases: readonly string[],
   agentName: string | undefined,
   resolver: ScopedPermissionResolver,
 ): PermissionCheckResult {
+  if (aliases.length === 0) {
+    return resolver.resolve({
+      kind: "tool",
+      surface: "bash",
+      input: { command },
+      agentName,
+    });
+  }
+  // The alias-aware intent, so the manager evaluates the texts as spellings of
+  // one invocation (`evaluateAnyValue`) rather than stopping at the first text
+  // that matches a rule. `command` rides `resultExtras` because the surface's
+  // own field is the emitter's business, not the manager's.
   return resolver.resolve({
-    kind: "tool",
+    kind: "alias-values",
     surface: "bash",
-    input: { command },
+    values: [command, ...aliases],
+    resultExtras: { command },
     agentName,
   });
 }

--- a/packages/pi-permission-system/src/handlers/gates/runner.ts
+++ b/packages/pi-permission-system/src/handlers/gates/runner.ts
@@ -109,6 +109,12 @@ export class GateRunner {
       ...renderReviewLogFacts(descriptor.payload),
       agentName,
       requestId,
+      // The resolved spelling, when a rule matched it rather than the command as
+      // typed. The entry's own `command` is the text the operator wrote, so
+      // without this the recorded rule and command read as a mismatch.
+      ...(check.matchedAlias === undefined
+        ? {}
+        : { matchedAlias: check.matchedAlias }),
     };
 
     // Each resolution below states its own decider. The provenance is built

--- a/packages/pi-permission-system/src/handlers/gates/tool-call-gate-pipeline.ts
+++ b/packages/pi-permission-system/src/handlers/gates/tool-call-gate-pipeline.ts
@@ -187,6 +187,7 @@ export class ToolCallGatePipeline {
             bashProgram.commands(),
             tcc.agentName ?? undefined,
             this.resolver,
+            bashProgram.commandAliasTexts(),
           ),
         };
       }

--- a/packages/pi-permission-system/src/policy/permission-manager.ts
+++ b/packages/pi-permission-system/src/policy/permission-manager.ts
@@ -334,6 +334,24 @@ export class PermissionManager implements ScopedPermissionManager {
       );
     }
 
+    if (intent.kind === "alias-values") {
+      const lookupValues =
+        intent.values.length > 0 ? [...intent.values] : ["*"];
+      return buildCheckResult(
+        intent.surface,
+        lookupValues,
+        intent.resultExtras,
+        intent.surface,
+        intent.surface,
+        fullRules,
+        this.flavor,
+        // The texts name one invocation, so the last rule matching any of
+        // them decides — `evaluateFirst` would stop at the first text with a
+        // rule, which is exactly what the alias exists to look past.
+        true,
+      );
+    }
+
     // kind === "tool"
     const toolName = intent.surface.trim();
     const { surface, values, resultExtras } = normalizeInput(
@@ -368,10 +386,16 @@ function buildCheckResult(
   toolName: string,
   fullRules: Ruleset,
   flavor: PathFlavor,
+  /**
+   * Force alias matching for a surface the path check does not claim, because
+   * the intent's values name one invocation in several spellings.
+   */
+  aliasMatching = false,
 ): PermissionCheckResult {
-  const { rule, value } = PATH_SURFACES.has(surface)
-    ? evaluateAnyValue(surface, values, fullRules, flavor)
-    : evaluateFirst(surface, values, fullRules, flavor);
+  const { rule, value } =
+    aliasMatching || PATH_SURFACES.has(surface)
+      ? evaluateAnyValue(surface, values, fullRules, flavor)
+      : evaluateFirst(surface, values, fullRules, flavor);
 
   // For MCP, replace the normalizer's fallback target with the actual
   // matched candidate value so PermissionCheckResult.target is accurate.
@@ -391,6 +415,9 @@ function buildCheckResult(
     source: deriveSource(rule, normalizedToolName),
     origin: rule.origin,
     ...extras,
+    // Only an alias has a spelling to report: when the first value decided,
+    // the result keeps the shape it had before this intent existed.
+    ...(aliasMatching && value !== values[0] ? { matchedAlias: value } : {}),
   };
 }
 

--- a/packages/pi-permission-system/src/presentation/tool-ask-payload.ts
+++ b/packages/pi-permission-system/src/presentation/tool-ask-payload.ts
@@ -44,7 +44,7 @@ export function buildToolAskPayload(facts: ToolAskFacts): PromptPayload {
       executedUnit: check.executedUnit ?? null,
     },
     evidence: bash
-      ? fullCommandEvidence(facts)
+      ? [...fullCommandEvidence(facts), ...aliasEvidence(check)]
       : inputPreviewEvidence(facts, mcp),
     annotations: [],
   };
@@ -81,6 +81,20 @@ function fullCommandEvidence(facts: ToolAskFacts): PromptEvidence[] {
     return [];
   }
   return [{ label: "full command", text: fullCommand, detail: null }];
+}
+/**
+ * The resolved spelling whose rule decided, when one did.
+ *
+ * An ask raised by a rule that matched a *resolved* spelling cannot be read off
+ * the command alone: the rule names the path in one spelling and the command
+ * uses another, so a reader who sees only the command sees a rule that does not
+ * appear to cover it. Shown only when the alias was what decided, so a prompt
+ * never displays a form no rule consulted.
+ */
+function aliasEvidence(check: PermissionCheckResult): PromptEvidence[] {
+  const alias = getNonEmptyString(check.matchedAlias);
+  if (alias === null || alias === check.command) return [];
+  return [{ label: "resolved as", text: alias, detail: null }];
 }
 
 /**

--- a/packages/pi-permission-system/src/types.ts
+++ b/packages/pi-permission-system/src/types.ts
@@ -63,6 +63,14 @@ export interface PermissionCheckResult {
   matchedPattern?: string;
   command?: string;
   target?: string;
+  /**
+   * The alias spelling that decided, when the winning rule matched one of the
+   * `bash` surface's alias texts rather than the command as typed.
+   *
+   * Absent otherwise, and absent whenever no alias was consulted, so a result
+   * that never used one keeps the shape it had.
+   */
+  matchedAlias?: string;
   source: "tool" | "bash" | "mcp" | "skill" | "special" | "default" | "session";
   /** Which source contributed the winning rule. */
   origin: RuleOrigin;

--- a/packages/pi-permission-system/test/access-intent/bash/parser.test.ts
+++ b/packages/pi-permission-system/test/access-intent/bash/parser.test.ts
@@ -244,3 +244,46 @@ describe("parseUnresolvedWithin", () => {
     });
   });
 });
+
+describe("node source spans", () => {
+  /**
+   * The one place the index space is asserted, because a caller that slices
+   * the source by these indices depends on it.
+   *
+   * A byte offset — what tree-sitter's own column reports — would put the
+   * words after a non-ASCII character at the wrong place, and the resolved-path
+   * rewrite would then replace the wrong text.
+   */
+  it("indexes the source in UTF-16 code units, not bytes", async () => {
+    const parser = await getParser();
+    const cases = [
+      { source: "cat é /tmp/x", nextWord: "/tmp/x", start: 6 },
+      { source: "cat 😀 /tmp/x", nextWord: "/tmp/x", start: 7 },
+      { source: "cat /tmp/x", nextWord: "/tmp/x", start: 4 },
+    ];
+    for (const { source, nextWord, start } of cases) {
+      const tree = parser.parse(source);
+      const words = collectNodes(tree?.rootNode ?? null).filter(
+        (node) => node.type === "word",
+      );
+      const word = words.find((node) => node.text === nextWord);
+      expect(word?.startIndex, source).toBe(start);
+      expect(word?.endIndex, source).toBe(start + nextWord.length);
+      expect(source.slice(word?.startIndex, word?.endIndex), source).toBe(
+        nextWord,
+      );
+      tree?.delete();
+    }
+  });
+});
+
+/** Every node of the tree, in walk order. */
+function collectNodes(root: TSNode | null): TSNode[] {
+  if (root === null) return [];
+  const found: TSNode[] = [root];
+  for (let i = 0; i < root.childCount; i++) {
+    const child = root.child(i);
+    if (child) found.push(...collectNodes(child));
+  }
+  return found;
+}

--- a/packages/pi-permission-system/test/access-intent/bash/program.test.ts
+++ b/packages/pi-permission-system/test/access-intent/bash/program.test.ts
@@ -2091,3 +2091,154 @@ describe("BashProgram", () => {
     });
   });
 });
+
+/**
+ * The alias text is the bash surface's second lookup value: the same command
+ * with its path arguments in an absolute spelling, so a rule written that way
+ * matches a command written relatively.
+ *
+ * A resolver rewrite exists only where an absolute form differs from the token
+ * as written, which is what keeps a non-literal base and a token already spelled
+ * absolutely on their typed text.
+ */
+describe("BashProgram commandAliasTexts", () => {
+  const cwd = "/projects/my-app";
+  const normalizer = new PathNormalizer(
+    pathFlavorForPlatform(process.platform),
+    cwd,
+  );
+
+  beforeEach(() => {
+    realpathSync.mockReset();
+    realpathSync.mockImplementation((p: string) => p);
+  });
+
+  describe("relative arguments", () => {
+    it("aliases a relative operand to the directory a literal cd establishes", async () => {
+      const program = await BashProgram.parse(
+        "cd /tmp && rm agent-builds/x",
+        normalizer,
+      );
+      expect(program.commands().map(({ text }) => text)).toEqual([
+        "cd /tmp",
+        "rm agent-builds/x",
+      ]);
+      expect(program.commandAliasTexts()).toEqual([
+        [],
+        ["rm /tmp/agent-builds/x"],
+      ]);
+    });
+
+    it("leaves the flags and the env prefix outside the substituted path", async () => {
+      const program = await BashProgram.parse(
+        "cd /tmp && AWS_PROFILE=prod rm -rf agent-builds/x",
+        normalizer,
+      );
+      expect(program.commandAliasTexts()).toEqual([
+        [],
+        ["rm -rf /tmp/agent-builds/x"],
+      ]);
+    });
+
+    it("rewrites every relative argument of one unit", async () => {
+      const program = await BashProgram.parse(
+        "cd /tmp && cp -r agent-builds/a agent-builds/b",
+        normalizer,
+      );
+      expect(program.commandAliasTexts()).toEqual([
+        [],
+        ["cp -r /tmp/agent-builds/a /tmp/agent-builds/b"],
+      ]);
+    });
+
+    it("drops the delimiters of a quoted relative operand", async () => {
+      const program = await BashProgram.parse(
+        "cd /tmp && rm 'agent-builds/x'",
+        normalizer,
+      );
+      expect(program.commandAliasTexts()).toEqual([
+        [],
+        ["rm /tmp/agent-builds/x"],
+      ]);
+    });
+
+    it("adds the canonical form as a second alias when a symlink resolves it", async () => {
+      realpathSync.mockImplementation((p: string) => {
+        if (p === "/tmp") return "/private/tmp";
+        if (p.startsWith("/tmp/")) return `/private/tmp${p.slice(4)}`;
+        return p;
+      });
+      const program = await BashProgram.parse(
+        "cd /tmp && rm agent-builds/x",
+        normalizer,
+      );
+      expect(program.commandAliasTexts()).toEqual([
+        ["cd /private/tmp"],
+        ["rm /tmp/agent-builds/x", "rm /private/tmp/agent-builds/x"],
+      ]);
+    });
+
+    it("reuses a rewrite's last form when it has fewer than the alias count", async () => {
+      // `../var/b` has one form and `agent-builds/a` has two, so the second
+      // alias text pairs the canonical form with the only form available.
+      realpathSync.mockImplementation((p: string) => {
+        if (p === "/tmp") return "/private/tmp";
+        if (p.startsWith("/tmp/")) return `/private/tmp${p.slice(4)}`;
+        return p;
+      });
+      const program = await BashProgram.parse(
+        "cd /tmp && cp agent-builds/a ../var/b",
+        normalizer,
+      );
+      expect(program.commandAliasTexts()).toEqual([
+        ["cd /private/tmp"],
+        [
+          "cp /tmp/agent-builds/a /var/b",
+          "cp /private/tmp/agent-builds/a /var/b",
+        ],
+      ]);
+    });
+
+    it("yields no alias for a value split out of an option", async () => {
+      // The token was read from the `--directory=value` split, not from a node
+      // of its own, so there is no span to replace and the flag survives.
+      const program = await BashProgram.parse(
+        "cd /tmp && tar --directory=x/y -xf a.tar",
+        normalizer,
+      );
+      expect(program.pathRuleCandidates().map(({ token }) => token)).toEqual([
+        "/tmp",
+        "x/y",
+      ]);
+      expect(program.commandAliasTexts()).toEqual([[], []]);
+    });
+
+    it("aliases an operand a statement names for itself", async () => {
+      const program = await BashProgram.parse(
+        "for f in etc/shadow; do cat $f; done",
+        normalizer,
+      );
+      expect(program.commandAliasTexts()).toEqual([
+        ["for f in /projects/my-app/etc/shadow; do cat $f; done"],
+        // The loop body is its own unit, and its variable is no path.
+        [],
+      ]);
+    });
+
+    it("yields no alias for a unit already spelled absolutely", async () => {
+      const program = await BashProgram.parse(
+        "rm /tmp/agent-builds/x",
+        normalizer,
+      );
+      expect(program.commandAliasTexts()).toEqual([[]]);
+    });
+
+    it("yields no alias when the effective base is not literal", async () => {
+      const program = await BashProgram.parse(
+        'cd "$DIR" && rm etc/shadow',
+        normalizer,
+      );
+      expect(program.commandAliasTexts()).toEqual([[], []]);
+    });
+  });
+});

--- a/packages/pi-permission-system/test/access-intent/bash/token-collection.test.ts
+++ b/packages/pi-permission-system/test/access-intent/bash/token-collection.test.ts
@@ -721,7 +721,11 @@ describe("statement operands", () => {
     const tree = parser.parse(command);
     if (!tree) throw new Error("parse returned null");
     try {
-      return collectPathCandidateTokens(tree.rootNode);
+      // Spans are dropped: this helper's subject is what a statement's own
+      // operand collects, not where it sits in the source.
+      return collectPathCandidateTokens(tree.rootNode).map(
+        ({ token, effect }) => ({ token, effect }),
+      );
     } finally {
       tree.delete();
     }
@@ -963,7 +967,12 @@ describe("effect attribution", () => {
     const tree = parser.parse(command);
     if (!tree) throw new Error("parse returned null");
     try {
-      return collectPathCandidateTokens(tree.rootNode);
+      // Spans are dropped: this helper's subject is the effect a token's
+      // position proved, and the span is asserted where a caller uses it
+      // (`program.test.ts`).
+      return collectPathCandidateTokens(tree.rootNode).map(
+        ({ token, effect }) => ({ token, effect }),
+      );
     } finally {
       tree.delete();
     }

--- a/packages/pi-permission-system/test/handlers/gates/bash-command.test.ts
+++ b/packages/pi-permission-system/test/handlers/gates/bash-command.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
 
+import { BashProgram } from "#src/access-intent/bash/program";
 import { resolveBashCommandCheck } from "#src/handlers/gates/bash-command";
+import { pathFlavorForPlatform } from "#src/path/path-flavor";
+import { PathNormalizer } from "#src/path/path-normalizer";
+import { PermissionResolver } from "#src/policy/permission-resolver";
 import type { PermissionCheckResult } from "#src/types";
 
 import { makeResolver } from "#test/helpers/gate-fixtures";
 import { makeCheckResult } from "#test/helpers/handler-fixtures";
+import { createInMemoryManager } from "#test/helpers/manager-harness";
 
 /** Build a bash-surface check result for a single command unit. */
 function bashResult(
@@ -678,6 +683,96 @@ describe("resolveBashCommandCheck", () => {
 
       expect(result.state).toBe("ask");
       expect(result.matchedPattern).toBe("<indirection-bash-wrapper>");
+    });
+  });
+});
+
+/**
+ * A `bash` rule that names a path in its absolute spelling has to reach the
+ * command that names the same path relatively, or the rule silently misses the
+ * command it was written for.
+ */
+describe("resolveBashCommandCheck — alias texts", () => {
+  const normalizer = new PathNormalizer(
+    pathFlavorForPlatform(process.platform),
+    "/projects/my-app",
+  );
+
+  /** A cwd that makes `agent-builds/x` resolve to the absolute spelling. */
+  const tmpCwd = new PathNormalizer(
+    pathFlavorForPlatform(process.platform),
+    "/tmp",
+  );
+
+  function resolverFor(bash: Record<string, "allow" | "ask" | "deny">) {
+    const manager = createInMemoryManager({
+      global: { permission: { "*": "ask", bash } },
+    });
+    return new PermissionResolver(manager, { getRuleset: () => [] });
+  }
+
+  const relativeRm = "cd /tmp && rm agent-builds/x";
+  const bashRules = {
+    "*": "allow",
+    "rm *": "ask",
+    "rm /tmp/agent-builds/*": "allow",
+  } as const;
+
+  it("decides on the alias text when the text as typed matches only an ask", async () => {
+    const program = await BashProgram.parse(relativeRm, normalizer);
+    const result = resolveBashCommandCheck(
+      program.commandText(),
+      program.commands(),
+      undefined,
+      resolverFor(bashRules),
+      program.commandAliasTexts(),
+    );
+    // The chain folds to its most permissive unit here, so the state is what
+    // this case turns on; the attribution is asserted on a single unit below.
+    expect(result.state).toBe("allow");
+  });
+
+  it("attributes the decision to the alias text and the rule it matched", async () => {
+    const program = await BashProgram.parse("rm agent-builds/x", tmpCwd);
+    const result = resolveBashCommandCheck(
+      program.commandText(),
+      program.commands(),
+      undefined,
+      resolverFor({ "rm *": "ask", "rm /tmp/agent-builds/*": "allow" }),
+      program.commandAliasTexts(),
+    );
+    expect(result.state).toBe("allow");
+    expect(result.matchedPattern).toBe("rm /tmp/agent-builds/*");
+    expect(result.matchedAlias).toBe("rm /tmp/agent-builds/x");
+  });
+
+  it("asks for the same command when no alias text is supplied", async () => {
+    const program = await BashProgram.parse(relativeRm, normalizer);
+    const result = resolveBashCommandCheck(
+      program.commandText(),
+      program.commands(),
+      undefined,
+      resolverFor(bashRules),
+    );
+    expect(result.state).toBe("ask");
+    expect(result.matchedPattern).toBe("rm *");
+  });
+
+  it("offers a unit's alias texts on the bash surface, beside the text as typed", () => {
+    const resolver = makeResolver(bashResult("ask", "rm agent-builds/x"));
+    resolveBashCommandCheck(
+      "rm agent-builds/x",
+      [{ text: "rm agent-builds/x" }],
+      undefined,
+      resolver,
+      [["rm /tmp/agent-builds/x"]],
+    );
+    expect(resolver.resolve).toHaveBeenCalledWith({
+      kind: "alias-values",
+      surface: "bash",
+      values: ["rm agent-builds/x", "rm /tmp/agent-builds/x"],
+      resultExtras: { command: "rm agent-builds/x" },
+      agentName: undefined,
     });
   });
 });

--- a/packages/pi-permission-system/test/handlers/gates/runner.test.ts
+++ b/packages/pi-permission-system/test/handlers/gates/runner.test.ts
@@ -1150,4 +1150,46 @@ describe("GateRunner — request identity", () => {
     await runner.run(makeDescriptor(), null);
     expect(decisions[0].requestId).toMatch(/^perm-/);
   });
+
+  it("records the resolved spelling a rule matched, not the command as typed", async () => {
+    const { runner, deps } = makeGateRunner({
+      resolveResult: makeCheckResult({
+        state: "deny",
+        matchedPattern: "rm /etc/*",
+        matchedAlias: "rm /etc/shadow",
+      }),
+    });
+    await runner.run(
+      makeDescriptor({
+        surface: "bash",
+        input: { command: "rm shadow" },
+        decision: { surface: "bash", value: "rm shadow" },
+      }),
+      null,
+    );
+    expect(deps.reporter.writeReviewLog).toHaveBeenCalledWith(
+      "permission_request.blocked",
+      expect.objectContaining({
+        matchedAlias: "rm /etc/shadow",
+      }),
+    );
+  });
+
+  it("omits the resolved spelling when the text as typed decided", async () => {
+    const { runner, deps } = makeGateRunner({
+      resolveResult: makeCheckResult({ state: "deny", matchedPattern: "rm *" }),
+    });
+    await runner.run(
+      makeDescriptor({
+        surface: "bash",
+        input: { command: "rm shadow" },
+        decision: { surface: "bash", value: "rm shadow" },
+      }),
+      null,
+    );
+    const entry = vi
+      .mocked(deps.reporter.writeReviewLog)
+      .mock.calls.find(([event]) => event === "permission_request.blocked");
+    expect(entry?.[1]).not.toHaveProperty("matchedAlias");
+  });
 });

--- a/packages/pi-permission-system/test/handlers/gates/tool-call-gate-pipeline.test.ts
+++ b/packages/pi-permission-system/test/handlers/gates/tool-call-gate-pipeline.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import type { BashExternalPath } from "#src/access-intent/bash/bash-path-resolver";
+import type { BashCommand } from "#src/access-intent/bash/command-enumeration";
 import { isGateDescriptor } from "#src/handlers/gates/descriptor";
 import { ToolCallGatePipeline } from "#src/handlers/gates/tool-call-gate-pipeline";
 import { PathNormalizer } from "#src/path/path-normalizer";
@@ -37,9 +37,10 @@ vi.mock("node:fs", () => ({
 function makeMockBashProgram(command = "echo hello") {
   return {
     commandText: vi.fn(() => command),
-    commands: vi.fn<() => []>(() => []),
+    commands: vi.fn<() => BashCommand[]>(() => []),
     pathRuleCandidates: vi.fn<() => []>(() => []),
     externalAccesses: vi.fn<() => BashExternalPath[]>(() => []),
+    commandAliasTexts: vi.fn<() => string[][]>(() => []),
   };
 }
 
@@ -223,6 +224,29 @@ describe("ToolCallGatePipeline", () => {
       expect(result).toEqual({ action: "allow" });
     });
 
+    it("offers the parsed program's alias texts to the bash check", async () => {
+      const program = makeMockBashProgram("rm agent-builds/x");
+      program.commands.mockReturnValue([{ text: "rm agent-builds/x" }]);
+      program.commandAliasTexts.mockReturnValue([["rm /tmp/agent-builds/x"]]);
+      mockBashProgramParse.mockResolvedValue(program);
+      const resolver = makeResolver(makeCheckResult());
+      const { runner } = makeGateRunner();
+      const pipeline = new ToolCallGatePipeline(resolver, makeGateInputs());
+
+      await pipeline.evaluate(
+        makeTcc({ toolName: "bash", input: { command: "rm agent-builds/x" } }),
+        runner,
+      );
+
+      expect(resolver.resolve).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "alias-values",
+          surface: "bash",
+          values: ["rm agent-builds/x", "rm /tmp/agent-builds/x"],
+        }),
+      );
+    });
+
     it("parses BashProgram exactly once per evaluate for bash tools with a command", async () => {
       const resolver = makeResolver(makeCheckResult());
       const inputs = makeGateInputs();
@@ -292,6 +316,7 @@ describe("ToolCallGatePipeline", () => {
         commands: vi.fn(() => [{ text }]),
         pathRuleCandidates: vi.fn<() => []>(() => []),
         externalAccesses: vi.fn<() => BashExternalPath[]>(() => []),
+        commandAliasTexts: vi.fn<() => []>(() => []),
       };
     }
 

--- a/packages/pi-permission-system/test/helpers/fake-ts-node.ts
+++ b/packages/pi-permission-system/test/helpers/fake-ts-node.ts
@@ -9,6 +9,8 @@ import type { TSNode } from "#src/access-intent/bash/parser";
  * `variable_name`, a quoted string's inner content) can be expressed directly.
  * A fake node is a well-formed one: it reports no parse error and no preceding
  * sibling, because the helpers this builds for read neither.
+ * Its span is `0..text.length`, the range a real parse reports for a node that
+ * begins at the source's own first character.
  *
  * Prefer a real parse (`getParser()`) when the test's subject is the AST shape
  * tree-sitter actually produces; use this when the subject is the helper's
@@ -23,6 +25,7 @@ export function makeTSNode(
     type,
     text,
     startIndex: 0,
+    endIndex: text.length,
     childCount: children.length,
     isNamed: true,
     hasError: false,

--- a/packages/pi-permission-system/test/helpers/gate-fixtures.ts
+++ b/packages/pi-permission-system/test/helpers/gate-fixtures.ts
@@ -214,7 +214,10 @@ export function makePathDispatchResolver(
       }
       return defaultResult;
     }
-    const values = intent.path.matchValues();
+    const values =
+      intent.kind === "alias-values"
+        ? intent.values
+        : intent.path.matchValues();
     for (const value of values) {
       if (value in byPath) return byPath[value];
     }

--- a/packages/pi-permission-system/test/helpers/handler-fixtures.ts
+++ b/packages/pi-permission-system/test/helpers/handler-fixtures.ts
@@ -320,6 +320,14 @@ export function makeHandler(overrides?: {
             sessionRules,
           );
         }
+        if (intent.kind === "alias-values") {
+          return surfaceCheck(
+            intent.surface,
+            { command: intent.values[0] ?? "*" },
+            intent.agentName,
+            sessionRules,
+          );
+        }
         return surfaceCheck(
           intent.surface,
           intent.input,

--- a/packages/pi-permission-system/test/policy/permission-manager-unified.test.ts
+++ b/packages/pi-permission-system/test/policy/permission-manager-unified.test.ts
@@ -3573,3 +3573,87 @@ describe("check — path-values intent", () => {
     }
   });
 });
+
+/**
+ * The bash surface matches text, so one command can name the same path in two
+ * spellings. The gate supplies both as aliases; the last rule matching either
+ * decides, exactly as the path surfaces treat a path's lexical and canonical
+ * forms (#418).
+ */
+describe("checkPermission — alias values on the bash surface", () => {
+  function aliasIntent(values: readonly string[]): ResolvedAccessIntent {
+    return {
+      kind: "alias-values",
+      surface: "bash",
+      values,
+      resultExtras: { command: values[0] ?? "" },
+    };
+  }
+
+  it("lets a later absolute-path allow decide over an earlier ask", () => {
+    const manager = createInMemoryManager({
+      global: {
+        permission: {
+          "*": "ask",
+          bash: {
+            "*": "allow",
+            "rm *": "ask",
+            "rm /tmp/agent-builds/*": "allow",
+          },
+        },
+      },
+    });
+    const result = manager.check(
+      aliasIntent(["rm agent-builds/x", "rm /tmp/agent-builds/x"]),
+    );
+    expect(result.state).toBe("allow");
+    expect(result.matchedPattern).toBe("rm /tmp/agent-builds/*");
+    expect(result.source).toBe("bash");
+    expect(result.command).toBe("rm agent-builds/x");
+    expect(result.matchedAlias).toBe("rm /tmp/agent-builds/x");
+  });
+
+  it("keeps the order the operator wrote, so a later ask still asks", () => {
+    const manager = createInMemoryManager({
+      global: {
+        permission: {
+          "*": "ask",
+          bash: {
+            "rm /tmp/agent-builds/*": "allow",
+            "rm *": "ask",
+          },
+        },
+      },
+    });
+    const result = manager.check(
+      aliasIntent(["rm agent-builds/x", "rm /tmp/agent-builds/x"]),
+    );
+    expect(result.state).toBe("ask");
+    expect(result.matchedPattern).toBe("rm *");
+  });
+
+  it("reports no alias when the text as typed decided", () => {
+    const manager = createInMemoryManager({
+      global: { permission: { "*": "ask", bash: { "*": "allow" } } },
+    });
+    const result = manager.check(
+      aliasIntent(["rm agent-builds/x", "rm /tmp/agent-builds/x"]),
+    );
+    expect(result.state).toBe("allow");
+    expect(result.matchedAlias).toBeUndefined();
+  });
+
+  it("still evaluates a deny on the alias text", () => {
+    const manager = createInMemoryManager({
+      global: {
+        permission: {
+          "*": "allow",
+          bash: { "rm /etc/*": "deny" },
+        },
+      },
+    });
+    const result = manager.check(aliasIntent(["rm shadow", "rm /etc/shadow"]));
+    expect(result.state).toBe("deny");
+    expect(result.matchedPattern).toBe("rm /etc/*");
+  });
+});

--- a/packages/pi-permission-system/test/presentation/tool-ask-payload.test.ts
+++ b/packages/pi-permission-system/test/presentation/tool-ask-payload.test.ts
@@ -146,6 +146,42 @@ describe("buildToolAskPayload", () => {
         detail: null,
       });
     });
+    test("carries the resolved spelling a rule matched instead of the text as typed", () => {
+      expect(
+        findEvidence(
+          buildPayload({
+            check: toolResult("bash", {
+              command: "rm agent-builds/x",
+              matchedPattern: "rm /tmp/agent-builds/*",
+              matchedAlias: "rm /tmp/agent-builds/x",
+            }),
+            input: { command: "rm agent-builds/x" },
+            formatter: makeFormatter(),
+          }),
+          "resolved as",
+        ),
+      ).toEqual({
+        label: "resolved as",
+        text: "rm /tmp/agent-builds/x",
+        detail: null,
+      });
+    });
+
+    test("omits the resolved spelling when the text as typed decided", () => {
+      expect(
+        findEvidence(
+          buildPayload({
+            check: toolResult("bash", {
+              command: "rm /tmp/agent-builds/x",
+              matchedPattern: "rm /tmp/agent-builds/*",
+            }),
+            input: { command: "rm /tmp/agent-builds/x" },
+            formatter: makeFormatter(),
+          }),
+          "resolved as",
+        ),
+      ).toBeUndefined();
+    });
 
     test("omits the enclosing command when it is the gated unit", () => {
       expect(


### PR DESCRIPTION
## What this change does

A `bash` rule that uses a full path did not work for the same command written in a short form.

```jsonc
"bash": { "*": "allow", "rm *": "ask", "rm /tmp/agent-builds/*": "allow" }
```

```bash
rm /tmp/agent-builds/x           # allow, no question
cd /tmp && rm agent-builds/x     # question: rule "rm *"
```

Both commands touch the same file.
The second command asks a question because the `bash` surface looked only at the command text.
The `path` and `external_directory` surfaces look at the real path, so they allow it.
One file therefore had two answers.

## How it works now

Each command unit is checked against two or three texts:

| text | when it is used | example |
| --- | --- | --- |
| as typed | always | `rm agent-builds/x` |
| absolute | the path is not absolute yet | `rm /tmp/agent-builds/x` |
| canonical | a symlink moves the path | `rm /private/tmp/agent-builds/x` |

The last rule that matches any text wins.
This is the same rule that the path surfaces already use for a path and its symlink target.
An `allow` written after a wider `ask` decides.
An `allow` written before it does not.

The prompt shows the text that decided as `resolved as`.
The review log writes it as `matchedAlias`.

## What does not change

The code does not touch a text when it cannot prove the path.
These cases keep their current answer:

- `cd "$DIR" && rm x` — the directory is not known
- `rm *` — a glob, not a literal path
- `rm /tmp/x` — absolute already
- `tar --directory=x/y` — the value is part of a flag
- a bare `cd` or `cd -` — no base to use

## Limits

- A session approval saves the command text that the prompt showed.
  A later command with the other spelling asks again.
- Two arguments that resolve to different spellings match a rule that names only one of them.
- A quoted full path (`rm "/tmp/x"`) is left as typed.
  A quoted short path (`rm "agent-builds/x"`) is changed.

## Checks

```text
Tests   4150 passed (157 files)
tsc     clean
lint    clean (biome, eslint, rumdl)
fallow  no dead code
```

No issue tracks this change.
The work was done in a local checkout.

## Disclaimer

This work was developed with the **deepseek v4.1 flash** model.
