### PR TITLE
Emit terminal bell for permission prompts

### DIFF
--- a/packages/pi-permission-system/src/authority/permission-dialog.ts
+++ b/packages/pi-permission-system/src/authority/permission-dialog.ts
@@ -156,6 +156,7 @@ export async function requestPermissionDecisionFromUi(
     DENY_WITH_REASON_OPTION,
   ];
 
+  process.stdout.write("\x07");
   const selected = await ui.select(`${title}\n${message}`, decisionOptions);
 
   if (selected === APPROVE_OPTION) {

--- a/packages/pi-permission-system/test/authority/permission-dialog.test.ts
+++ b/packages/pi-permission-system/test/authority/permission-dialog.test.ts
@@ -41,6 +41,27 @@ describe("isPermissionDecisionState", () => {
 });
 
 describe("requestPermissionDecisionFromUi", () => {
+  it("emits a terminal bell before opening the prompt", async () => {
+    const writeSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const selectFn = vi.fn().mockResolvedValue("Yes");
+    const ui: PermissionDecisionUi = {
+      select: selectFn,
+      input: vi.fn(),
+    };
+
+    try {
+      await requestPermissionDecisionFromUi(ui, "Title", "Message");
+      expect(writeSpy).toHaveBeenCalledWith("\x07");
+      expect(writeSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        selectFn.mock.invocationCallOrder[0],
+      );
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
   it("returns approved when user selects Yes", async () => {
     const ui: PermissionDecisionUi = {
       select: vi.fn().mockResolvedValue("Yes"),


### PR DESCRIPTION
## Summary

- Emit an ASCII BEL before opening a permission decision prompt.
- Add a regression test verifying the signal is emitted before the UI select.

## Validation

- Permission-system tests: 4,193 passed
- Typecheck, Biome, and ESLint passed

Refs gotgenes/pi-packages#906